### PR TITLE
feat: Add attribute keyAdsExperienceType to signify Shoppable Ads

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -793,6 +793,9 @@ class RoktInternalImplementation {
 
     // MARK: - Shoppable Ads
 
+    private let keyAdsExperienceType = "adsExperience"
+    private let valueAdsExperienceShoppable = "shoppable"
+
     /// Display a Shoppable Ads overlay placement.
     func selectShoppableAds(
         identifier: String,
@@ -816,10 +819,15 @@ class RoktInternalImplementation {
             return
         }
 
+        var enrichedAttributes = attributes
+        if enrichedAttributes[keyAdsExperienceType] == nil {
+            enrichedAttributes[keyAdsExperienceType] = valueAdsExperienceShoppable
+        }
+
         // Reuse the existing execute flow — backend routes based on placement config
         execute(
             viewName: identifier,
-            attributes: attributes,
+            attributes: enrichedAttributes,
             placements: nil,
             config: config,
             placementOptions: nil,

--- a/Tests/Rokt_WidgetTests/TestShoppableAds.swift
+++ b/Tests/Rokt_WidgetTests/TestShoppableAds.swift
@@ -103,7 +103,19 @@ final class TestShoppableAds: XCTestCase {
 
         XCTAssertEqual(mockImplementation.executeCallCount, 1)
         XCTAssertEqual(mockImplementation.lastViewName, "test")
-        XCTAssertEqual(mockImplementation.lastAttributes, ["email": "test@example.com"])
+        XCTAssertEqual(mockImplementation.lastAttributes, ["email": "test@example.com", "adsExperience": "shoppable"])
+    }
+
+    func test_selectShoppableAds_doesNotOverwriteAdsExperience_whenAlreadySet() {
+        mockImplementation.initFeatureFlags = Self.featureFlags(
+            postPurchase: true,
+            minimumSchema: true
+        )
+        mockImplementation.registerPaymentExtension(StubPaymentExtension(), config: [:])
+
+        Rokt.selectShoppableAds(identifier: "test", attributes: ["adsExperience": "custom"])
+
+        XCTAssertEqual(mockImplementation.lastAttributes["adsExperience"], "custom")
     }
 
     func test_selectShoppableAds_emitsPlacementFailure_whenGateOff() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

To differentiate Shoppable Ads on downstream systems this PR introduces `keyAdsExperienceType` and sets it to Shoppable when `selectShoppableAds` is called.
