### PR TITLE
feat(example): add Shoppable Ads demo

### DIFF
--- a/Example/Tests/ShoppableAdsDemoTests.swift
+++ b/Example/Tests/ShoppableAdsDemoTests.swift
@@ -1,0 +1,383 @@
+import UIKit
+import XCTest
+import RoktPaymentExtension
+@testable import Rokt_Widget
+
+final class ShoppableAdsDemoTests: XCTestCase {
+    private var window: UIWindow?
+
+    override func tearDown() {
+        window?.isHidden = true
+        window = nil
+        super.tearDown()
+    }
+
+    func testDefaultsUseSandboxShoppableAdsValues() {
+        XCTAssertEqual(ShoppableAdsDefaults.tagID, "3068704822624787054")
+        XCTAssertEqual(ShoppableAdsDefaults.viewName, "StgRoktShoppableAds")
+        XCTAssertEqual(ShoppableAdsDefaults.stripePublishableKey, "")
+        XCTAssertFalse(ShoppableAdsDefaults.applePayMerchantId.isEmpty)
+        XCTAssertTrue(ShoppableAdsDefaults.attributes.contains { $0.key == "sandbox" && $0.value == "true" })
+        XCTAssertTrue(ShoppableAdsDefaults.attributes.contains { $0.key == "paymenttype" && $0.value == "ApplePay" })
+        XCTAssertEqual(Environment.Stage.roktEnvironment, .Stage)
+        XCTAssertEqual(Environment.Prod.roktEnvironment, .Prod)
+    }
+
+    func testDemoRendersDefaultSectionsAndRows() {
+        let controller = ShoppableAdsDemoViewController(
+            seed: ShoppableAdsDemoSeed(environment: .Prod, tagID: "previous-tag-id"),
+            roktClient: SpyShoppableAdsRoktClient()
+        )
+        controller.loadViewIfNeeded()
+
+        XCTAssertEqual(controller.numberOfSections(in: controller.tableView), 4)
+        XCTAssertEqual(controller.tableView(controller.tableView, titleForHeaderInSection: 0), "Account")
+        XCTAssertEqual(controller.tableView(controller.tableView, titleForHeaderInSection: 1), "Attributes")
+        XCTAssertNil(controller.tableView(controller.tableView, titleForHeaderInSection: 2))
+        XCTAssertEqual(controller.tableView(controller.tableView, titleForHeaderInSection: 3), "Event Log")
+        XCTAssertEqual(controller.tableView(controller.tableView, numberOfRowsInSection: 0), 4)
+        XCTAssertEqual(
+            controller.tableView(controller.tableView, numberOfRowsInSection: 1),
+            ShoppableAdsDefaults.attributes.count
+        )
+        XCTAssertEqual(controller.tableView(controller.tableView, numberOfRowsInSection: 2), 5)
+        XCTAssertEqual(controller.tableView(controller.tableView, numberOfRowsInSection: 3), 1)
+
+        let tagCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        XCTAssertTrue(tagCell.descendants(of: UILabel.self).contains { $0.text == "Tag ID" })
+        XCTAssertEqual(tagCell.descendants(of: UITextField.self).first?.text, "previous-tag-id")
+
+        let actionCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 2)
+        )
+        let actionContent = actionCell.contentConfiguration as? UIListContentConfiguration
+        XCTAssertEqual(actionContent?.text, "Initialize Rokt")
+    }
+
+    func testDemoActionsWriteValidationMessagesAndClearLog() {
+        let roktClient = SpyShoppableAdsRoktClient()
+        let controller = ShoppableAdsDemoViewController(roktClient: roktClient)
+        controller.loadViewIfNeeded()
+        let logView = installedLogView(for: controller)
+
+        waitForLog(logView, contains: "Ready.")
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 1, section: 2)
+        )
+        waitForLog(logView, contains: "Initialize Rokt before registering")
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 2, section: 2)
+        )
+        waitForLog(logView, contains: "Initialize Rokt before launching")
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 4, section: 2)
+        )
+        XCTAssertEqual(logView.text, "")
+        XCTAssertEqual(roktClient.sessionIDs, [" "])
+    }
+
+    func testInitializeSetsEnvironmentAndCallsInitWithEditableTag() throws {
+        let roktClient = SpyShoppableAdsRoktClient()
+        let controller = ShoppableAdsDemoViewController(
+            seed: ShoppableAdsDemoSeed(environment: .Prod, tagID: "previous-tag-id"),
+            roktClient: roktClient
+        )
+        controller.loadViewIfNeeded()
+        let logView = installedLogView(for: controller)
+
+        let tagCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        let tagField = try XCTUnwrap(tagCell.descendants(of: UITextField.self).first)
+        tagField.text = "edited-tag-id"
+        tagField.sendActions(for: .editingChanged)
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 0, section: 2)
+        )
+
+        XCTAssertEqual(roktClient.environments, [.Prod])
+        XCTAssertEqual(roktClient.initializedTagIDs, ["edited-tag-id"])
+        XCTAssertNotNil(roktClient.globalEventHandler)
+        waitForLog(logView, contains: "Set Rokt environment: Prod.")
+        waitForLog(logView, contains: "Called Rokt.initWith(roktTagId: \"edited-tag-id\")")
+
+        roktClient.globalEventHandler?(RoktEvent.InitComplete(success: true))
+        waitForLog(logView, contains: "Global event: InitComplete(success=true)")
+    }
+
+    func testRegisterAfterInitValidatesBlankStripeKey() {
+        let roktClient = SpyShoppableAdsRoktClient()
+        let controller = ShoppableAdsDemoViewController(roktClient: roktClient)
+        controller.loadViewIfNeeded()
+        let logView = installedLogView(for: controller)
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 0, section: 2)
+        )
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 1, section: 2)
+        )
+
+        waitForLog(logView, contains: "Missing Stripe publishable key.")
+    }
+
+    func testLaunchAfterInitLogsEnvironmentAndUnregisteredPaymentWarning() {
+        let roktClient = SpyShoppableAdsRoktClient()
+        let controller = ShoppableAdsDemoViewController(
+            seed: ShoppableAdsDemoSeed(environment: .Stage, tagID: "tag-id", viewName: "ViewName"),
+            roktClient: roktClient
+        )
+        controller.loadViewIfNeeded()
+        let logView = installedLogView(for: controller)
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 0, section: 2)
+        )
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 2, section: 2)
+        )
+
+        XCTAssertEqual(roktClient.selections.count, 1)
+        XCTAssertEqual(roktClient.selections.first?.identifier, "ViewName")
+        waitForLog(logView, contains: "payment extension not registered")
+        waitForLog(logView, contains: "in Stage")
+    }
+
+    func testResetRestoresDefaultAccountValues() throws {
+        let controller = ShoppableAdsDemoViewController()
+        controller.loadViewIfNeeded()
+
+        let tagCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        let tagField = try XCTUnwrap(tagCell.descendants(of: UITextField.self).first)
+        tagField.text = "changed"
+        tagField.sendActions(for: .editingChanged)
+
+        controller.tableView(
+            controller.tableView,
+            didSelectRowAt: IndexPath(row: 3, section: 2)
+        )
+
+        let resetCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        XCTAssertEqual(resetCell.descendants(of: UITextField.self).first?.text, ShoppableAdsDefaults.tagID)
+    }
+
+    func testDescribeFormatsCommonRoktEvents() {
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.InitComplete(success: true)),
+            "InitComplete(success=true)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PlacementReady(identifier: "layout")),
+            "PlacementReady(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PlacementClosed(identifier: nil)),
+            "PlacementClosed(-)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PlacementCompleted(identifier: "layout")),
+            "PlacementCompleted(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PlacementFailure(identifier: "layout")),
+            "PlacementFailure(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PlacementInteractive(identifier: "layout")),
+            "PlacementInteractive(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.OfferEngagement(identifier: "layout")),
+            "OfferEngagement(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.PositiveEngagement(identifier: "layout")),
+            "PositiveEngagement(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.FirstPositiveEngagement(identifier: "layout")),
+            "FirstPositiveEngagement(layout)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.OpenUrl(identifier: "layout", url: "https://example.com")),
+            "OpenUrl(https://example.com)"
+        )
+        XCTAssertEqual(
+            ShoppableAdsDemoViewController.describe(RoktEvent.ShowLoadingIndicator()),
+            "RoktEvent: ShowLoadingIndicator"
+        )
+    }
+
+    func testTagSelectionInstallsDemoButtonAndPushesDemo() throws {
+        let controller = TagIdSelectionTableViewController()
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let initializeButton = UIButton(type: .system)
+        initializeButton.accessibilityIdentifier = "InitializeButton"
+        initializeButton.translatesAutoresizingMaskIntoConstraints = false
+        rootView.addSubview(initializeButton)
+        NSLayoutConstraint.activate([
+            initializeButton.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+            initializeButton.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+            initializeButton.bottomAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.bottomAnchor),
+            initializeButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+        let environmentPicker = UIPickerView()
+        let tagIdPicker = UIPickerView()
+        let customTagIdLabel = UILabel()
+        let customTagIdTextField = UITextField()
+        [environmentPicker, tagIdPicker, customTagIdLabel, customTagIdTextField].forEach(rootView.addSubview)
+        controller.environmentPicker = environmentPicker
+        controller.tagIdPicker = tagIdPicker
+        controller.customTagIdLabel = customTagIdLabel
+        controller.customTagIdTextField = customTagIdTextField
+        controller.view = rootView
+        controller.viewDidLoad()
+        environmentPicker.selectRow(1, inComponent: 0, animated: false)
+        controller.pickerView(environmentPicker, didSelectRow: 1, inComponent: 0)
+        customTagIdTextField.text = "previous-screen-tag"
+
+        let navigationController = UINavigationController(rootViewController: controller)
+        showInWindow(navigationController)
+        controller.view.layoutIfNeeded()
+
+        let demoButton = try XCTUnwrap(
+            controller.view.firstDescendant(
+                of: UIButton.self,
+                where: { $0.accessibilityIdentifier == "ShoppableAdsDemoButton" }
+            )
+        )
+
+        XCTAssertEqual(demoButton.title(for: .normal), "Shoppable Ads Demo")
+        XCTAssertLessThanOrEqual(demoButton.frame.maxY, initializeButton.frame.minY + 0.5)
+
+        demoButton.sendActions(for: .touchUpInside)
+        let demoController = try XCTUnwrap(navigationController.topViewController as? ShoppableAdsDemoViewController)
+        let tagCell = demoController.tableView(
+            demoController.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 0)
+        )
+        XCTAssertEqual(tagCell.descendants(of: UITextField.self).first?.text, "previous-screen-tag")
+        waitForLog(installedLogView(for: demoController), contains: "Environment: Prod")
+    }
+
+    private func installedLogView(for controller: ShoppableAdsDemoViewController) -> UITextView {
+        let logCell = controller.tableView(
+            controller.tableView,
+            cellForRowAt: IndexPath(row: 0, section: 3)
+        )
+        return logCell.descendants(of: UITextView.self).first!
+    }
+
+    private func waitForLog(
+        _ logView: UITextView,
+        contains expectedText: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = expectation(description: "Log contains \(expectedText)")
+        pollUntil(
+            timeout: Date().addingTimeInterval(2),
+            condition: { logView.text.contains(expectedText) },
+            onSuccess: { expectation.fulfill() }
+        )
+        wait(for: [expectation], timeout: 2.5)
+        XCTAssertTrue(logView.text.contains(expectedText), file: file, line: line)
+    }
+
+    private func pollUntil(timeout: Date, condition: @escaping () -> Bool, onSuccess: @escaping () -> Void) {
+        if condition() {
+            onSuccess()
+        } else if Date() < timeout {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                self.pollUntil(timeout: timeout, condition: condition, onSuccess: onSuccess)
+            }
+        }
+    }
+
+    private func showInWindow(_ viewController: UIViewController) {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+}
+
+private final class SpyShoppableAdsRoktClient: ShoppableAdsRoktClient {
+    struct Selection {
+        let identifier: String
+        let attributes: [String: String]
+    }
+
+    var environments: [RoktEnvironment] = []
+    var initializedTagIDs: [String] = []
+    var sessionIDs: [String] = []
+    var selections: [Selection] = []
+    var registeredConfigs: [[String: String]] = []
+    var globalEventHandler: ((RoktEvent) -> Void)?
+
+    func setEnvironment(_ environment: RoktEnvironment) {
+        environments.append(environment)
+    }
+
+    func globalEvents(onEvent: @escaping (RoktEvent) -> Void) {
+        globalEventHandler = onEvent
+    }
+
+    func initWith(roktTagId: String) {
+        initializedTagIDs.append(roktTagId)
+    }
+
+    func registerPaymentExtension(_ paymentExtension: RoktPaymentExtension, config: [String: String]) {
+        registeredConfigs.append(config)
+    }
+
+    func selectShoppableAds(identifier: String, attributes: [String: String], onEvent: ((RoktEvent) -> Void)?) {
+        selections.append(Selection(identifier: identifier, attributes: attributes))
+    }
+
+    func setSessionId(_ sessionId: String) {
+        sessionIDs.append(sessionId)
+    }
+}
+
+private extension UIView {
+    func descendants<T: UIView>(of type: T.Type) -> [T] {
+        subviews.flatMap { subview -> [T] in
+            var matches = subview.descendants(of: type)
+            if let typedSubview = subview as? T {
+                matches.insert(typedSubview, at: 0)
+            }
+            return matches
+        }
+    }
+
+    func firstDescendant<T: UIView>(of type: T.Type, where predicate: (T) -> Bool) -> T? {
+        for descendant in descendants(of: type) where predicate(descendant) {
+            return descendant
+        }
+        return nil
+    }
+}

