### PR TITLE
feat(UTYP-1419): source forward-payment fulfillment from transactionData

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.1")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.2")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Sources/Rokt_Widget/Models/Payment/ShippingAttributes.swift
+++ b/Sources/Rokt_Widget/Models/Payment/ShippingAttributes.swift
@@ -1,4 +1,5 @@
 import Foundation
+internal import RoktUXHelper
 
 struct ShippingAttributes {
     let address1: String
@@ -34,6 +35,21 @@ struct ShippingAttributes {
         self.lastName = lastName
         self.companyName = companyName
         self.countryCode = countryCode
+    }
+
+    /// Creates ShippingAttributes from a backend-supplied `TransactionData.shippingAddress`.
+    /// Prefers `stateCode`/`countryCode` when populated (matches backend expectations),
+    /// falling back to `state`/`country`. Name fields are not emitted — shipping
+    /// attributes are address-only.
+    init(from address: RoktUXHelper.Address) {
+        self.init(
+            address1: address.address1,
+            city: address.city,
+            state: address.stateCode.isEmpty ? address.state : address.stateCode,
+            postalCode: address.zip ?? "",
+            country: address.countryCode.isEmpty ? address.country : address.countryCode,
+            address2: address.address2
+        )
     }
 
     /// Creates ShippingAttributes from a RoktContracts ContactAddress.

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -39,7 +39,7 @@ class RoktInternalImplementation {
                                                               featureFlags: [:])
     var processedTimingsRequests: TimingsRequestProcessor?
 
-    private var stateManager: StateBagManaging = StateBagManager()
+    var stateManager: StateBagManaging = StateBagManager()
     private var clientTimeoutMilliseconds: Double = RoktInternalImplementation.defaultTimeout
     private var defaultLaunchDelayMilliseconds: Double = RoktInternalImplementation.defaultDelay
     private var loadingFonts = false
@@ -517,21 +517,9 @@ class RoktInternalImplementation {
             upsellItems: [item],
             paymentDetails: PurchasePaymentDetails(
                 token: nil,
-                partnerPaymentReference: event.partnerPaymentReference
+                partnerPaymentReference: event.transactionData?.partnerPaymentReference
             ),
             fulfillmentDetails: fulfillmentDetails
-        )
-    }
-
-    /// Build `FulfillmentDetails` from partner-supplied shipping attributes.
-    /// Returns `nil` if no shipping address was provided — caller should fall
-    /// through to a server-side error rather than sending `{}`.
-    func buildFulfillmentDetailsFromAttributes() -> FulfillmentDetails? {
-        guard let contactAddress = buildContactAddressFromAttributes() else {
-            return nil
-        }
-        return FulfillmentDetails(
-            shippingAttributes: ShippingAttributes(from: contactAddress)
         )
     }
 
@@ -552,9 +540,11 @@ class RoktInternalImplementation {
         return (false, failureReason)
     }
 
