### PR TITLE
Mp 3246 i os privacy manifest for spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     dependencies: [],
     targets: [
         .binaryTarget(name: "Rokt_Widget",
-                      url: "https://apps.rokt.com/msdk/ios/3.17.0/Rokt_Widget.xcframework.zip",
-                      checksum: "d1f245a1e5e9672cba267bd65b4c31244e14a130bcaaa8ee44b6239fb8a6fbb6"),
+                      url: "https://apps.rokt.com/msdk/ios/4.1.0/Rokt_Widget.xcframework.zip",
+                      checksum: "3eab30986bd748aebdf2edb99ff9236bc97247cbc15c865ed74725197770c9a8"),
         .target(name: "RoktWidget",
                 dependencies: [
                     .target(name: "Rokt_Widget")

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,18 @@ let package = Package(
     products: [
         .library(
             name: "Rokt-Widget",
-            targets: ["Rokt_Widget"]),
+            targets: ["Rokt_WidgetTargets"]),
     ],
     dependencies: [],
     targets: [
         .binaryTarget(name: "Rokt_Widget",
                       url: "https://rokt-eng-us-west-2-mobile-sdk-artefacts.s3.amazonaws.com/ios/3.15.8/Rokt_Widget.xcframework.zip",
-                      checksum: "13312a7197e513a9838cc4167381cc1fca9735a108c7727c3dc34529692b229f")
+                      checksum: "13312a7197e513a9838cc4167381cc1fca9735a108c7727c3dc34529692b229f"),
+        .target(name: "Rokt_WidgetTargets",
+                dependencies: [
+                    .target(name: "Rokt_Widget")
+                ],
+                path: "Source",
+                resources: [.copy("PrivacyInfo.xcprivacy")])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,14 +9,14 @@ let package = Package(
     products: [
         .library(
             name: "Rokt-Widget",
-            targets: ["Rokt_WidgetTargets"]),
+            targets: ["RoktWidget"]),
     ],
     dependencies: [],
     targets: [
         .binaryTarget(name: "Rokt_Widget",
                       url: "https://apps.rokt.com/msdk/ios/3.17.0/Rokt_Widget.xcframework.zip",
                       checksum: "d1f245a1e5e9672cba267bd65b4c31244e14a130bcaaa8ee44b6239fb8a6fbb6"),
-        .target(name: "Rokt_WidgetTargets",
+        .target(name: "RoktWidget",
                 dependencies: [
                     .target(name: "Rokt_Widget")
                 ],

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ To install for iOS development:
 On Xcode: 
 * Go to File > Add Packages
 * Enter Package URL `https://github.com/ROKT/rokt-sdk-ios.git`
-* Select *Up to Next Major* with *3.17.0*
+* Select *Up to Next Major* with *4.1.0*
 
 Alternatively add below code to the `dependencies` part of `Package.swift`.
 ```swift
 dependencies: [
-    .package(url: "https://github.com/ROKT/rokt-sdk-ios.git", .upToNextMajor(from: "3.17.0"))
+    .package(url: "https://github.com/ROKT/rokt-sdk-ios.git", .upToNextMajor(from: "4.1.0"))
 ]
 ```
 

--- a/Source/PrivacyInfo.xcprivacy
+++ b/Source/PrivacyInfo.xcprivacy
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAdvertisingData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Source/PrivacyInfo.xcprivacy
+++ b/Source/PrivacyInfo.xcprivacy
@@ -8,7 +8,7 @@
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
@@ -20,7 +20,7 @@
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeAdvertisingData</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
@@ -34,7 +34,7 @@
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypePerformanceData</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>

--- a/Source/Source.swift
+++ b/Source/Source.swift
@@ -1,0 +1,1 @@
+// empty source file to make Swift package manager register the Rokt_WidgetTargets target

--- a/Source/Source.swift
+++ b/Source/Source.swift
@@ -1,1 +1,1 @@
-// empty source file to make Swift package manager register the Rokt_WidgetTargets target
+// empty source file to make Swift package manager register the RoktWidget target


### PR DESCRIPTION
### Background ###

Adding privacy manifest to Swift package

Fixes https://rokt.atlassian.net/browse/MP-3246

### What Has Changed: ###

Added privacy manifest
Create new target that contains privacy manifest resource and the Rokt-Widget binary target as a dependency

### How Has This Been Tested? ###

Built an app with tag created from this branch. Privacy report generated:

<img width="1453" alt="Screenshot 2024-03-01 at 3 25 26 pm" src="https://github.com/ROKT/rokt-sdk-ios/assets/122853726/a1b1e660-a62e-427d-be15-12627a7723fb">

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.