### PR TITLE
MP-3084 - Update Rokt SDK binary deployment URL

### DIFF
--- a/.buildkite/bin/update_version.sh
+++ b/.buildkite/bin/update_version.sh
@@ -6,12 +6,12 @@ set -eu
 # $2 Package.swift file location
 # $3 README.md file location
 
-FILE_LOCATION="https://rokt-eng-us-west-2-mobile-sdk-artefacts.s3.amazonaws.com/ios/"$1"/Rokt_Widget.xcframework.zip"
+FILE_LOCATION="https://apps.rokt.com/msdk/ios/"$1"/Rokt_Widget.xcframework.zip"
 brew install wget
 wget "${FILE_LOCATION}"
 CHECKSUM=$(swift package compute-checksum Rokt_Widget.xcframework.zip)
 
-perl -pi -e "s/(?<=amazonaws.com\/ios\/)(.*)(?=\/Rokt)/$1/g" $2
+perl -pi -e "s/(?<=msdk\/ios\/)(.*)(?=\/Rokt)/$1/g" $2
 perl -pi -e "s/(?<=checksum: \")(.*)(?=\")/$CHECKSUM/g" $2
 perl -pi -e "s/(?<=Select \*Up to Next Major\* with \*)(.*)(?=\*)/$1/g" $3
 perl -pi -e "s/(?<=upToNextMajor\(from: \")(.*)(?=\")/$1/g" $3

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [],
     targets: [
         .binaryTarget(name: "Rokt_Widget",
-                      url: "https://rokt-eng-us-west-2-mobile-sdk-artefacts.s3.amazonaws.com/ios/3.17.0/Rokt_Widget.xcframework.zip",
+                      url: "https://apps.rokt.com/msdk/ios/3.17.0/Rokt_Widget.xcframework.zip",
                       checksum: "d1f245a1e5e9672cba267bd65b4c31244e14a130bcaaa8ee44b6239fb8a6fbb6")
     ]
 )


### PR DESCRIPTION
### Background ###

Change the URL from direct S3 bucket URL to apps.rokt.com

Fixes [MP-3084](https://rokt.atlassian.net/browse/MP-3084)

### What Has Changed: ###

Binary URL updated

### How Has This Been Tested? ###

Tested locally
```
$ swift package resolve
Downloading binary artifact https://apps.rokt.com/msdk/ios/3.17.0/Rokt_Widget.xcframework.zip
Downloaded https://apps.rokt.com/msdk/ios/3.17.0/Rokt_Widget.xcframework.zip (2.49s)
```

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.