### PR TITLE
fix(networking): add layoutsSchemaVersionHeader to initialize request

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.0")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.1")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+internal import RoktUXHelper
 
 // MARK: - URL constants (internal — also used by test mocks)
 
@@ -45,7 +46,17 @@ internal class RoktNetWorkAPI {
     private static let timingsDiagnosticCode = "[TIMINGS]"
     private static let timingsSdkType = "msdk"
     private static let layoutsSchemaVersionHeader = "rokt-layout-schema-version"
-    private static let layoutsSchemaVersion = "2.4"
+    private static var layoutsSchemaVersion: String {
+        // layoutSchemaVersion is internal in RoktUXHelper; decode it through Codable.
+        struct LayoutInfo: Decodable { let layoutSchemaVersion: String }
+        guard
+            let data = try? JSONEncoder().encode(RoktUX.integrationInfo.integration),
+            let info = try? JSONDecoder().decode(LayoutInfo.self, from: data)
+        else { return "2.5" }
+        let parts = info.layoutSchemaVersion.split(separator: ".")
+        guard parts.count >= 2 else { return info.layoutSchemaVersion }
+        return "\(parts[0]).\(parts[1])"
+    }
     private static let fullFontLogCode3 = "[FFL003]"
     private static let fullFontLogCode4 = "[FFL004]"
 

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -63,7 +63,8 @@ internal class RoktNetWorkAPI {
                                     params: nil,
                                     headers: [
                                         headerTagIdKey: roktTagId,
-                                        headerSdkFrameworkType: Rokt.shared.roktImplementation.frameworkType.toString
+                                        headerSdkFrameworkType: Rokt.shared.roktImplementation.frameworkType.toString,
+                                        layoutsSchemaVersionHeader: layoutsSchemaVersion
                                     ],
                                     extraErrorCheck: true,
                                     success: { (dict, _, _) in

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -47,13 +47,8 @@ internal class RoktNetWorkAPI {
     private static let timingsSdkType = "msdk"
     private static let layoutsSchemaVersionHeader = "rokt-layout-schema-version"
     private static var layoutsSchemaVersion: String {
-        // layoutSchemaVersion is internal in RoktUXHelper; decode it through Codable.
-        struct LayoutInfo: Decodable { let layoutSchemaVersion: String }
-        guard
-            let data = try? JSONEncoder().encode(RoktUX.integrationInfo.integration),
-            let info = try? JSONDecoder().decode(LayoutInfo.self, from: data)
-        else { return "2.5" }
-        return info.layoutSchemaVersion.split(separator: ".").prefix(2).joined(separator: ".")
+        RoktUX.integrationInfo.integration.layoutSchemaVersion
+            .split(separator: ".").prefix(2).joined(separator: ".")
     }
     private static let fullFontLogCode3 = "[FFL003]"
     private static let fullFontLogCode4 = "[FFL004]"

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -53,9 +53,7 @@ internal class RoktNetWorkAPI {
             let data = try? JSONEncoder().encode(RoktUX.integrationInfo.integration),
             let info = try? JSONDecoder().decode(LayoutInfo.self, from: data)
         else { return "2.5" }
-        let parts = info.layoutSchemaVersion.split(separator: ".")
-        guard parts.count >= 2 else { return info.layoutSchemaVersion }
-        return "\(parts[0]).\(parts[1])"
+        return info.layoutSchemaVersion.split(separator: ".").prefix(2).joined(separator: ".")
     }
     private static let fullFontLogCode3 = "[FFL003]"
     private static let fullFontLogCode4 = "[FFL004]"


### PR DESCRIPTION
## Background

The `rokt-layout-schema-version` header was added in ios-sdk-source but was omitted when the PR was transferred to this repo. It is already sent in `getExperienceData` but was missing from the `/v1/init` call.

## What Has Changed

- Added `layoutsSchemaVersionHeader: layoutsSchemaVersion` to the headers dictionary in `RoktNetWorkAPI.initialize()`

## How Has This Been Tested

Verified the existing constants (`layoutsSchemaVersionHeader` = `"rokt-layout-schema-version"`, `layoutsSchemaVersion` = `"2.4"`) are reused — no new code introduced.

## Notes

N/A

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.