### PR TITLE
feat: add Afterpay payment support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "0.1.3")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.9.0")),
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", branch: "feat/afterpay-button-fix"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", branch: "feat/afterpay-button-fix"),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.0")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'Rokt_Widget' => ['Sources/Rokt_Widget/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'RoktContracts', '~> 0.1'
-  s.dependency 'RoktUXHelper', '~> 0.9'
+  s.dependency 'RoktContracts', '~> 1.0'
+  s.dependency 'RoktUXHelper', '~> 0.10'
 end

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -20,7 +20,7 @@ final class PaymentOrchestrator {
     /// Register a payment extension with configuration.
     ///
     /// - Parameters:
-    ///   - paymentExtension: The extension to register (e.g. RoktStripePaymentExtension)
+    ///   - paymentExtension: The extension to register (e.g. RoktPaymentExtension)
     ///   - config: Configuration parameters (e.g. ["stripeKey": "pk_live_..."])
     /// - Returns: `true` if registration succeeded.
     @discardableResult

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -58,6 +58,18 @@ final class PaymentOrchestrator {
         return allWireValues.compactMap { PaymentMethodType(wireValue: $0) }
     }
 
+    /// Forward a URL to each registered extension until one claims it.
+    ///
+    /// Used for redirect-based payment methods (e.g. Afterpay) that return to the host app
+    /// via a custom URL scheme. Iteration stops at the first extension that returns `true`.
+    ///
+    /// - Parameter url: The URL received by the host app.
+    /// - Returns: `true` if any registered extension recognized and handled the URL.
+    @discardableResult
+    func handleURLCallback(with url: URL) -> Bool {
+        registeredExtensions.contains { $0.handleURLCallback?(with: url) ?? false }
+    }
+
     // MARK: - Payment Processing
 
     /// Process a payment using the first registered extension that supports the given method.
@@ -71,6 +83,7 @@ final class PaymentOrchestrator {
     func processPayment(
         method: PaymentMethodType,
         item: PaymentItem,
+        context: PaymentContext,
         cartItemId: String,
         from viewController: UIViewController,
         completion: @escaping (PaymentSheetResult) -> Void
@@ -97,6 +110,7 @@ final class PaymentOrchestrator {
         ext.presentPaymentSheet(
             item: item,
             method: method,
+            context: context,
             from: viewController,
             preparePayment: preparePayment,
             completion: completion

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -160,6 +160,31 @@ internal import RoktUXHelper
         shared.roktImplementation.registerPaymentExtension(paymentExtension, config: config)
     }
 
+    /// Forward an incoming URL to registered payment extensions.
+    ///
+    /// Redirect-based payment methods (e.g. Afterpay) authenticate the user in a
+    /// web view and return to the host app via a custom URL scheme. The host app
+    /// should forward every incoming URL to this method — the SDK asks each
+    /// registered extension whether it recognizes the URL and stops at the first
+    /// match.
+    ///
+    /// Example (SwiftUI):
+    /// ```swift
+    /// WindowGroup {
+    ///     ContentView()
+    ///         .onOpenURL { url in
+    ///             Rokt.handleURLCallback(with: url)
+    ///         }
+    /// }
+    /// ```
+    ///
+    /// - Parameter url: The URL received by the host app.
+    /// - Returns: `true` if a registered payment extension handled the URL.
+    @discardableResult
+    public static func handleURLCallback(with url: URL) -> Bool {
+        shared.roktImplementation.handleURLCallback(with: url)
+    }
+
     /// Display a Shoppable Ads overlay placement.
     ///
     /// Always renders as an overlay/lightbox — no embedded views.

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -151,7 +151,7 @@ internal import RoktUXHelper
     /// Must be called before `selectShoppableAds()`.
     ///
     /// - Parameters:
-    ///   - paymentExtension: The payment extension to register (e.g. `RoktStripePaymentExtension`)
+    ///   - paymentExtension: The payment extension to register (e.g. `RoktPaymentExtension`)
     ///   - config: Configuration dictionary (e.g. `["stripeKey": "pk_live_..."]`)
     public static func registerPaymentExtension(
         _ paymentExtension: PaymentExtension,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -121,6 +121,43 @@ class RoktInternalImplementation {
         uxHelper.devicePayFinalized(layoutId: layoutId, catalogItemId: catalogItemId, success: success)
     }
 
+    /// Map a UX-helper `Address` (from backend `TransactionData`) to the contracts
+    /// `ContactAddress` shape expected by a `PaymentExtension`. Email is not part of
+    /// `Address`, so it falls back to the partner-supplied `email` attribute.
+    /// Returns `nil` if `address` is `nil`.
+    func buildContactAddress(from address: RoktUXHelper.Address?) -> ContactAddress? {
+        guard let address else { return nil }
+        return ContactAddress(
+            name: address.name,
+            email: attributes["email"] ?? "",
+            addressLine1: address.address1,
+            city: address.city,
+            state: address.stateCode.isEmpty ? address.state : address.stateCode,
+            postalCode: address.zip,
+            country: address.countryCode.isEmpty ? address.country : address.countryCode
+        )
+    }
+
+    /// Legacy fallback: build a `ContactAddress` from partner-supplied attributes
+    /// for backends that do not yet populate `TransactionData`. Returns `nil` if
+    /// no address attributes were provided.
+    func buildContactAddressFromAttributes() -> ContactAddress? {
+        let line1 = attributes["shippingaddress1"] ?? ""
+        guard !line1.isEmpty else { return nil }
+        let name = [attributes["firstname"], attributes["lastname"]]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        return ContactAddress(
+            name: name,
+            email: attributes["email"] ?? "",
+            addressLine1: line1,
+            city: attributes["shippingcity"],
+            state: attributes["shippingstate"],
+            postalCode: attributes["shippingzipcode"],
+            country: attributes["shippingcountry"]
+        )
+    }
+
     func setFrameworkType(_ frameworkType: RoktFrameworkType) {
         self.frameworkType = frameworkType
     }
@@ -321,22 +358,16 @@ class RoktInternalImplementation {
                 currency: event.currency
             )
 
-            // Build PaymentContext — for Afterpay, populate from stored attributes
+            // Build PaymentContext from backend-provided TransactionData, falling
+            // back to partner-supplied attributes if the offer did not include
+            // transaction data (e.g. older backend versions).
             let context: PaymentContext
             if paymentMethod == .afterpay {
-                let name = [attributes["firstname"], attributes["lastname"]]
-                    .compactMap { $0 }
-                    .joined(separator: " ")
-                let address = ContactAddress(
-                    name: name,
-                    email: attributes["email"] ?? "",
-                    addressLine1: attributes["shippingaddress1"],
-                    city: attributes["shippingcity"],
-                    state: attributes["shippingstate"],
-                    postalCode: attributes["shippingzipcode"],
-                    country: attributes["shippingcountry"]
-                )
-                context = PaymentContext(billingAddress: address, shippingAddress: address)
+                let billing = buildContactAddress(from: event.transactionData?.billingAddress)
+                    ?? buildContactAddressFromAttributes()
+                let shipping = buildContactAddress(from: event.transactionData?.shippingAddress)
+                    ?? buildContactAddressFromAttributes()
+                context = PaymentContext(billingAddress: billing, shippingAddress: shipping)
             } else {
                 context = PaymentContext()
             }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -303,6 +303,8 @@ class RoktInternalImplementation {
                 paymentMethod = .applePay
             case "Stripe":
                 paymentMethod = .card
+            case "Afterpay":
+                paymentMethod = .afterpay
             default:
                 RoktLogger.shared.error("Unsupported payment provider: \(event.paymentProvider.rawValue)")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
@@ -319,6 +321,26 @@ class RoktInternalImplementation {
                 currency: event.currency
             )
 
+            // Build PaymentContext — for Afterpay, populate from stored attributes
+            let context: PaymentContext
+            if paymentMethod == .afterpay {
+                let name = [attributes["firstname"], attributes["lastname"]]
+                    .compactMap { $0 }
+                    .joined(separator: " ")
+                let address = ContactAddress(
+                    name: name,
+                    email: attributes["email"] ?? "",
+                    addressLine1: attributes["shippingaddress1"],
+                    city: attributes["shippingcity"],
+                    state: attributes["shippingstate"],
+                    postalCode: attributes["shippingzipcode"],
+                    country: attributes["shippingcountry"]
+                )
+                context = PaymentContext(billingAddress: address, shippingAddress: address)
+            } else {
+                context = PaymentContext()
+            }
+
             // Find the topmost view controller for presenting the payment sheet
             guard let viewController = UIApplication.topViewController() else {
                 RoktLogger.shared.error("No view controller available to present payment sheet")
@@ -331,6 +353,7 @@ class RoktInternalImplementation {
             paymentOrchestrator.processPayment(
                 method: paymentMethod,
                 item: item,
+                context: context,
                 cartItemId: event.cartItemId,
                 from: viewController
             ) { [weak self] result in
@@ -789,6 +812,12 @@ class RoktInternalImplementation {
                 severity: .warning
             )
         }
+    }
+
+    /// Forward a URL to registered payment extensions.
+    @discardableResult
+    func handleURLCallback(with url: URL) -> Bool {
+        paymentOrchestrator.handleURLCallback(with: url)
     }
 
     // MARK: - Shoppable Ads

--- a/Tests/Rokt_WidgetTests/Shared/Extensions/TestRoktUxEvent+Extension.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Extensions/TestRoktUxEvent+Extension.swift
@@ -220,7 +220,8 @@ final class TestRoktUxEventExtension: XCTestCase {
             quantity: 1,
             totalPrice: 9.99,
             unitPrice: 9.99,
-            paymentProvider: .applePay
+            paymentProvider: .applePay,
+            transactionData: nil
         )
 
         let returnedEvent = providedEvent.mapToRoktEvent

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -14,6 +14,7 @@ final class MockPaymentExtension: PaymentExtension {
     var shouldRegisterSuccessfully: Bool = true
     var shouldAutomaticallyCompletePayment: Bool = true
     var paymentResultToReturn: PaymentSheetResult = .succeeded(transactionId: "txn_mock")
+    var urlCallbackHandler: ((URL) -> Bool)?
 
     private(set) var onRegisterCallCount = 0
     private(set) var onRegisterLastParameters: [String: String]?
@@ -22,6 +23,8 @@ final class MockPaymentExtension: PaymentExtension {
     private(set) var presentPaymentSheetLastMethod: PaymentMethodType?
     private(set) var presentPaymentSheetLastItem: PaymentItem?
     private(set) var capturedPreparePayment: ((ContactAddress, @escaping (PaymentPreparation?, Error?) -> Void) -> Void)?
+    private(set) var handleURLCallbackCallCount = 0
+    private(set) var handleURLCallbackLastURL: URL?
 
     init(
         id: String = "mock_extension",
@@ -46,6 +49,7 @@ final class MockPaymentExtension: PaymentExtension {
     func presentPaymentSheet(
         item: PaymentItem,
         method: PaymentMethodType,
+        context: PaymentContext,
         from viewController: UIViewController,
         preparePayment: @escaping (ContactAddress, @escaping (PaymentPreparation?, Error?) -> Void) -> Void,
         completion: @escaping (PaymentSheetResult) -> Void
@@ -57,6 +61,12 @@ final class MockPaymentExtension: PaymentExtension {
         if shouldAutomaticallyCompletePayment {
             completion(paymentResultToReturn)
         }
+    }
+
+    func handleURLCallback(with url: URL) -> Bool {
+        handleURLCallbackCallCount += 1
+        handleURLCallbackLastURL = url
+        return urlCallbackHandler?(url) ?? false
     }
 }
 
@@ -193,6 +203,56 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(methods.count, 2, "Should not contain duplicates")
     }
 
+    // MARK: - handleURLCallback
+
+    func test_handleURLCallback_noExtensions_returnsFalse() {
+        let url = URL(string: "myapp://stripe-redirect")!
+        XCTAssertFalse(sut.handleURLCallback(with: url))
+    }
+
+    func test_handleURLCallback_noExtensionClaims_returnsFalse() {
+        let ext1 = MockPaymentExtension(id: "ext1")
+        let ext2 = MockPaymentExtension(id: "ext2")
+        ext1.urlCallbackHandler = { _ in false }
+        ext2.urlCallbackHandler = { _ in false }
+        sut.register(ext1, config: [:])
+        sut.register(ext2, config: [:])
+
+        let url = URL(string: "myapp://foo")!
+        XCTAssertFalse(sut.handleURLCallback(with: url))
+        XCTAssertEqual(ext1.handleURLCallbackCallCount, 1)
+        XCTAssertEqual(ext2.handleURLCallbackCallCount, 1)
+        XCTAssertEqual(ext1.handleURLCallbackLastURL, url)
+    }
+
+    func test_handleURLCallback_firstClaims_shortCircuits() {
+        let ext1 = MockPaymentExtension(id: "ext1")
+        let ext2 = MockPaymentExtension(id: "ext2")
+        ext1.urlCallbackHandler = { _ in true }
+        ext2.urlCallbackHandler = { _ in true }
+        sut.register(ext1, config: [:])
+        sut.register(ext2, config: [:])
+
+        let url = URL(string: "myapp://stripe-redirect")!
+        XCTAssertTrue(sut.handleURLCallback(with: url))
+        XCTAssertEqual(ext1.handleURLCallbackCallCount, 1)
+        XCTAssertEqual(ext2.handleURLCallbackCallCount, 0, "second extension should not be called")
+    }
+
+    func test_handleURLCallback_secondClaims_returnsTrue() {
+        let ext1 = MockPaymentExtension(id: "ext1")
+        let ext2 = MockPaymentExtension(id: "ext2")
+        ext1.urlCallbackHandler = { _ in false }
+        ext2.urlCallbackHandler = { _ in true }
+        sut.register(ext1, config: [:])
+        sut.register(ext2, config: [:])
+
+        let url = URL(string: "myapp://paypal-return")!
+        XCTAssertTrue(sut.handleURLCallback(with: url))
+        XCTAssertEqual(ext1.handleURLCallbackCallCount, 1)
+        XCTAssertEqual(ext2.handleURLCallbackCallCount, 1)
+    }
+
     // MARK: - processPayment
 
     func test_processPayment_routesToCorrectExtension() {
@@ -207,7 +267,9 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item1", name: "Widget", amount: 9.99, currency: "USD")
         let vc = UIViewController()
 
-        sut.processPayment(method: .card, item: item, cartItemId: "v1:cart-123:canal", from: vc) { result in
+        sut
+            .processPayment(method: .card, item: item, context: PaymentContext(), cartItemId: "v1:cart-123:canal",
+                            from: vc) { result in
             XCTAssertEqual(result.outcome, .succeeded)
             XCTAssertEqual(result.transactionId, "txn_card")
             expectation.fulfill()
@@ -226,7 +288,9 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item1", name: "Widget", amount: 9.99, currency: "USD")
         let vc = UIViewController()
 
-        sut.processPayment(method: .applePay, item: item, cartItemId: "v1:cart-456:canal", from: vc) { result in
+        sut
+            .processPayment(method: .applePay, item: item, context: PaymentContext(), cartItemId: "v1:cart-456:canal",
+                            from: vc) { result in
             XCTAssertEqual(result.outcome, .failed)
             XCTAssertTrue(result.errorMessage?.contains("No payment extension found") == true,
                           "Error should indicate no extension found, got: \(result.errorMessage ?? "nil")")
@@ -264,6 +328,7 @@ class TestPaymentOrchestrator: XCTestCase {
         sut.processPayment(
             method: .applePay,
             item: item,
+            context: PaymentContext(),
             cartItemId: "v1:cart-789:canal",
             from: UIViewController()
         ) { _ in

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Foundation
+@testable internal import RoktUXHelper
 
 @testable import Rokt_Widget
 
@@ -158,6 +159,75 @@ class TestRokt: XCTestCase {
         let sessionId = roktInternalImplementation.getSessionId()
 
         XCTAssertEqual(sessionId, expectedSessionId)
+    }
+
+    func test_buildContactAddress_mapsTransactionDataAddress() throws {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.attributes["email"] = "jane@example.com"
+
+        let address = try JSONDecoder().decode(
+            Address.self,
+            from: Data(
+                """
+                {
+                  "name": "Jane Doe",
+                  "address1": "123 Test St",
+                  "address2": null,
+                  "city": "New York",
+                  "state": "New York",
+                  "stateCode": "NY",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "zip": "10001"
+                }
+                """.utf8
+            )
+        )
+
+        let contactAddress = roktInternalImplementation.buildContactAddress(from: address)
+
+        XCTAssertEqual(contactAddress?.name, "Jane Doe")
+        XCTAssertEqual(contactAddress?.email, "jane@example.com")
+        XCTAssertEqual(contactAddress?.addressLine1, "123 Test St")
+        XCTAssertEqual(contactAddress?.city, "New York")
+        XCTAssertEqual(contactAddress?.state, "NY")
+        XCTAssertEqual(contactAddress?.postalCode, "10001")
+        XCTAssertEqual(contactAddress?.country, "US")
+    }
+
+    func test_buildContactAddressFromAttributes_mapsLegacyShippingAttributes() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.attributes = [
+            "firstname": "Jane",
+            "lastname": "Doe",
+            "email": "jane@example.com",
+            "shippingaddress1": "456 Legacy Rd",
+            "shippingcity": "Boston",
+            "shippingstate": "MA",
+            "shippingzipcode": "02110",
+            "shippingcountry": "US"
+        ]
+
+        let contactAddress = roktInternalImplementation.buildContactAddressFromAttributes()
+
+        XCTAssertEqual(contactAddress?.name, "Jane Doe")
+        XCTAssertEqual(contactAddress?.email, "jane@example.com")
+        XCTAssertEqual(contactAddress?.addressLine1, "456 Legacy Rd")
+        XCTAssertEqual(contactAddress?.city, "Boston")
+        XCTAssertEqual(contactAddress?.state, "MA")
+        XCTAssertEqual(contactAddress?.postalCode, "02110")
+        XCTAssertEqual(contactAddress?.country, "US")
+    }
+
+    func test_buildContactAddressFromAttributes_returnsNilWithoutAddressLine1() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.attributes = [
+            "firstname": "Jane",
+            "lastname": "Doe",
+            "shippingcity": "Boston"
+        ]
+
+        XCTAssertNil(roktInternalImplementation.buildContactAddressFromAttributes())
     }
 
     // MARK: - Rokt Public API Tests

--- a/Tests/Rokt_WidgetTests/TestShoppableAds.swift
+++ b/Tests/Rokt_WidgetTests/TestShoppableAds.swift
@@ -171,6 +171,7 @@ private final class StubPaymentExtension: PaymentExtension {
     func presentPaymentSheet(
         item: PaymentItem,
         method: PaymentMethodType,
+        context: PaymentContext,
         from viewController: UIViewController,
         preparePayment: @escaping (
             _ address: ContactAddress,


### PR DESCRIPTION
## Summary

Extends Shoppable Ads to support **Afterpay** (via Stripe) alongside Apple Pay, and introduces a provider-agnostic `Rokt.handleURLCallback(with:)` API so partner apps no longer depend on any specific payment SDK.

## Changes

- **Payment routing** — Map `PaymentProvider.Afterpay` → `PaymentMethodType.afterpay` in the `CartItemDevicePay` event chain.
- **PaymentContext** — Construct a `PaymentContext` with billing/shipping address from the `selectShoppableAds` attributes before dispatching to the extension (Afterpay needs address before payment UI; Apple Pay ignores context).
- **Orchestrator** — Forward `context` through `PaymentOrchestrator.processPayment`.
- **Public URL callback API** — Add `Rokt.handleURLCallback(with:)`. The orchestrator iterates registered extensions and stops at the first that recognizes the URL. This decouples partners from `StripeAPI.handleURLCallback` — future providers (PayPal, Klarna) will plug in with zero partner code changes.

## Dependencies

- `rokt-contracts-apple` → **1.0.0** (adds `PaymentContext`, `PaymentMethodType.afterpay`, optional `handleURLCallback` in protocol)
- `rokt-ux-helper-ios` → **branch `feat/afterpay-button-fix`** (children rendering for non-Apple-Pay buttons). Switch back to a tagged version before merge once the UX helper PR lands.

## Test plan

- [x] `TestPaymentOrchestrator` — 19 tests pass (includes 4 new `handleURLCallback` routing tests: no extensions, none claims, first claims with short-circuit, second claims)
- [ ] End-to-end with `PaymentSampleApp` (separate repo artifact) — Afterpay flow verified against real Stripe test account + Canal backend
- [x] Apple Pay regression check
- [x] Wait for UX helper PR (#249) to merge, then pin to a tagged version here

## Partner-facing API changes

```swift
// Init with returnURL for Afterpay support
let ext = RoktStripePaymentExtension(
    applePayMerchantId: "merchant.com.partner",
    returnURL: "com.partner.app://stripe-redirect"
)!
Rokt.registerPaymentExtension(ext, config: ["stripeKey": "pk_live_..."])

// Forward URL callbacks — no direct Stripe dependency
.onOpenURL { url in
    Rokt.handleURLCallback(with: url)
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)