### PR TITLE
fix: emit missing Shoppable Ads payment events to partners

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -115,6 +115,15 @@ class RoktInternalImplementation {
             catalogItemId: catalogItemId,
             success: success
         )
+
+        if !success {
+            state.onRoktEvent?(RoktEvent.CartItemInstantPurchaseFailure(
+                identifier: identifier,
+                catalogItemId: catalogItemId,
+                cartItemId: "",
+                error: nil
+            ))
+        }
     }
 
     private func devicePayFinalized(executeId: String, layoutId: String, catalogItemId: String, success: Bool) {
@@ -331,8 +340,20 @@ class RoktInternalImplementation {
             callOnUnLoad(executeId)
             placements = nil
             _swiftUiExecuteLayout = nil
+        } else if let event = uxEvent as? RoktUXEvent.CartItemInstantPurchase {
+            callOnRoktEvent(executeId, event: RoktEvent.CartItemInstantPurchaseInitiated(
+                identifier: event.layoutId,
+                catalogItemId: event.catalogItemId,
+                cartItemId: event.cartItemId
+            ))
+            callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
         } else if let event = uxEvent as? RoktUXEvent.CartItemDevicePay {
-            // Forward the public event to the partner
+            // Forward the public initiation and device-pay events to the partner
+            callOnRoktEvent(executeId, event: RoktEvent.CartItemInstantPurchaseInitiated(
+                identifier: event.layoutId,
+                catalogItemId: event.catalogItemId,
+                cartItemId: event.cartItemId
+            ))
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
 
             // Map PaymentProvider -> PaymentMethodType
@@ -391,6 +412,28 @@ class RoktInternalImplementation {
                 from: viewController
             ) { [weak self] result in
                 let success = result.outcome == .succeeded
+                if success {
+                    self?.callOnRoktEvent(executeId, event: RoktEvent.CartItemInstantPurchase(
+                        identifier: event.layoutId,
+                        name: event.name,
+                        cartItemId: event.cartItemId,
+                        catalogItemId: event.catalogItemId,
+                        currency: event.currency,
+                        description: event.description,
+                        linkedProductId: event.linkedProductId,
+                        providerData: event.providerData,
+                        quantity: NSDecimalNumber(decimal: event.quantity),
+                        totalPrice: event.totalPrice.map { NSDecimalNumber(decimal: $0) },
+                        unitPrice: event.unitPrice.map { NSDecimalNumber(decimal: $0) }
+                    ))
+                } else {
+                    self?.callOnRoktEvent(executeId, event: RoktEvent.CartItemInstantPurchaseFailure(
+                        identifier: event.layoutId,
+                        catalogItemId: event.catalogItemId,
+                        cartItemId: event.cartItemId,
+                        error: nil
+                    ))
+                }
                 self?.devicePayFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,

--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -77,6 +77,12 @@ class PlatformEventProcessor {
         }.forEach { _ in
             stateBagManager?.finishInstantPurchase(id: executeId)
         }
+        eventRequests.filter {
+            $0.eventType == .SignalInstantPurchaseDismissal
+        }.forEach { _ in
+            stateBagManager?.getState(id: executeId)?
+                .onRoktEvent?(RoktEvent.InstantPurchaseDismissal(identifier: executeId))
+        }
     }
 
     private func processTimingRequests(eventRequests: [RoktEventRequest], selectionId: String) {

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
@@ -60,6 +60,21 @@ class TestPlatformEventProcessor: XCTestCase {
         XCTAssertEqual(mockStateManager.stateIdRetrieved, "1")
     }
 
+    func testGivenInstantPurchaseDismissalSignal_ThenEmitsPublicDismissalEvent() {
+        mockStateManager.mockSelectionId = "1"
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalInstantPurchaseDismissal)
+            ]
+        )!
+        sut.process(payload, executeId: "1", cacheProperties: nil)
+
+        XCTAssertEqual(mockStateManager.capturedEvents.count, 1)
+        let event = mockStateManager.capturedEvents.first as? RoktEvent.InstantPurchaseDismissal
+        XCTAssertNotNil(event)
+        XCTAssertEqual(event?.identifier, "1")
+    }
+
     func test_insert_ProcessedEvent() {
         let eventRequest = EventRequest(
             sessionId: "session1",
@@ -420,6 +435,7 @@ private class MockTimingsRequestProcessor: TimingsRequestProcessor {
 
 private class MockStateManager: StateBagManaging {
     var mockSelectionId: String?
+    var capturedEvents: [RoktEvent] = []
 
     func addState(id: String, state: any Bag) {}
     func removeState(id: String) {}
@@ -427,7 +443,9 @@ private class MockStateManager: StateBagManaging {
         if mockSelectionId != nil {
             return ExecuteStateBag(
                 uxHelper: nil,
-                onRoktEvent: nil
+                onRoktEvent: { [weak self] event in
+                    self?.capturedEvents.append(event)
+                }
             )
         }
         return nil


### PR DESCRIPTION
## Background

The iOS SDK documents five partner-facing `RoktEvent`s for the Shoppable Ads
payment flow, but three are never emitted and one is only partially emitted:

| Event                              | Before |
|------------------------------------|--------|
| `CartItemDevicePay`                | ✓      |
| `CartItemInstantPurchase`          | partial (non-device-pay only) |
| `CartItemInstantPurchaseInitiated` | missing |
| `CartItemInstantPurchaseFailure`   | missing |
| `InstantPurchaseDismissal`         | missing |

All five event types already exist in `RoktContracts` and all underlying
signals already flow through the UX helper — only the SDK wiring was
missing. Partners subscribed via `Rokt.events(identifier:onEvent:)` were
silently missing analytics and failure/dismissal hooks.

Fixes [(issue)]

## What Has Changed

- `RoktInternalImplementation.callOnRoktUXEvent`: emit `CartItemInstantPurchaseInitiated` whenever a `CartItemInstantPurchase` or `CartItemDevicePay` UX event arrives (full data from the UX event).
- Device-pay completion closure: emit `CartItemInstantPurchase` on success and `CartItemInstantPurchaseFailure` on failure, using the captured UX event data.
- `RoktInternalImplementation.purchaseFinalized`: emit `CartItemInstantPurchaseFailure` when the partner reports `success == false` (non-device-pay path). `cartItemId` is `""` and `error` is `nil` — values the partner API does not supply.
- `PlatformEventProcessor.processInstantPurchase`: emit `InstantPurchaseDismissal` on the `SignalInstantPurchaseDismissal` platform signal.

## How Has This Been Tested

- Full SPM test suite green: 348 tests, 0 failures (`xcodebuild test -scheme Rokt-Widget`).
- New unit test `testGivenInstantPurchaseDismissalSignal_ThenEmitsPublicDismissalEvent` in `TestPlatformEventProcessor` asserts the new signal → public event wiring; `MockStateManager.getState` extended to capture emitted events.
- Other paths (device-pay closure, `purchaseFinalized`) rely on private `stateManager` state and the UX helper's `RoktUX` concrete type, so are covered by manual verification rather than new unit tests.

## Notes

- Semantics for non-device-pay success are unchanged: `CartItemInstantPurchase` still fires at _initiation_ (existing behavior), not at true success. Changing that is out of scope.
- `InstantPurchaseDismissal.identifier` uses the selection id, since `PlatformEventProcessor` does not hold a layoutId. If partners need the plugin id specifically, a follow-up can stash it on the state bag at placement load.
- Missing `error` string on `CartItemInstantPurchaseFailure`: the payment orchestrator does not expose a reason. Left as `nil`.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.