### PR TITLE
ci: harden GitHub Actions workflows (artipacked + zizmor CI)

### DIFF
--- a/.github/workflows/ci-size-report.yml
+++ b/.github/workflows/ci-size-report.yml
@@ -21,12 +21,14 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: pr-branch
 
       - name: Checkout target branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha || 'main' }}
           path: base-branch
 
@@ -227,7 +229,7 @@ jobs:
 
       - name: Find Comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -236,7 +238,7 @@ jobs:
 
       - name: Create or update PR comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/maintenance-trunk-upgrade.yml
+++ b/.github/workflows/maintenance-trunk-upgrade.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Trunk Check
@@ -39,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install CocoaPods
         run: sudo gem install cocoapods
@@ -54,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -84,7 +89,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -105,6 +110,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -133,7 +140,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./ui-coverage.xml
@@ -153,6 +160,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get current version
         id: version-file
@@ -62,6 +64,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build XCFramework
         run: ./scripts/build_xcframework_zip.sh
@@ -78,6 +82,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install CocoaPods
         run: sudo gem install cocoapods

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        continue-on-error: true # Permanent — reports findings without blocking PRs
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
**TL;DR:** Adds `persist-credentials: false` to 11 checkout steps across 4 workflows (prevents credential leakage), pins 3 unpinned third-party actions to commit SHAs, and adds a zizmor security scan workflow for inline PR annotations.

---

## What changed

### 1. Artipacked fix — `persist-credentials: false` on 11 checkouts

| Workflow | Job | Safe because |
|----------|-----|-------------|
| `release-publish.yml` | create-release | `softprops/action-gh-release` uses GitHub API, not git credentials |
| `release-publish.yml` | upload-xcframework | Build + `softprops/action-gh-release` (GitHub API) |
| `release-publish.yml` | publish-cocoapods | `pod spec lint` + `pod trunk push` (no git ops) |
| `pull-request.yml` | trunk-check | Lint only |
| `pull-request.yml` | podspec-lint | Lint only |
| `pull-request.yml` | unit-test | xcodebuild test + codecov upload |
| `pull-request.yml` | ui-test | xcodebuild test + codecov upload |
| `pull-request.yml` | periphery-scan | Dead code analysis only |
| `ci-size-report.yml` | measure-size (PR branch) | Build + measure + PR comment (GitHub API) |
| `ci-size-report.yml` | measure-size (base branch) | Build + measure |
| `maintenance-trunk-upgrade.yml` | trunk-check | Lint only |

**Already hardened (no change):** `release-publish.yml` → `upload-release-notes` already has `persist-credentials: false`.

**Intentionally skipped:** `release-draft.yml` → `prepare-release` — `peter-evans/create-pull-request` needs git credentials to create commits and push branches.

### 2. SHA pinning — 3 third-party actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `codecov/codecov-action` | v5 | `75cd11691c0faa626561e295848008c8a7dddffe` |
| `peter-evans/find-comment` | v4 | `b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad` |
| `peter-evans/create-or-update-comment` | v5 | `e8674b075228eee787fea43ef493e45ece1004c9` |

**Internal workflows left on `@main`:** `ROKT/rokt-workflows` reusable workflows and actions (`oss_pr_opened_notification`, `generate-changelog`, `trunk-upgrade`) are intentionally left tracking `main` — these are internal ROKT tooling where the SDK team wants the latest version.

### 3. New `zizmor.yml` — recurring security scan
Adds a [zizmor](https://github.com/woodruffw/zizmor) security scan that runs on every PR and push touching `.github/workflows/**` or `.github/actions/**`. Uses the official [zizmor-action](https://github.com/zizmorcore/zizmor-action) (v0.5.2, pinned to SHA) for inline PR annotations.

---

## Design decisions

| Decision | Rationale |
|----------|-----------|
| **`release-draft.yml` checkout left unchanged** | `peter-evans/create-pull-request` needs git credentials to commit and push the release branch. |
| **Existing permissions blocks left as-is** | `contents: write`, `packages: write`, `checks: write`, `id-token: write` are all used by existing jobs. Not tightening — removing permissions has caused `startup_failure` on other repos in this rollout. |
| **Internal `@main` references left unpinned** | Internal ROKT reusable workflows are pinned to `main` by convention so teams always get the latest internal tooling. |
| **`continue-on-error: true` is permanent** | zizmor runs in advisory mode — reports findings via inline PR annotations without blocking merges. This is the agreed design across the org-wide rollout, per Ashwin (project lead). Blocking requires triaging all pre-existing findings first; advisory ships coverage now. |
| **`advanced-security: false`** | Kept for consistency with the org-wide template. This is a public repo where GHAS is free — enabling `advanced-security: true` for SARIF dashboard could be a follow-up. |
| **`annotations: true`** | Enables inline PR annotations (capped at 10 per run by GitHub). |
| **`ubuntu-24.04` for zizmor** | Pure static analysis — no macOS dependencies. Pinned for reproducibility, cheaper than macOS runners. |
| **Both `pull_request` and `push` triggers on zizmor.yml** | `pull_request` catches issues before merge. `push` catches direct pushes or merges that bypass PR review, and ensures a baseline scan exists on `main`. |

---

## Pre-existing zizmor findings (not addressed in this PR)

These are flagged by the scanner but tracked separately in the broader rollout:

- **Excessive permissions** — `id-token: write`, `checks: write` in `pull-request.yml`; `contents: write`, `packages: write` in `release-publish.yml`; `contents: write`, `pull-requests: write` in `maintenance-trunk-upgrade.yml` and `release-draft.yml`. All are required by their respective jobs. Tightening is Phase 2c (requires per-repo CI validation).
- **Template injection in `ci-size-report.yml`** — `${{ steps.*.outputs.* }}` in `run:` blocks. These are false positives — outputs come from earlier steps in the same job, not untrusted input. Template injection remediation is Phase 2c.
- **Internal unpinned uses** — `ROKT/rokt-workflows@main` references. Internal tooling pinned to `main` by convention.

---

## What this PR does NOT change
- **No permissions tightened** — existing `permissions:` blocks are untouched
- **No workflow logic changes** — all jobs behave identically
- **`release-draft.yml` unchanged** — needs git credentials for `create-pull-request`

---

## Test plan
- [x] Verified each of the 11 checkouts is NOT followed by git-write operations
- [x] Verified `release-draft.yml` checkout is skipped (needs git credentials for `create-pull-request`)
- [x] Verified `release-publish.yml` upload-release-notes already has `persist-credentials: false`
- [x] Verified existing `with:` blocks (fetch-depth, ref, path) are preserved — no duplicate keys
- [x] Verified 3 third-party action SHAs are commit objects (not tag objects)
- [x] Verified default branch is `main` (used in zizmor.yml triggers)
- [x] Verified checkout SHA matches existing workflows (`de0fac2e4500dabe0009e67214ff5f5447ce83dd` / v6.0.2)
- [x] Verified `zizmor.yml` includes `annotations: true` and `advanced-security: false`
- [x] Verified existing permissions blocks are untouched
- [ ] CI passes (trunk-check, podspec-lint, unit-test, ui-test, periphery-scan, size-report)