### PR TITLE
fix: SDKE-433 move JSON deserialization to a separate thread

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -682,9 +682,11 @@ class RoktInternalImplementation {
                                          selectionId: String,
                                          viewName: String? = nil,
                                          attributes: [String: String]) -> LayoutPageExecutePayload? {
-        guard let pageData = try? page.data(using: .utf8),
-              let pageDecodedData = try? JSONDecoder().decode(RoktUXExperienceResponse.self, from: pageData)
-        else {
+        guard let pageData = page.data(using: .utf8) else {
+            return nil
+        }
+
+        guard let pageDecodedData = try? decodeOnSeparateThread(RoktUXExperienceResponse.self, pageData) else {
             return nil
         }
         sessionManager.updateSessionId(newSessionId: pageDecodedData.sessionId)
@@ -692,7 +694,7 @@ class RoktInternalImplementation {
         guard let pageModel = pageDecodedData.getPageModel() else {
             return nil
         }
-        let events = try? JSONDecoder().decode(UntriggeredEventsContainer.self, from: pageData)
+        let events = try? decodeOnSeparateThread(UntriggeredEventsContainer.self, pageData)
         if let events = events {
             RealTimeEventManager.shared.addUntriggeredEvents(events.untriggeredEvents)
         }
@@ -895,6 +897,36 @@ class RoktInternalImplementation {
             placementOptions: nil,
             onRoktEvent: onRoktEvent
         )
+    }
+
+    private func decodeOnSeparateThread<T: Decodable>(_ type: T.Type, _ data: Data) throws -> T {
+        var result: Result<T, Error>?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let decodingThread = Thread {
+            defer { semaphore.signal() }
+            do {
+                let decoded = try JSONDecoder().decode(type, from: data)
+                result = .success(decoded)
+            } catch {
+                result = .failure(error)
+            }
+        }
+        decodingThread.name = "com.rokt.decoder"
+        decodingThread.stackSize = max(decodingThread.stackSize, 8 * 1024 * 1024)
+        decodingThread.qualityOfService = Thread.current.qualityOfService
+        decodingThread.start()
+
+        semaphore.wait()
+
+        switch result {
+        case .success(let decoded):
+            return decoded
+        case .failure(let error):
+            throw error
+        case .none:
+            throw RoktError("Decoding failed")
+        }
     }
 }
 


### PR DESCRIPTION
## Background

`processLayoutPageExecutePayload` decodes the RoktUX experience response on
the caller's thread using `JSONDecoder().decode`. For deeply nested DCUI
JSON payloads the default thread stack size is not sufficient and decoding
can overflow the stack, crashing the host app.

Fixes SDKE-433

## What Has Changed

- `processLayoutPageExecutePayload` now routes both
  `RoktUXExperienceResponse` and `UntriggeredEventsContainer` decodes
  through a new private `decodeOnSeparateThread(_:_:)` helper instead of
  calling `JSONDecoder().decode` directly.
- The helper spawns a `Thread` named `com.rokt.decoder` with
  `stackSize = max(default, 8 * 1024 * 1024)`, inherits the caller's
  `qualityOfService`, blocks on a `DispatchSemaphore`, and re-throws any
  decoding error (or a `RoktError("Decoding failed")` fallback).

## How Has This Been Tested

- `xcodebuild -scheme Rokt-Widget -sdk iphonesimulator -destination '…iPhone 17e…' build` → **BUILD SUCCEEDED**.
- `xcodebuild -scheme Rokt-Widget … -only-testing:Rokt_WidgetTests/TestRokt test` → **16 tests passed, 0 failures**, including `testProcessLayoutPageExecutePayload_noPlugins_sessionIdIsSaved` which exercises the changed decode path.

## Notes

JIRA: SDKE-433

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.