--- a/Example/rokt.xcodeproj/project.pbxproj
+++ b/Example/rokt.xcodeproj/project.pbxproj
@@ -77,6 +77,20 @@
 		58EF6D2025E364BE0058A2B2 /* initWithFalseRoktTrackingStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = 58EF6D1F25E364BE0058A2B2 /* initWithFalseRoktTrackingStatus.json */; };
 		58EF6D2125E364BE0058A2B2 /* initWithFalseRoktTrackingStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = 58EF6D1F25E364BE0058A2B2 /* initWithFalseRoktTrackingStatus.json */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
+		C1C0D10000000000000001E1 /* ShoppableAdsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C0D10000000000000002E1 /* ShoppableAdsDemoViewController.swift */; };
+		C1C0D10000000000000005E1 /* RoktPaymentExtension in Frameworks */ = {isa = PBXBuildFile; productRef = C1C0D10000000000000004E1 /* RoktPaymentExtension */; };
+		C1C0D10000000000000006E1 /* ShoppableAdsDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C0D10000000000000007E1 /* ShoppableAdsDefaults.swift */; };
+		C1C0D10000000000000009E1 /* ShoppableAdsDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C0D10000000000000008E1 /* ShoppableAdsDemoTests.swift */; };
+		C1C0D10000000000000010E1 /* RoktPaymentExtension in Frameworks */ = {isa = PBXBuildFile; productRef = C1C0D10000000000000011E1 /* RoktPaymentExtension */; };
+		C1C0D10000000000000013E1 /* ShoppableAdsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C0D10000000000000002E1 /* ShoppableAdsDemoViewController.swift */; };
+		C1C0D10000000000000014E1 /* ShoppableAdsDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C0D10000000000000007E1 /* ShoppableAdsDefaults.swift */; };
+		C1C0D10000000000000015E1 /* TagIdSelectionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F31D685213D829100F044CC /* TagIdSelectionTableViewController.swift */; };
+		C1C0D10000000000000016E1 /* CartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* CartViewController.swift */; };
+		C1C0D10000000000000017E1 /* OrderCompleteTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250B2B08236AF29E0020A450 /* OrderCompleteTableViewController.swift */; };
+		C1C0D10000000000000018E1 /* RoktTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258EDB1624062BBF003202F5 /* RoktTag.swift */; };
+		C1C0D10000000000000019E1 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258EDB1824062D59003202F5 /* Environment.swift */; };
+		C1C0D10000000000000020E1 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25226FF52A415C85006AFCF7 /* Toast.swift */; };
+		C1C0D10000000000000021E1 /* RoktCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250B2B06236AF2430020A450 /* RoktCell.swift */; };
 		607FACD81AFB9204008FA782 /* CartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* CartViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
@@ -194,6 +208,9 @@
 		607FACD01AFB9204008FA782 /* rokt_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = rokt_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C1C0D10000000000000002E1 /* ShoppableAdsDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsDemoViewController.swift; sourceTree = "<group>"; };
+		C1C0D10000000000000007E1 /* ShoppableAdsDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShoppableAdsDefaults.swift; path = model/ShoppableAdsDefaults.swift; sourceTree = "<group>"; };
+		C1C0D10000000000000008E1 /* ShoppableAdsDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppableAdsDemoTests.swift; sourceTree = "<group>"; };
 		607FACD71AFB9204008FA782 /* CartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewController.swift; sourceTree = "<group>"; };
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -222,6 +239,7 @@
 				B3457BC42F46BC2F00AE9D86 /* PassKit.framework in Frameworks */,
 				898FAB782EC50F6A00EFBA65 /* SVProgressHUD in Frameworks */,
 				B3457BC72F46BCB300AE9D86 /* Rokt-Widget in Frameworks */,
