### PR TITLE
[NO-JIRA] Update git automated script

### DIFF
--- a/.buildkite/bin/create_tag_and_update_branch.sh
+++ b/.buildkite/bin/create_tag_and_update_branch.sh
@@ -10,9 +10,9 @@ git config user.name "nativeappsdev"
 
 git tag -d "$1" || true
 git stash
-git checkout "${BUILDKITE_BRANCH}"
+git fetch origin "${BUILDKITE_BRANCH}"
+git reset --hard origin/"${BUILDKITE_BRANCH}"
 git stash pop
-git pull
 git add Package.swift
 git add README.md
 git commit -m "$1"


### PR DESCRIPTION
### Background ###

Popping before pulling can cause conflicts. Changing to fetching then resetting to the fetched head so that it's always clean.

Fixes [NO-JIRA]

### What Has Changed: ###

- Fetch the latest remote target branch then hard reset to it before popping the stash

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.