### PR TITLE
fix(ci): pin release tag to triggering commit SHA on maintenance/4.x

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -38,6 +38,7 @@ jobs:
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           tag_name: ${{ steps.version-file.outputs.release-version }}
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.version-file.outputs.release-version }}
           make_latest: ${{ github.ref_name == 'main' }}
           body: |


### PR DESCRIPTION
## Summary

Backports the `target_commitish` fix to `maintenance/4.x`'s `release-publish.yml` so future 4.x patch releases tag the correct commit.

## Why

Without `target_commitish`, `softprops/action-gh-release` creates the tag against the repository's default branch (`main`) when the tag does not already exist. As a result, the `4.16.5` release workflow ran from `maintenance/4.x` but the GitHub release tag ended up pointing at `main`'s HEAD rather than the maintenance commit. The release had to be deleted and re-done manually.

The same one-line fix was landed on `main` via `fix/release-tag-target-commitish` (commit `9d2cc6f`). This PR mirrors it onto `maintenance/4.x`'s copy of the workflow, since GitHub Actions executes the workflow file from the branch that received the push — so a fix on `main` alone does not protect 4.x releases.

On a `push` event, `github.sha` is the commit that triggered the workflow, which is exactly what we want the tag to point at.

## Change

```yaml
  with:
    tag_name: ${{ steps.version-file.outputs.release-version }}
+   target_commitish: ${{ github.sha }}
    name: Release ${{ steps.version-file.outputs.release-version }}
```

## Test plan

- [ ] Verify the workflow YAML still parses (GitHub Actions lint in PR checks).
- [ ] On the next 4.x patch release, confirm the created tag points to the `maintenance/4.x` commit that bumped `VERSION` (not `main`'s HEAD).
- [ ] Confirm `make_latest` behavior is unchanged — maintenance releases should not become the "Latest" release on GitHub.

Made with [Cursor](https://cursor.com)