+				C1C0D10000000000000005E1 /* RoktPaymentExtension in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,6 +250,7 @@
 				A11F4D132F9B87AC006B1A2F /* Rokt-Widget in Frameworks */,
 				8922B0A92ECE64BC0083D05B /* Quick in Frameworks */,
 				898FAB7A2EC5127100EFBA65 /* SVProgressHUD in Frameworks */,
+				C1C0D10000000000000010E1 /* RoktPaymentExtension in Frameworks */,
 				89FA8CA32ECE5C2D00F26E1B /* Nimble-Snapshots in Frameworks */,
 				5881EE5D26D8A2AB006DA89C /* Mocker in Frameworks */,
 			);
@@ -301,6 +320,7 @@
 			children = (
 				258EDB1624062BBF003202F5 /* RoktTag.swift */,
 				258EDB1824062D59003202F5 /* Environment.swift */,
+				C1C0D10000000000000007E1 /* ShoppableAdsDefaults.swift */,
 			);
 			name = model;
 			sourceTree = "<group>";
@@ -345,6 +365,7 @@
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				25FD47362BF4922C0051C704 /* main.swift */,
 				4F31D685213D829100F044CC /* TagIdSelectionTableViewController.swift */,
+				C1C0D10000000000000002E1 /* ShoppableAdsDemoViewController.swift */,
 				607FACD71AFB9204008FA782 /* CartViewController.swift */,
 				4FCF94A0210931B7000CE923 /* OrderCompleteViewController.swift */,
 				250B2B08236AF29E0020A450 /* OrderCompleteTableViewController.swift */,
