### PR TITLE
computed checksum for reverted 3.15.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,6 @@ let package = Package(
     targets: [
         .binaryTarget(name: "Rokt_Widget",
                       url: "https://rokt-eng-us-west-2-mobile-sdk-artefacts.s3.amazonaws.com/ios/3.15.6/Rokt_Widget.xcframework.zip",
-                      checksum: "61ae6b977b9463b7ce9c56bb3ed20be4cdce3cedd65ac12ab73a2db2bcc4618c")
+                      checksum: "caf2cd25d960a4f7df2bd9218143c15335f604cf96ea78e2176ebaa6172c0bd0")
     ]
 )


### PR DESCRIPTION
### Background ###

This PR is to fix the generated checksum as we have reverted the 3.15.6 Swift Package

### What Has Changed: ###

Updated to recomputed checksum

### How Has This Been Tested? ###

Tested checksum locally

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.