-    private func handleForwardPayment(executeId: String,
-                                      event: RoktUXEvent.CartItemForwardPayment) {
-        let fulfillmentDetails = buildFulfillmentDetailsFromAttributes()
+    func handleForwardPayment(executeId: String,
+                              event: RoktUXEvent.CartItemForwardPayment) {
+        let fulfillmentDetails = event.transactionData?.shippingAddress.map {
+            FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
+        }
         guard let request = Self.buildForwardPaymentRequest(
             from: event,
             fulfillmentDetails: fulfillmentDetails

--- a/Tests/Rokt_WidgetTests/TestForwardPaymentPriceResolution.swift
+++ b/Tests/Rokt_WidgetTests/TestForwardPaymentPriceResolution.swift
@@ -26,7 +26,16 @@ final class TestForwardPaymentPriceResolution: XCTestCase {
             quantity: quantity,
             totalPrice: totalPrice,
             unitPrice: unitPrice,
-            partnerPaymentReference: partnerPaymentReference
+            transactionData: TransactionData(
+                shippingAddress: nil,
+                billingAddress: nil,
+                paymentType: nil,
+                supportedPaymentMethods: nil,
+                isPartnerManagedPurchase: false,
+                partnerPaymentReference: partnerPaymentReference,
+                confirmationRef: nil,
+                metadata: [:]
+            )
         )
     }
 
@@ -175,36 +184,6 @@ final class TestForwardPaymentPriceResolution: XCTestCase {
         XCTAssertEqual(request?.fulfillmentDetails?.shippingAttributes.state, "CA")
         XCTAssertEqual(request?.fulfillmentDetails?.shippingAttributes.postalCode, "90210")
         XCTAssertEqual(request?.fulfillmentDetails?.shippingAttributes.country, "US")
-    }
-
-    func test_buildFulfillmentDetailsFromAttributes_returnsNil_whenNoShippingAttributes() {
-        let sut = RoktInternalImplementation()
-        sut.attributes = ["email": "buyer@example.com"]
-
-        XCTAssertNil(sut.buildFulfillmentDetailsFromAttributes())
-    }
-
-    func test_buildFulfillmentDetailsFromAttributes_mapsPartnerSuppliedShipping() {
-        let sut = RoktInternalImplementation()
-        sut.attributes = [
-            "firstname": "Jane",
-            "lastname": "Doe",
-            "shippingaddress1": "123 Mock St",
-            "shippingcity": "Mock City",
-            "shippingstate": "CA",
-            "shippingzipcode": "90210",
-            "shippingcountry": "US"
-        ]
-
-        let fulfillment = sut.buildFulfillmentDetailsFromAttributes()
-
-        XCTAssertEqual(fulfillment?.shippingAttributes.address1, "123 Mock St")
-        XCTAssertEqual(fulfillment?.shippingAttributes.city, "Mock City")
-        XCTAssertEqual(fulfillment?.shippingAttributes.state, "CA")
-        XCTAssertEqual(fulfillment?.shippingAttributes.postalCode, "90210")
-        XCTAssertEqual(fulfillment?.shippingAttributes.country, "US")
-        XCTAssertEqual(fulfillment?.shippingAttributes.firstName, "Jane")
-        XCTAssertEqual(fulfillment?.shippingAttributes.lastName, "Doe")
     }
 
     func test_resolveForwardPaymentFinalization_returnsSuccessWithoutFailureReason() {

--- a/Tests/Rokt_WidgetTests/TestForwardPaymentRequestBody.swift
+++ b/Tests/Rokt_WidgetTests/TestForwardPaymentRequestBody.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import Rokt_Widget
+@testable internal import RoktUXHelper
+import Mocker
+
+/// Verifies the shape of the `/v1/cart/purchase` request body produced by
+/// `handleForwardPayment`. Both `paymentDetails.partnerPaymentReference`
+/// and `fulfillmentDetails.shippingAttributes` must be sourced from
+/// `event.transactionData` (exposed by rokt-ux-helper-ios 0.10.2), and
+/// `fulfillmentDetails` must be omitted when no shipping address is present.
+final class TestForwardPaymentRequestBody: XCTestCase {
+
+    private let purchaseURL = URL(string: "https://mobile-api.rokt.com/v1/cart/purchase")!
+    private let executeId = "test-execute-id"
+
+    private var originalTagId: String?
+
+    override func setUp() {
+        super.setUp()
+        Rokt.setEnvironment(environment: .Prod)
+        originalTagId = Rokt.shared.roktImplementation.roktTagId
+        Rokt.shared.roktImplementation.roktTagId = "test-tag-id"
+    }
+
+    override func tearDown() {
+        Rokt.shared.roktImplementation.roktTagId = originalTagId
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeEvent(
+        transactionData: TransactionData? = nil
+    ) -> RoktUXEvent.CartItemForwardPayment {
+        RoktUXEvent.CartItemForwardPayment(
+            layoutId: "layout-1",
+            name: "Test item",
+            cartItemId: "cart-1",
+            catalogItemId: "catalog-1",
+            currency: "USD",
+            description: "desc",
+            linkedProductId: nil,
+            providerData: "provider",
+            quantity: 1,
+            totalPrice: 9.99,
+            unitPrice: 9.99,
+            transactionData: transactionData
+        )
+    }
+
+    private func makeImplementation() -> RoktInternalImplementation {
+        let impl = RoktInternalImplementation()
+        let bag = ExecuteStateBag(uxHelper: nil, onRoktEvent: { _ in })
+        impl.stateManager.addState(id: executeId, state: bag)
+        return impl
+    }
+
+    private func installMockingHTTPClient() {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockingURLProtocol.self]
+        NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
+    }
+
+    // MARK: - Tests
+
+    func test_purchaseBody_shippingAttributes_sourcedFromTransactionData() throws {
+        let impl = makeImplementation()
+
+        let address = RoktUXHelper.Address(
+            name: "Ignored Name",
+            address1: "123 Mock St",
+            address2: "Apt 4B",
+            city: "Mock City",
+            state: "California",
+            stateCode: "CA",
+            country: "United States",
+            countryCode: "US",
+            zip: "90210"
+        )
+        let transactionData = TransactionData(
+            shippingAddress: address,
+            billingAddress: nil,
+            paymentType: nil,
+            supportedPaymentMethods: nil,
+            isPartnerManagedPurchase: false,
+            partnerPaymentReference: "ref-xyz",
+            confirmationRef: nil,
+            metadata: [:]
+        )
+
+        let requestCaptured = expectation(description: "/cart/purchase request captured")
+        var capturedBody: [String: Any]?
+
+        var mock = Mock(
+            url: purchaseURL,
+            dataType: .json,
+            statusCode: 200,
+            data: [.post: Data("{\"success\":true}".utf8)]
+        )
+        mock.onRequest = { request, _ in
+            capturedBody = request.bodyStreamAsJSON() as? [String: Any]
+            requestCaptured.fulfill()
+        }
+        mock.register()
+        installMockingHTTPClient()
+
+        impl.handleForwardPayment(
+            executeId: executeId,
+            event: makeEvent(transactionData: transactionData)
+        )
+
+        wait(for: [requestCaptured], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody)
+        let paymentDetails = try XCTUnwrap(body["paymentDetails"] as? [String: Any])
+        XCTAssertEqual(paymentDetails["partnerPaymentReference"] as? String, "ref-xyz")
+        XCTAssertNil(paymentDetails["token"], "token must be omitted when not supplied")
+
+        let fulfillment = try XCTUnwrap(body["fulfillmentDetails"] as? [String: Any])
+        let shipping = try XCTUnwrap(fulfillment["shippingAttributes"] as? [String: Any])
+        XCTAssertEqual(shipping["address1"] as? String, "123 Mock St")
+        XCTAssertEqual(shipping["address2"] as? String, "Apt 4B")
+        XCTAssertEqual(shipping["city"] as? String, "Mock City")
+        XCTAssertEqual(shipping["state"] as? String, "CA", "should prefer stateCode over state")
+        XCTAssertEqual(shipping["country"] as? String, "US", "should prefer countryCode over country")
+        XCTAssertEqual(shipping["postalCode"] as? String, "90210")
+        XCTAssertNil(shipping["firstName"], "name fields must not leak into shippingAttributes")
+        XCTAssertNil(shipping["lastName"], "name fields must not leak into shippingAttributes")
+    }
+
+    func test_purchaseBody_noFulfillment_whenTransactionDataShippingAddressMissing() throws {
+        let impl = makeImplementation()
+
+        // transactionData is nil (shippingAddress therefore absent).
+        let requestCaptured = expectation(description: "/cart/purchase request captured")
+        var capturedBody: [String: Any]?
+
+        var mock = Mock(
+            url: purchaseURL,
+            dataType: .json,
+            statusCode: 200,
+            data: [.post: Data("{\"success\":true}".utf8)]
+        )
+        mock.onRequest = { request, _ in
+            capturedBody = request.bodyStreamAsJSON() as? [String: Any]
+            requestCaptured.fulfill()
+        }
+        mock.register()
+        installMockingHTTPClient()
+
+        impl.handleForwardPayment(executeId: executeId, event: makeEvent())
+
+        wait(for: [requestCaptured], timeout: 2.0)
+
+        let body = try XCTUnwrap(capturedBody)
+        XCTAssertNil(
+            body["fulfillmentDetails"],
+            "fulfillmentDetails key must be omitted when transactionData.shippingAddress is absent"
+        )
+    }
+}

--- a/Tests/Rokt_WidgetTests/TestShippingAttributesFromAddress.swift
+++ b/Tests/Rokt_WidgetTests/TestShippingAttributesFromAddress.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Rokt_Widget
+@testable internal import RoktUXHelper
+
+/// Covers `ShippingAttributes.init(from: RoktUXHelper.Address)` branching:
+/// `stateCode`/`countryCode` are preferred when populated, falling back to
+/// `state`/`country` when empty, and a nil `zip` becomes an empty string.
+final class TestShippingAttributesFromAddress: XCTestCase {
+
+    private func makeAddress(
+        state: String = "California",
+        stateCode: String = "CA",
+        country: String = "United States",
+        countryCode: String = "US",
+        zip: String? = "90210"
+    ) -> RoktUXHelper.Address {
+        RoktUXHelper.Address(
+            name: "Ada Lovelace",
+            address1: "123 Mock St",
+            address2: "Apt 4B",
+            city: "Mock City",
+            state: state,
+            stateCode: stateCode,
+            country: country,
+            countryCode: countryCode,
+            zip: zip
+        )
+    }
+
+    func test_prefersStateCodeAndCountryCode_whenPopulated() {
+        let attrs = ShippingAttributes(from: makeAddress())
+
+        XCTAssertEqual(attrs.state, "CA")
+        XCTAssertEqual(attrs.country, "US")
+    }
+
+    func test_fallsBackToState_whenStateCodeEmpty() {
+        let attrs = ShippingAttributes(from: makeAddress(stateCode: ""))
+
+        XCTAssertEqual(attrs.state, "California")
+    }
+
+    func test_fallsBackToCountry_whenCountryCodeEmpty() {
+        let attrs = ShippingAttributes(from: makeAddress(countryCode: ""))
+
+        XCTAssertEqual(attrs.country, "United States")
+    }
+
+    func test_postalCodeDefaultsToEmptyString_whenZipNil() {
+        let attrs = ShippingAttributes(from: makeAddress(zip: nil))
+
+        XCTAssertEqual(attrs.postalCode, "")
+    }
+
+    func test_doesNotEmitNameFields_fromAddress() {
+        let attrs = ShippingAttributes(from: makeAddress())
+
+        XCTAssertNil(attrs.firstName)
+        XCTAssertNil(attrs.lastName)
+        XCTAssertNil(attrs.companyName)
+    }
+}


### PR DESCRIPTION
## Summary
- Bumps `rokt-ux-helper-ios` to `0.10.2` (ships UTYP-1406 `TransactionData` on `CartItemForwardPayment`).
- `paymentDetails.partnerPaymentReference` + `fulfillmentDetails.shippingAttributes` on `/v1/cart/purchase` now read from `event.transactionData`; `fulfillmentDetails` is omitted when `shippingAddress` is nil.
- Deletes `buildFulfillmentDetailsFromAttributes()` — forward-payment has no legacy attribute-fallback contract (UTYP-1395 shipped unreleased). Device-pay's `buildContactAddressFromAttributes` fallback is left intact.

## Ordering
Base retargeted to `main`. This unblocks `main`, which is currently broken by `RoktUXHelper 0.10.2` dropping top-level `partnerPaymentReference` from `CartItemForwardPayment`. [#133](https://github.com/ROKT/rokt-sdk-ios/pull/133) (UTYP-1401, loading-indicator) stacks on top of this and will be rebased onto main after this lands.

## Tested on stage
/purchase request
```
{
  "paymentDetails": {
    "partnerPaymentReference": "gpabfk4x"
  },
  "totalUpsellPrice": 49.88,
  "currency": "USD",
  "upsellItems": [
    {
      "totalPrice": 49.88,
      "cartItemId": "v1:ac9d6475-3c36-4757-85a8-d09a5d0cad20:canal",
      "catalogItemId": "5f60b555-a4fc-4209-a061-16e1270d0f07",
      "unitPrice": 49.88,
      "quantity": 1,
      "currency": "USD"
    }
  ],
  "fulfillmentDetails": {
    "shippingAttributes": {
      "postalCode": "10001",
      "state": "NY",
      "address1": "123 Main St",
      "address2": "Apt 4B",
      "city": "New York",
      "country": "US"
    }
  }
}
```


/purchase response (200) -> matches what we see on web
```
{
  "success": true,
  "reason": "",
  "totalUpsellPrice": 49.88,
  "currency": "USD",
  "identifiers": {},
  "upsellItems": [
    {
      "cartItemId": "v1:ac9d6475-3c36-4757-85a8-d09a5d0cad20:canal",
      "catalogItemId": "5f60b555-a4fc-4209-a061-16e1270d0f07",
      "quantity": 1,
      "unitPrice": 49.88,
      "totalPrice": 49.88,
      "currency": "USD"
    }
  ],
  "paid": false,
  "paymentDetails": {
    "method": "",
    "message": ""
  },
  "shippingInitiated": false,
  "shippingDetails": {
    "method": "",
    "message": ""
  }
}
```

## Test plan
- [x] `xcodebuild build` (iPhone 16 / iOS 18.6 / DebugSTAGE) — `** BUILD SUCCEEDED **`
- [x] `xcodebuild test -only-testing:Rokt_WidgetTests/TestForwardPaymentPriceResolution` — 17/17 passing; new assertions cover `transactionData`-sourced `partnerPaymentReference` and exercise the pricing-resolution paths
- [ ] Loading-indicator request-body assertions (shipping shape, stateCode/countryCode precedence, address2 pass-through, no name-field leak, omission when shippingAddress nil) land with UTYP-1401 (#133)

Ticket: https://rokt.atlassian.net/browse/UTYP-1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)