@@ -373,6 +394,7 @@
 				250610FA232F66CB00E6CBD9 /* ViewControllers */,
 				2534233C231F2C2900463C74 /* NetworkMock */,
 				4F7DEE35212DBBAF007DABC4 /* UnitTests.swift */,
+				C1C0D10000000000000008E1 /* ShoppableAdsDemoTests.swift */,
 				2536C0C029D29D0A00AABC4F /* ValidLayoutBottomSheetTests.swift */,
 				252120F02A4AB1720087B6F9 /* ValidLayoutOverlayTests.swift */,
 				250CF2472A4BB88B00C6FDE7 /* ValidLayoutEmbedded.swift */,
@@ -481,6 +503,7 @@
 			packageProductDependencies = (
 				898FAB772EC50F6A00EFBA65 /* SVProgressHUD */,
 				B3457BC62F46BCB300AE9D86 /* Rokt-Widget */,
+				C1C0D10000000000000004E1 /* RoktPaymentExtension */,
 			);
 			productName = rokt;
 			productReference = 607FACD01AFB9204008FA782 /* rokt_Example.app */;
@@ -507,6 +530,7 @@
 				89FA8CA22ECE5C2D00F26E1B /* Nimble-Snapshots */,
 				8922B0A82ECE64BC0083D05B /* Quick */,
 				B3457BC22F45127800AE9D86 /* Rokt-Widget */,
+				C1C0D10000000000000011E1 /* RoktPaymentExtension */,
 			);
 			productName = Tests;
 			productReference = 607FACE51AFB9204008FA782 /* rokt_Tests.xctest */;
@@ -556,6 +580,7 @@
 				898FAB762EC50F6A00EFBA65 /* XCRemoteSwiftPackageReference "SVProgressHUD" */,
 				89FA8CA12ECE5C2D00F26E1B /* XCRemoteSwiftPackageReference "Nimble-Snapshots" */,
 				8922B0A72ECE64BC0083D05B /* XCRemoteSwiftPackageReference "Quick" */,
+				C1C0D10000000000000003E1 /* XCRemoteSwiftPackageReference "rokt-payment-extension-ios" */,
 				B3457BC52F46BCB300AE9D86 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
@@ -678,6 +703,8 @@
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				25690F9C260AB87C00744387 /* HashUtils.swift in Sources */,
 				4F31D686213D829100F044CC /* TagIdSelectionTableViewController.swift in Sources */,
+				C1C0D10000000000000001E1 /* ShoppableAdsDemoViewController.swift in Sources */,
+				C1C0D10000000000000006E1 /* ShoppableAdsDefaults.swift in Sources */,
 				25FD47372BF4922C0051C704 /* main.swift in Sources */,
 				25226FF32A415861006AFCF7 /* OrderCompleteSwiftUI.swift in Sources */,
 				4FCF94A1210931B7000CE923 /* OrderCompleteViewController.swift in Sources */,
@@ -705,6 +732,16 @@
 				4F4B29B8210B68D600334961 /* OrderCompleteViewController.swift in Sources */,
 				250CF2482A4BB88B00C6FDE7 /* ValidLayoutEmbedded.swift in Sources */,
 				9914913E2C4651DE00D3355B /* MockTimingsRequest.swift in Sources */,
+				C1C0D10000000000000021E1 /* RoktCell.swift in Sources */,
+				C1C0D10000000000000020E1 /* Toast.swift in Sources */,
+				C1C0D10000000000000019E1 /* Environment.swift in Sources */,
+				C1C0D10000000000000018E1 /* RoktTag.swift in Sources */,
+				C1C0D10000000000000017E1 /* OrderCompleteTableViewController.swift in Sources */,
+				C1C0D10000000000000016E1 /* CartViewController.swift in Sources */,
+				C1C0D10000000000000015E1 /* TagIdSelectionTableViewController.swift in Sources */,
+				C1C0D10000000000000013E1 /* ShoppableAdsDemoViewController.swift in Sources */,
+				C1C0D10000000000000014E1 /* ShoppableAdsDefaults.swift in Sources */,
+				C1C0D10000000000000009E1 /* ShoppableAdsDemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2024,8 +2061,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashfurrow/Nimble-Snapshots";
 			requirement = {
-				kind = exactVersion;
-				version = 9.8.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.9.1;
+			};
+		};
+		C1C0D10000000000000003E1 /* XCRemoteSwiftPackageReference "rokt-payment-extension-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ROKT/rokt-payment-extension-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -2063,6 +2108,16 @@
 		B3457BC62F46BCB300AE9D86 /* Rokt-Widget */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = "Rokt-Widget";
+		};
+		C1C0D10000000000000004E1 /* RoktPaymentExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C1C0D10000000000000003E1 /* XCRemoteSwiftPackageReference "rokt-payment-extension-ios" */;
+			productName = RoktPaymentExtension;
+		};
+		C1C0D10000000000000011E1 /* RoktPaymentExtension */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C1C0D10000000000000003E1 /* XCRemoteSwiftPackageReference "rokt-payment-extension-ios" */;
+			productName = RoktPaymentExtension;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/rokt/Info.plist
+++ b/Example/rokt/Info.plist
@@ -48,6 +48,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>ApplePayMerchantID</key>
+	<string>merchant.rokt.test</string>
 	<key>NSUserTrackingUsageDescription</key>
 	<string> Personal and device information is used to deliver personalised offers</string>
 	<key>UILaunchStoryboardName</key>

