### PR TITLE
feat: add PaymentExtensionAttributeEnricher to detect extension registration

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -69,6 +69,8 @@ class RoktInternalImplementation {
     // Payment orchestrator for Shoppable Ads
     private lazy var paymentOrchestrator = PaymentOrchestrator()
 
+    var isPaymentExtensionRegistered: Bool { paymentOrchestrator.hasRegisteredExtension }
+
     func close() {
         guard let window = UIApplication.shared.windows.filter({$0.isKeyWindow}).first,
               let rootViewController = window.rootViewController

--- a/Sources/Rokt_Widget/Util/AttributeEnrichment.swift
+++ b/Sources/Rokt_Widget/Util/AttributeEnrichment.swift
@@ -9,7 +9,8 @@ struct AttributeEnrichment {
     static let shared: AttributeEnrichment = AttributeEnrichment(enrichers: [
         ApplePayAttributeEnricher(),
         ColorModeAttributeEnricher(),
-        StripeAttributeEnricher()
+        StripeAttributeEnricher(),
+        PaymentExtensionAttributeEnricher { Rokt.shared.roktImplementation.isPaymentExtensionRegistered }
     ])
     let enrichers: [AttributeEnricher]
 

--- a/Sources/Rokt_Widget/Util/PaymentExtensionAttributeEnricher.swift
+++ b/Sources/Rokt_Widget/Util/PaymentExtensionAttributeEnricher.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+private let BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY = "paymentExtensionRegistered"
+
+/// Enriches experience requests with whether a payment extension has been registered.
+///
+/// Downstream systems use this attribute to determine whether Shoppable Ads requiring
+/// a payment extension can be presented to the user.
+///
+/// - Returns:
+///  - `"true"` for `paymentExtensionActivated` when a payment extension is registered.
+///  - `"false"` for `paymentExtensionActivated` when no payment extension is registered.
+class PaymentExtensionAttributeEnricher: AttributeEnricher {
+    private let provider: () -> Bool
+
+    init(provider: @escaping () -> Bool) {
+        self.provider = provider
+    }
+
+    func enrich(config: RoktConfig?) -> [String: String] {
+        return [BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY: String(provider())]
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestPaymentExtensionAttributeEnricher.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestPaymentExtensionAttributeEnricher.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Rokt_Widget
+
+private let BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY = "paymentExtensionRegistered"
+
+class TestPaymentExtensionAttributeEnricher: XCTestCase {
+
+    private var mockConfig: RoktConfig!
+
+    override func setUp() {
+        super.setUp()
+        mockConfig = RoktConfig.Builder().build()
+    }
+
+    override func tearDown() {
+        mockConfig = nil
+        super.tearDown()
+    }
+
+    func testEnrich_withPaymentExtensionRegistered_shouldReturnTrue() {
+        // Given
+        let sut = PaymentExtensionAttributeEnricher(provider: { true })
+
+        // When
+        let attributes = sut.enrich(config: mockConfig)
+
+        // Then
+        XCTAssertEqual(attributes.count, 1, "Should contain one key.")
+        XCTAssertEqual(
+            attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "true",
+            "paymentExtensionActivated should be true when a payment extension is registered."
+        )
+    }
+
+    func testEnrich_withNoPaymentExtensionRegistered_shouldReturnFalse() {
+        // Given
+        let sut = PaymentExtensionAttributeEnricher(provider: { false })
+
+        // When
+        let attributes = sut.enrich(config: mockConfig)
+
+        // Then
+        XCTAssertEqual(attributes.count, 1, "Should contain one key.")
+        XCTAssertEqual(
+            attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "false",
+            "paymentExtensionActivated should be false when no payment extension is registered."
+        )
+    }
+
+    func testEnrich_withNilConfig_shouldStillReturnAttribute() {
+        // Given
+        let sut = PaymentExtensionAttributeEnricher(provider: { true })
+
+        // When
+        let attributes = sut.enrich(config: nil)
+
+        // Then
+        XCTAssertEqual(attributes.count, 1, "Should contain one key regardless of config.")
+        XCTAssertEqual(attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "true")
+    }
+
+    func testEnrich_providerIsCalledOnEachEnrich() {
+        // Given
+        var callCount = 0
+        let sut = PaymentExtensionAttributeEnricher(provider: {
+            callCount += 1
+            return true
+        })
+
+        // When
+        _ = sut.enrich(config: mockConfig)
+        _ = sut.enrich(config: mockConfig)
+
+        // Then
+        XCTAssertEqual(callCount, 2, "Provider should be called on every enrich call.")
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

For Shoppable Ads to be functional a payment extension needs to be registered

## What Has Changed

- Adds an attribute enricher to log when a Payment Extension has been registered

## How Has This Been Tested

- Local tests pass

## Notes

N/A