--- a/Example/rokt/ShoppableAdsDemoViewController.swift
+++ b/Example/rokt/ShoppableAdsDemoViewController.swift
@@ -1,0 +1,480 @@
+import UIKit
+import Rokt_Widget
+import RoktPaymentExtension
+
+struct ShoppableAdsDemoSeed {
+    let environment: Environment
+    let tagID: String
+    let viewName: String
+
+    init(
+        environment: Environment = .Stage,
+        tagID: String = ShoppableAdsDefaults.tagID,
+        viewName: String = ShoppableAdsDefaults.viewName
+    ) {
+        self.environment = environment
+        self.tagID = tagID
+        self.viewName = viewName
+    }
+}
+
+protocol ShoppableAdsRoktClient {
+    func setEnvironment(_ environment: RoktEnvironment)
+    func globalEvents(onEvent: @escaping (RoktEvent) -> Void)
+    func initWith(roktTagId: String)
+    func registerPaymentExtension(_ paymentExtension: RoktPaymentExtension, config: [String: String])
+    func selectShoppableAds(identifier: String, attributes: [String: String], onEvent: ((RoktEvent) -> Void)?)
+    func setSessionId(_ sessionId: String)
+}
+
+private struct LiveShoppableAdsRoktClient: ShoppableAdsRoktClient {
+    func setEnvironment(_ environment: RoktEnvironment) {
+        Rokt.setEnvironment(environment: environment)
+    }
+
+    func globalEvents(onEvent: @escaping (RoktEvent) -> Void) {
+        Rokt.globalEvents(onEvent: onEvent)
+    }
+
+    func initWith(roktTagId: String) {
+        Rokt.initWith(roktTagId: roktTagId)
+    }
+
+    func registerPaymentExtension(_ paymentExtension: RoktPaymentExtension, config: [String: String]) {
+        Rokt.registerPaymentExtension(paymentExtension, config: config)
+    }
+
+    func selectShoppableAds(identifier: String, attributes: [String: String], onEvent: ((RoktEvent) -> Void)?) {
+        Rokt.selectShoppableAds(identifier: identifier, attributes: attributes, onEvent: onEvent)
+    }
+
+    func setSessionId(_ sessionId: String) {
+        Rokt.setSessionId(sessionId: sessionId)
+    }
+}
+
+/// Grouped-table demo screen for exercising Shoppable Ads end-to-end.
+///
+/// Layout mirrors the public `rokt-demo-ios` Shoppable Ads flow so operators
+/// get a consistent experience in either app:
+///
+/// - **Account** - Tag ID, Stripe publishable key, Apple Pay merchant ID, view name.
+/// - **Attributes** - every attribute the Rokt dashboard typically reads,
+///   pre-populated with sandbox values and individually editable.
+/// - **Actions** - initialize Rokt, register the payment extension, launch
+///   Shoppable Ads, reset the form, clear the log.
+/// - **Event log** - human-readable stream of `RoktEvent`s delivered by the SDK.
+///
+/// Apple Pay entitlement is required to actually present the payment sheet;
+/// registration and the `selectShoppableAds` call succeed without one.
+final class ShoppableAdsDemoViewController: UITableViewController {
+
+    private enum Section: Int, CaseIterable {
+        case account
+        case attributes
+        case actions
+        case log
+
+        var title: String? {
+            switch self {
+            case .account: return "Account"
+            case .attributes: return "Attributes"
+            case .actions: return nil
+            case .log: return "Event Log"
+            }
+        }
+    }
+
+    private struct Field {
+        let key: String
+        let label: String
+        var value: String
+    }
+
+    private let seed: ShoppableAdsDemoSeed
+    private let roktClient: ShoppableAdsRoktClient
+    private var accountFields: [Field] = []
+    private var attributeFields: [Field] = []
+    private var logLines: [String] = []
+    private var registeredExtension: RoktPaymentExtension?
+    private var initializedTagID: String?
+    private var initializedEnvironment: Environment?
+    private var isGlobalEventsRegistered = false
+
+    private lazy var logView: UITextView = {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.isScrollEnabled = true
+        tv.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        tv.backgroundColor = .secondarySystemBackground
+        tv.layer.cornerRadius = 6
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        tv.accessibilityIdentifier = "shoppable-ads-demo-log"
+        return tv
+    }()
+
+    init(
+        seed: ShoppableAdsDemoSeed = ShoppableAdsDemoSeed(),
+        roktClient: ShoppableAdsRoktClient = LiveShoppableAdsRoktClient()
+    ) {
+        self.seed = seed
+        self.roktClient = roktClient
+        super.init(style: .insetGrouped)
+    }
+
+    required init?(coder: NSCoder) {
+        seed = ShoppableAdsDemoSeed()
+        roktClient = LiveShoppableAdsRoktClient()
+        super.init(coder: coder)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Shoppable Ads Demo"
+        tableView.keyboardDismissMode = .interactive
+        tableView.register(TextEntryCell.self, forCellReuseIdentifier: TextEntryCell.reuseId)
+        tableView.register(ActionCell.self, forCellReuseIdentifier: ActionCell.reuseId)
+        tableView.register(LogCell.self, forCellReuseIdentifier: LogCell.reuseId)
+        loadDefaults()
+        appendLog("Ready. Environment: \(seed.environment.rawValue). Tag ID defaults from the previous screen.")
+    }
+
+    private func loadDefaults() {
+        accountFields = [
+            Field(key: "tagID", label: "Tag ID", value: seed.tagID),
+            Field(key: "stripeKey", label: "Stripe Publishable Key", value: ShoppableAdsDefaults.stripePublishableKey),
+            Field(key: "merchantId", label: "Apple Pay Merchant ID", value: ShoppableAdsDefaults.applePayMerchantId),
+            Field(key: "viewName", label: "View Name (identifier)", value: seed.viewName)
+        ]
+        attributeFields = ShoppableAdsDefaults.attributes.map {
+            Field(key: $0.key, label: $0.key, value: $0.value)
+        }
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        Section(rawValue: section)?.title
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Section(rawValue: section) {
+        case .account: return accountFields.count
+        case .attributes: return attributeFields.count
+        case .actions: return 5
+        case .log: return 1
+        case .none: return 0
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch Section(rawValue: indexPath.section) {
+        case .account:
+            let cell = tableView.dequeueReusableCell(withIdentifier: TextEntryCell.reuseId, for: indexPath) as! TextEntryCell
+            let field = accountFields[indexPath.row]
+            cell.configure(label: field.label, value: field.value, isSecure: field.key == "stripeKey")
+            cell.onChange = { [weak self] newValue in
+                guard let self, indexPath.row < self.accountFields.count else { return }
+                self.accountFields[indexPath.row].value = newValue
+                if field.key == "tagID" {
+                    self.initializedTagID = nil
+                }
+            }
+            return cell
+        case .attributes:
+            let cell = tableView.dequeueReusableCell(withIdentifier: TextEntryCell.reuseId, for: indexPath) as! TextEntryCell
+            let field = attributeFields[indexPath.row]
+            cell.configure(label: field.label, value: field.value, isSecure: false)
+            cell.onChange = { [weak self] newValue in
+                self?.attributeFields[indexPath.row].value = newValue
+            }
+            return cell
+        case .actions:
+            let cell = tableView.dequeueReusableCell(withIdentifier: ActionCell.reuseId, for: indexPath) as! ActionCell
+            switch indexPath.row {
+            case 0: cell.configure(title: "Initialize Rokt", destructive: false)
+            case 1: cell.configure(title: "Register Payment Extension", destructive: false)
+            case 2: cell.configure(title: "Launch Shoppable Ads", destructive: false)
+            case 3: cell.configure(title: "Reset to Defaults", destructive: false)
+            case 4: cell.configure(title: "Clear Log", destructive: true)
+            default: break
+            }
+            return cell
+        case .log:
+            let cell = tableView.dequeueReusableCell(withIdentifier: LogCell.reuseId, for: indexPath) as! LogCell
+            cell.install(logView: logView)
+            return cell
+        case .none:
+            return UITableViewCell()
+        }
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        Section(rawValue: indexPath.section) == .log ? 200 : UITableView.automaticDimension
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard Section(rawValue: indexPath.section) == .actions else { return }
+        view.endEditing(true)
+        switch indexPath.row {
+        case 0: initializeRokt()
+        case 1: registerExtension()
+        case 2: launchShoppableAds()
+        case 3: resetToDefaults()
+        case 4: clearLog()
+        default: break
+        }
+    }
+
+    // MARK: - Actions
+
+    private func initializeRokt() {
+        let tagID = value(for: "tagID", in: accountFields).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tagID.isEmpty else {
+            appendLog("Missing tag ID.")
+            return
+        }
+        roktClient.setEnvironment(seed.environment.roktEnvironment)
+        appendLog("Set Rokt environment: \(seed.environment.rawValue).")
+        if !isGlobalEventsRegistered {
+            roktClient.globalEvents { [weak self] roktEvent in
+                DispatchQueue.main.async {
+                    self?.appendLog("Global event: \(Self.describe(roktEvent))")
+                }
+            }
+            isGlobalEventsRegistered = true
+            appendLog("Subscribed to Rokt.globalEvents.")
+        }
+        roktClient.initWith(roktTagId: tagID)
+        initializedTagID = tagID
+        initializedEnvironment = seed.environment
+        appendLog("Called Rokt.initWith(roktTagId: \"\(tagID)\").")
+    }
+
+    private func registerExtension() {
+        guard isInitializedForCurrentInputs else {
+            appendLog("Initialize Rokt before registering the payment extension.")
+            return
+        }
+        if registeredExtension != nil {
+            appendLog("Payment extension already registered; skipping.")
+            return
+        }
+        let stripeKey = value(for: "stripeKey", in: accountFields)
+        let merchantId = value(for: "merchantId", in: accountFields)
+        guard !stripeKey.isEmpty else {
+            appendLog("Missing Stripe publishable key.")
+            return
+        }
+        guard !merchantId.isEmpty else {
+            appendLog("Missing Apple Pay merchant ID.")
+            return
+        }
+        guard let ext = RoktPaymentExtension(applePayMerchantId: merchantId) else {
+            appendLog("RoktPaymentExtension init returned nil.")
+            return
+        }
+        registeredExtension = ext
+        roktClient.registerPaymentExtension(ext, config: ["stripeKey": stripeKey])
+        appendLog("Registered RoktPaymentExtension (merchantId=\(merchantId)).")
+    }
+
+    private func launchShoppableAds() {
+        guard isInitializedForCurrentInputs else {
+            appendLog("Initialize Rokt before launching Shoppable Ads.")
+            return
+        }
+        if registeredExtension == nil {
+            appendLog("Warning: payment extension not registered in this session - Apple Pay will not be available.")
+        }
+        let identifier = value(for: "viewName", in: accountFields)
+        guard !identifier.isEmpty else {
+            appendLog("Missing view name (identifier).")
+            return
+        }
+        var attributes: [String: String] = [:]
+        for field in attributeFields where !field.value.isEmpty {
+            attributes[field.key] = field.value
+        }
+        appendLog(
+            "Calling selectShoppableAds(identifier: \"\(identifier)\") in \(seed.environment.rawValue) with " +
+                "\(attributes.count) attributes ..."
+        )
+        roktClient.selectShoppableAds(identifier: identifier, attributes: attributes) { [weak self] event in
+            DispatchQueue.main.async {
+                self?.appendLog(Self.describe(event))
+            }
+        }
+    }
+
+    private func resetToDefaults() {
+        loadDefaults()
+        appendLog("Form reset to defaults for environment \(seed.environment.rawValue).")
+    }
+
+    private func clearLog() {
+        roktClient.setSessionId(" ")
+        logLines.removeAll()
+        logView.text = ""
+    }
+
+    // MARK: - Helpers
+
+    private func value(for key: String, in fields: [Field]) -> String {
+        fields.first(where: { $0.key == key })?.value ?? ""
+    }
+
+    private var isInitializedForCurrentInputs: Bool {
+        initializedEnvironment == seed.environment &&
+            initializedTagID == value(for: "tagID", in: accountFields).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func appendLog(_ line: String) {
+        DispatchQueue.main.async {
+            self.logLines.append(line)
+            self.logView.text = self.logLines.joined(separator: "\n")
+            let end = NSRange(location: (self.logView.text as NSString).length, length: 0)
+            self.logView.scrollRangeToVisible(end)
+        }
+    }
+
+    static func describe(_ event: RoktEvent) -> String {
+        switch event {
+        case let e as RoktEvent.InitComplete:
+            return "InitComplete(success=\(e.success))"
+        case let e as RoktEvent.PlacementReady:
+            return "PlacementReady(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.PlacementClosed:
+            return "PlacementClosed(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.PlacementCompleted:
+            return "PlacementCompleted(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.PlacementFailure:
+            return "PlacementFailure(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.PlacementInteractive:
+            return "PlacementInteractive(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.OfferEngagement:
+            return "OfferEngagement(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.PositiveEngagement:
+            return "PositiveEngagement(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.FirstPositiveEngagement:
+            return "FirstPositiveEngagement(\(e.identifier ?? "-"))"
+        case let e as RoktEvent.OpenUrl:
+            return "OpenUrl(\(e.url))"
+        case let e as RoktEvent.CartItemInstantPurchase:
+            return "CartItemInstantPurchase(catalogItemId=\(e.catalogItemId))"
+        case let e as RoktEvent.CartItemDevicePay:
+            return "CartItemDevicePay(\(e.paymentProvider))"
+        default:
+            return "RoktEvent: \(type(of: event))"
+        }
+    }
+}
+
+// MARK: - Cells
+
+private final class TextEntryCell: UITableViewCell, UITextFieldDelegate {
+    static let reuseId = "TextEntryCell"
+
+    private let labelView = UILabel()
+    private let field = UITextField()
+
+    var onChange: ((String) -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+        selectionStyle = .none
+        labelView.font = .preferredFont(forTextStyle: .caption1)
+        labelView.textColor = .secondaryLabel
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        field.borderStyle = .none
+        field.clearButtonMode = .whileEditing
+        field.autocorrectionType = .no
+        field.autocapitalizationType = .none
+        field.spellCheckingType = .no
+        field.delegate = self
+        field.addTarget(self, action: #selector(editingChanged), for: .editingChanged)
+        field.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(labelView)
+        contentView.addSubview(field)
+
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            labelView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            field.topAnchor.constraint(equalTo: labelView.bottomAnchor, constant: 4),
+            field.leadingAnchor.constraint(equalTo: labelView.leadingAnchor),
+            field.trailingAnchor.constraint(equalTo: labelView.trailingAnchor),
+            field.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func configure(label: String, value: String, isSecure: Bool) {
+        labelView.text = label
+        field.text = value
+        field.isSecureTextEntry = isSecure
+        field.placeholder = isSecure ? "pk_test_..." : label
+    }
+
+    @objc private func editingChanged() {
+        onChange?(field.text ?? "")
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}
+
+private final class ActionCell: UITableViewCell {
+    static let reuseId = "ActionCell"
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func configure(title: String, destructive: Bool) {
+        var content = defaultContentConfiguration()
+        content.text = title
+        content.textProperties.color = destructive ? .systemRed : .systemBlue
+        content.textProperties.alignment = .center
+        contentConfiguration = content
+    }
+}
+
+private final class LogCell: UITableViewCell {
+    static let reuseId = "LogCell"
+    private weak var hostedLogView: UITextView?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+        selectionStyle = .none
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func install(logView: UITextView) {
+        guard logView !== hostedLogView else { return }
+        hostedLogView?.removeFromSuperview()
+        contentView.addSubview(logView)
+        NSLayoutConstraint.activate([
+            logView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            logView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            logView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            logView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+        ])
+        hostedLogView = logView
+    }
+}

--- a/Example/rokt/TagIdSelectionTableViewController.swift
+++ b/Example/rokt/TagIdSelectionTableViewController.swift
@@ -12,6 +12,7 @@ class TagIdSelectionTableViewController: UIViewController, UIPickerViewDelegate,
     @IBOutlet weak var customTagIdLabel: UILabel!
     @IBOutlet weak var customTagIdTextField: UITextField!
     var roktTags: [RoktTag] = [RoktTag]()
+    private var currentEnvironment: Environment = .Stage
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,6 +22,40 @@ class TagIdSelectionTableViewController: UIViewController, UIPickerViewDelegate,
         customTagIdTextField.text = "2754655826098840951"
         customTagIdTextField.delegate = self
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self.view, action: #selector(UIView.endEditing(_:))))
+        installShoppableAdsDemoButton()
+    }
+
+    private func installShoppableAdsDemoButton() {
+        let button = UIButton(type: .system)
+        button.setTitle("Shoppable Ads Demo", for: .normal)
+        button.accessibilityIdentifier = "ShoppableAdsDemoButton"
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .boldSystemFont(ofSize: 16)
+        button.backgroundColor = .systemBlue
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(openShoppableAdsDemo), for: .touchUpInside)
+        view.addSubview(button)
+
+        var constraints: [NSLayoutConstraint] = [
+            button.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            button.heightAnchor.constraint(equalToConstant: 50)
+        ]
+        // Stack flush above the Initialize button; fall back to the safe-area bottom.
+        if let initializeButton = view.findSubview(withAccessibilityIdentifier: "InitializeButton") {
+            constraints.append(button.bottomAnchor.constraint(equalTo: initializeButton.topAnchor))
+        } else {
+            constraints.append(button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor))
+        }
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    @objc private func openShoppableAdsDemo() {
+        let seed = ShoppableAdsDemoSeed(
+            environment: selectedEnvironment(),
+            tagID: selectedTagID()
+        )
+        navigationController?.pushViewController(ShoppableAdsDemoViewController(seed: seed), animated: true)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -124,17 +159,11 @@ class TagIdSelectionTableViewController: UIViewController, UIPickerViewDelegate,
     }
 
     func setEnvironment(_ environment: Environment) {
-        switch environment {
-        case .Stage: Rokt.setEnvironment(environment: .Stage)
-        case .Prod: Rokt.setEnvironment(environment: .Prod)
-        case .ProdDemo: Rokt.setEnvironment(environment: .ProdDemo)
-        case .Local: Rokt.setEnvironment(environment: .Local)
-        }
+        currentEnvironment = environment
+        Rokt.setEnvironment(environment: environment.roktEnvironment)
     }
 
     @IBAction func initialRokt(_ sender: Any) {
-        let selectedRow = tagIdPicker.selectedRow(inComponent: 0)
-        let selectedTag = selectedRow == 0 ? customTagIdTextField.text ?? "" : roktTags[selectedRow].id
         Rokt.globalEvents { roktEvent in
             if let initEvent = roktEvent as? RoktEvent.InitComplete {
                 print("Received Rokt global event InitComplete with status: \(initEvent.success)")
@@ -142,7 +171,7 @@ class TagIdSelectionTableViewController: UIViewController, UIPickerViewDelegate,
                 print("Received Rokt global event \(roktEvent)")
             }
         }
-        Rokt.initWith(roktTagId: selectedTag)
+        Rokt.initWith(roktTagId: selectedTagID())
     }
 
     @IBAction func getTrackingConsent(_ sender: Any) {
@@ -213,4 +242,28 @@ class TagIdSelectionTableViewController: UIViewController, UIPickerViewDelegate,
         return true
     }
 
+    private func selectedEnvironment() -> Environment {
+        currentEnvironment
+    }
+
+    private func selectedTagID() -> String {
+        let selectedRow = tagIdPicker.selectedRow(inComponent: 0)
+        guard selectedRow != 0 else {
+            return customTagIdTextField.text ?? ""
+        }
+        return roktTags[selectedRow].id
+    }
+
+}
+
+private extension UIView {
+    func findSubview(withAccessibilityIdentifier identifier: String) -> UIView? {
+        if accessibilityIdentifier == identifier { return self }
+        for subview in subviews {
+            if let match = subview.findSubview(withAccessibilityIdentifier: identifier) {
+                return match
+            }
+        }
+        return nil
+    }
 }

--- a/Example/rokt/model/Environment.swift
+++ b/Example/rokt/model/Environment.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Rokt_Widget
+
 enum Environment: String, CaseIterable {
     case Stage
     case Prod
@@ -11,5 +13,14 @@ enum Environment: String, CaseIterable {
 
     static var all: [Environment] {
         return Environment.allCases
+    }
+
+    var roktEnvironment: RoktEnvironment {
+        switch self {
+        case .Stage: return .Stage
+        case .Prod: return .Prod
+        case .ProdDemo: return .ProdDemo
+        case .Local: return .Local
+        }
     }
 }

--- a/Example/rokt/model/ShoppableAdsDefaults.swift
+++ b/Example/rokt/model/ShoppableAdsDefaults.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pre-populated defaults for the Shoppable Ads demo screen.
+///
+/// Mirrors the structure used by the public `rokt-demo-ios` app so that
+/// QA / ops teams get a near-identical sandbox experience in either app.
+enum ShoppableAdsDefaults {
+    static let tagID = "3068704822624787054"
+    static let viewName = "StgRoktShoppableAds"
+    static let stripePublishableKey = ""
+    static let applePayMerchantId =
+        Bundle.main.object(forInfoDictionaryKey: "ApplePayMerchantID") as? String ?? "merchant.rokt.test"
+
+    static let attributes: [(key: String, value: String)] = [
+        ("email", "jenny.smith@example.com"),
+        ("firstname", "Jenny"),
+        ("lastname", "Smith"),
+        ("confirmationref", "ORD-12345"),
+        ("country", "US"),
+        ("sandbox", "true"),
+        ("shippingaddress1", "123 Main St"),
+        ("shippingaddress2", "Apt 4B"),
+        ("shippingcity", "New York"),
+        ("shippingstate", "NY"),
+        ("shippingzipcode", "10001"),
+        ("shippingcountry", "US"),
+        ("billingzipcode", "07762"),
+        ("paymenttype", "ApplePay"),
+        ("last4digits", "4444")
+    ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Add a Shoppable Ads demo to the example app so developers can exercise the Apple Pay payment extension registration flow and `selectShoppableAds` from the existing sample app. This is limited to example-app UI and package wiring; it does not change SDK source or public SDK API.

## What Has Changed

- Added a Shoppable Ads Demo entry button above Initialize in the example tag selection flow.
- Added a demo screen with sandbox defaults, editable tag ID seeded from the previous screen, Rokt initialization, payment extension registration, launch, reset, and log clearing actions.
- Set and log the selected Rokt environment during the Shoppable Ads initialization flow.
- Reset the SDK session from Clear Log with `Rokt.setSessionId(sessionId: " ")`.
- Updated the example app package dependency from `RoktStripePaymentExtension` `0.1.2+` to `RoktPaymentExtension` `2.0.1+`.
- Added focused example-app tests for demo defaults, button wiring, validation, reset, clear log, launch warning, and event formatting.

## How Has This Been Tested

Local simulator validation used `iPhone 16 Pro, OS=18.6` because `OS=latest` was not available for that device locally.

- `trunk check --ci`
- `swift package resolve`
- `xcodebuild build -project Example/rokt.xcodeproj -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO`
- Built `rokt-Example-MOCK`, `rokt-Example-STAGE`, and `rokt-Example-PROD` with the same destination and signing flags.
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure -resultBundlePath TestResult.xcresult`
- `xcodebuild test -project Example/rokt.xcodeproj -scheme rokt-Example-MOCK -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure -resultBundlePath UiTestResult.xcresult`
- `periphery scan --format github-actions`
- `Tests/SizeReport/measure_size.sh --json`
- `pod lib lint Rokt-Widget.podspec --allow-warnings --verbose`
- Manual simulator smoke verified the Shoppable Ads Demo button placement, default fields, blank Stripe key validation log, reset behavior, clear log behavior, and launch warning/failure path before registration.
- After the CI fix, `trunk check --ci` and `xcodebuild test -project Example/rokt.xcodeproj -scheme rokt-Example-MOCK -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -only-testing:rokt_Tests/ShoppableAdsDemoTests -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure` passed locally.

Size report:

```json
{"baseline_app_size_kb":84,"baseline_executable_size_bytes":74928,"with_sdk_app_size_kb":4784,"with_sdk_executable_size_bytes":4873544,"sdk_framework_size_kb":0,"sdk_framework_binary_bytes":0,"sdk_impact_kb":4700,"sdk_executable_impact_bytes":4798616}
```

## Notes

This PR changes example-app UI; please attach a screenshot or video if required for review. Full payment-sheet verification still requires a valid sandbox Stripe publishable key and Apple Pay setup.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
