### PR TITLE
fix(UTYP-1422): rewrite forward-payment events to accepted types

### DIFF
--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -26,6 +26,11 @@ class PlatformEventProcessor {
     func process(_ eventPayload: [String: Any],
                  executeId: String,
                  cacheProperties: LayoutPageCacheProperties?) {
+        // Clean up instant-purchase state for forward-payment completion events before the rewrite
+        // drops them — otherwise `initiateInstantPurchase` (set by the Initiated rewrite) stays
+        // flipped on forever and stale state can match future `purchaseFinalized` lookups.
+        finishInstantPurchaseForForwardPaymentCompletion(eventPayload: eventPayload, executeId: executeId)
+
         let payload = Self.rewriteForwardPaymentEvents(eventPayload)
         // Skip the send when the rewrite drops every event — /v2/events rejects empty payloads as 400.
         if let events = payload["events"] as? [[String: Any]], events.isEmpty {
@@ -56,7 +61,7 @@ class PlatformEventProcessor {
             sendAndCacheEvents(eventRequests: eventRequests, cacheProperties: cacheProperties)
         } catch {
             RoktLogger.shared.error("Failed to process platform events", error: error)
-            RoktLogger.shared.debug("Event payload that failed: \(payload)")
+            RoktLogger.shared.debug("Event payload that failed: \(eventPayload)")
             RoktAPIHelper.sendEvents(events: (payload["events"] as? [[String: Any]]) ?? [])
         }
     }
@@ -94,6 +99,26 @@ class PlatformEventProcessor {
         }
         params.removeValue(forKey: Self.eventDataKey)
         return params
+    }
+
+    // UTYP-1422: `rewriteForwardPaymentEvents` drops SignalCartItemForwardPayment{Success,Failure}
+    // before decode, so `processInstantPurchase` never sees them. Inspect the raw payload here and
+    // finish the instant-purchase state explicitly so it doesn't stay stuck after a forward-payment
+    // flow completes.
+    private func finishInstantPurchaseForForwardPaymentCompletion(eventPayload: [String: Any],
+                                                                  executeId: String) {
+        guard let events = eventPayload["events"] as? [[String: Any]] else { return }
+        let completionTypes: Set<String> = [
+            RoktUXEventType.SignalCartItemForwardPaymentSuccess.rawValue,
+            RoktUXEventType.SignalCartItemForwardPaymentFailure.rawValue
+        ]
+        let hasCompletion = events.contains { event in
+            guard let type = event[eventTypeKey] as? String else { return false }
+            return completionTypes.contains(type)
+        }
+        if hasCompletion {
+            stateBagManager?.finishInstantPurchase(id: executeId)
+        }
     }
 
     private func processInstantPurchase(eventRequests: [RoktEventRequest], executeId: String) {

--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -66,10 +66,10 @@ class PlatformEventProcessor {
         }
     }
 
-    // UTYP-1422: rokt-ux-helper-ios emits SignalCartItemForwardPayment{Initiated,Success,Failure}
-    // which /v2/events rejects as InvalidEventType. Rewrite Initiated to the accepted
-    // SignalCartItemInstantPurchaseInitiated; drop Success/Failure since
-    // upsells/3p-retail-provider already emits the equivalent server-side.
+    // rokt-ux-helper-ios emits SignalCartItemForwardPayment{Initiated,Success,Failure} which
+    // /v2/events rejects as InvalidEventType. Rewrite Initiated to the accepted
+    // SignalCartItemInstantPurchaseInitiated; drop Success/Failure since the backend
+    // (upsells/3p-retail-provider) already emits the equivalent server-side.
     static func rewriteForwardPaymentEvents(_ payload: [String: Any]) -> [String: Any] {
         guard let events = payload["events"] as? [[String: Any]] else { return payload }
         let rewritten: [[String: Any]] = events.compactMap { event in
@@ -101,10 +101,10 @@ class PlatformEventProcessor {
         return params
     }
 
-    // UTYP-1422: `rewriteForwardPaymentEvents` drops SignalCartItemForwardPayment{Success,Failure}
-    // before decode, so `processInstantPurchase` never sees them. Inspect the raw payload here and
-    // finish the instant-purchase state explicitly so it doesn't stay stuck after a forward-payment
-    // flow completes.
+    // `rewriteForwardPaymentEvents` drops SignalCartItemForwardPayment{Success,Failure} before
+    // decode, so `processInstantPurchase` never sees them. Inspect the raw payload here and
+    // finish the instant-purchase state explicitly so it doesn't stay stuck after a
+    // forward-payment flow completes.
     private func finishInstantPurchaseForForwardPaymentCompletion(eventPayload: [String: Any],
                                                                   executeId: String) {
         guard let events = eventPayload["events"] as? [[String: Any]] else { return }

--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -27,6 +27,10 @@ class PlatformEventProcessor {
                  executeId: String,
                  cacheProperties: LayoutPageCacheProperties?) {
         let payload = Self.rewriteForwardPaymentEvents(eventPayload)
+        // Skip the send when the rewrite drops every event — /v2/events rejects empty payloads as 400.
+        if let events = payload["events"] as? [[String: Any]], events.isEmpty {
+            return
+        }
         do {
             let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 

--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -26,18 +26,19 @@ class PlatformEventProcessor {
     func process(_ eventPayload: [String: Any],
                  executeId: String,
                  cacheProperties: LayoutPageCacheProperties?) {
+        let payload = Self.rewriteForwardPaymentEvents(eventPayload)
         do {
-            let data = try JSONSerialization.data(withJSONObject: eventPayload, options: [])
+            let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
             guard let jsonString = String(data: data, encoding: .utf8), !jsonString.isEmpty else {
                 RoktLogger.shared.error("Invalid UTF-8 or empty data in event payload")
-                RoktAPIHelper.sendEvents(events: (eventPayload["events"] as? [[String: Any]]) ?? [])
+                RoktAPIHelper.sendEvents(events: (payload["events"] as? [[String: Any]]) ?? [])
                 return
             }
 
             guard let validatedData = jsonString.data(using: .utf8) else {
                 RoktLogger.shared.error("Failed to re-encode validated UTF-8 string")
-                RoktAPIHelper.sendEvents(events: (eventPayload["events"] as? [[String: Any]]) ?? [])
+                RoktAPIHelper.sendEvents(events: (payload["events"] as? [[String: Any]]) ?? [])
                 return
             }
 
@@ -51,9 +52,34 @@ class PlatformEventProcessor {
             sendAndCacheEvents(eventRequests: eventRequests, cacheProperties: cacheProperties)
         } catch {
             RoktLogger.shared.error("Failed to process platform events", error: error)
-            RoktLogger.shared.debug("Event payload that failed: \(eventPayload)")
-            RoktAPIHelper.sendEvents(events: (eventPayload["events"] as? [[String: Any]]) ?? [])
+            RoktLogger.shared.debug("Event payload that failed: \(payload)")
+            RoktAPIHelper.sendEvents(events: (payload["events"] as? [[String: Any]]) ?? [])
         }
+    }
+
+    // UTYP-1422: rokt-ux-helper-ios emits SignalCartItemForwardPayment{Initiated,Success,Failure}
+    // which /v2/events rejects as InvalidEventType. Rewrite Initiated to the accepted
+    // SignalCartItemInstantPurchaseInitiated; drop Success/Failure since
+    // upsells/3p-retail-provider already emits the equivalent server-side.
+    static func rewriteForwardPaymentEvents(_ payload: [String: Any]) -> [String: Any] {
+        guard let events = payload["events"] as? [[String: Any]] else { return payload }
+        let rewritten: [[String: Any]] = events.compactMap { event in
+            guard let eventType = event[eventTypeKey] as? String else { return event }
+            switch eventType {
+            case RoktUXEventType.SignalCartItemForwardPaymentInitiated.rawValue:
+                var mutated = event
+                mutated[eventTypeKey] = RoktUXEventType.SignalCartItemInstantPurchaseInitiated.rawValue
+                return mutated
+            case RoktUXEventType.SignalCartItemForwardPaymentSuccess.rawValue,
+                 RoktUXEventType.SignalCartItemForwardPaymentFailure.rawValue:
+                return nil
+            default:
+                return event
+            }
+        }
+        var newPayload = payload
+        newPayload["events"] = rewritten
+        return newPayload
     }
 
     func getEventParams(_ event: RoktEventRequest) -> [String: Any] {

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
@@ -78,9 +78,17 @@ class TestPlatformEventProcessor: XCTestCase {
     // MARK: - Forward-payment rewrite (UTYP-1422)
 
     func test_forwardPaymentInitiated_rewrittenToInstantPurchaseInitiated() throws {
+        // Include eventData so the assertion below also locks in that the rewrite
+        // only touches eventType — no other fields should be stripped or mutated.
         let payload = mockEventsPayload(
             events: [
-                .mock(eventType: .SignalCartItemForwardPaymentInitiated)
+                RoktEventRequest(
+                    sessionId: "sessionId",
+                    eventType: .SignalCartItemForwardPaymentInitiated,
+                    parentGuid: "parent",
+                    eventData: ["catalogItemId": "cat-123"],
+                    jwtToken: "token"
+                )
             ]
         )!
 
@@ -88,6 +96,44 @@ class TestPlatformEventProcessor: XCTestCase {
         let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events[0]["eventType"] as? String, "SignalCartItemInstantPurchaseInitiated")
+        XCTAssertEqual(events[0]["sessionId"] as? String, "sessionId")
+        XCTAssertEqual(events[0]["parentGuid"] as? String, "parent")
+        let eventData = try XCTUnwrap(events[0]["eventData"] as? [[String: String]])
+        XCTAssertEqual(eventData.first?["name"], "catalogItemId")
+        XCTAssertEqual(eventData.first?["value"], "cat-123")
+    }
+
+    func test_mixedPayload_preservesOrderAndTransforms() throws {
+        // Single payload exercising all three transformations — rewrite, drop, passthrough —
+        // while preserving input order for the survivors.
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalImpression, parentGuid: "a"),
+                .mock(eventType: .SignalCartItemForwardPaymentInitiated, parentGuid: "b"),
+                .mock(eventType: .SignalCartItemForwardPaymentSuccess, parentGuid: "c"),
+                .mock(eventType: .SignalLoadStart, parentGuid: "d"),
+                .mock(eventType: .SignalCartItemForwardPaymentFailure, parentGuid: "e")
+            ]
+        )!
+
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+        let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
+        XCTAssertEqual(events.map { $0["parentGuid"] as? String }, ["a", "b", "d"])
+        XCTAssertEqual(events.map { $0["eventType"] as? String }, [
+            "SignalImpression",
+            "SignalCartItemInstantPurchaseInitiated",
+            "SignalLoadStart"
+        ])
+    }
+
+    func test_payloadWithoutEventsKey_roundTripsUnchanged() {
+        // Defensive: when upstream hands us a payload without a valid events array,
+        // the rewrite should be a no-op rather than coerce shape.
+        let payload: [String: Any] = ["integration": ["name": "test"], "events": "not-an-array"]
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+
+        XCTAssertEqual(rewritten["events"] as? String, "not-an-array")
+        XCTAssertEqual((rewritten["integration"] as? [String: String])?["name"], "test")
     }
 
     func test_forwardPaymentInitiated_triggersInitiateInstantPurchaseState() {
@@ -131,6 +177,33 @@ class TestPlatformEventProcessor: XCTestCase {
         let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
         let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
         XCTAssertTrue(events.isEmpty)
+    }
+
+    func test_forwardPaymentSuccess_clearsInstantPurchaseState() {
+        // The rewrite drops Success before decode, so processInstantPurchase would never see it.
+        // process() must still clear the state flipped on by the rewritten Initiated signal —
+        // otherwise stateManager.find(where: \.instantPurchaseInitiated) stays true forever and a
+        // later Rokt.purchaseFinalized(...) for an unrelated flow would match this stale state.
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentSuccess)
+            ]
+        )!
+        sut.process(payload, executeId: "1", cacheProperties: nil)
+
+        XCTAssertTrue(mockStateManager.finishInstantPurchaseCalled)
+        XCTAssertEqual(mockStateManager.stateIdRetrieved, "1")
+    }
+
+    func test_forwardPaymentFailure_clearsInstantPurchaseState() {
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentFailure)
+            ]
+        )!
+        sut.process(payload, executeId: "1", cacheProperties: nil)
+
+        XCTAssertTrue(mockStateManager.finishInstantPurchaseCalled)
     }
 
     func test_nonForwardPaymentEvents_passThroughUnchanged() throws {

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
@@ -117,6 +117,22 @@ class TestPlatformEventProcessor: XCTestCase {
         XCTAssertEqual(events[0]["eventType"] as? String, "SignalImpression")
     }
 
+    func test_forwardPaymentSuccessOnly_collapsesToEmptyEvents() throws {
+        // Precondition for the process() early-return: a standalone Success/Failure payload
+        // (what ux-helper fires after /cart/purchase returns) must collapse to zero events,
+        // so PlatformEventProcessor.process must skip the send — otherwise /v2/events returns
+        // 400 InvalidRequestPayload on an empty events array.
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentSuccess)
+            ]
+        )!
+
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+        let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
+        XCTAssertTrue(events.isEmpty)
+    }
+
     func test_nonForwardPaymentEvents_passThroughUnchanged() throws {
         let payload = mockEventsPayload(
             events: [

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
@@ -75,7 +75,7 @@ class TestPlatformEventProcessor: XCTestCase {
         XCTAssertEqual(event?.identifier, "1")
     }
 
-    // MARK: - Forward-payment rewrite (UTYP-1422)
+    // MARK: - Forward-payment rewrite
 
     func test_forwardPaymentInitiated_rewrittenToInstantPurchaseInitiated() throws {
         // Include eventData so the assertion below also locks in that the rewrite

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessor.swift
@@ -75,6 +75,63 @@ class TestPlatformEventProcessor: XCTestCase {
         XCTAssertEqual(event?.identifier, "1")
     }
 
+    // MARK: - Forward-payment rewrite (UTYP-1422)
+
+    func test_forwardPaymentInitiated_rewrittenToInstantPurchaseInitiated() throws {
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentInitiated)
+            ]
+        )!
+
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+        let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0]["eventType"] as? String, "SignalCartItemInstantPurchaseInitiated")
+    }
+
+    func test_forwardPaymentInitiated_triggersInitiateInstantPurchaseState() {
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentInitiated)
+            ]
+        )!
+        sut.process(payload, executeId: "1", cacheProperties: nil)
+
+        XCTAssertTrue(mockStateManager.initiateInstantPurchaseCalled,
+                      "Rewritten Initiated signal should participate in instant-purchase state tracking")
+    }
+
+    func test_forwardPaymentSuccessAndFailure_droppedFromPayload() throws {
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalCartItemForwardPaymentSuccess),
+                .mock(eventType: .SignalCartItemForwardPaymentFailure),
+                .mock(eventType: .SignalImpression)
+            ]
+        )!
+
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+        let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1, "Success and Failure must be dropped; unrelated events preserved")
+        XCTAssertEqual(events[0]["eventType"] as? String, "SignalImpression")
+    }
+
+    func test_nonForwardPaymentEvents_passThroughUnchanged() throws {
+        let payload = mockEventsPayload(
+            events: [
+                .mock(eventType: .SignalImpression),
+                .mock(eventType: .SignalCartItemInstantPurchaseInitiated)
+            ]
+        )!
+
+        let rewritten = PlatformEventProcessor.rewriteForwardPaymentEvents(payload)
+        let events = try XCTUnwrap(rewritten["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0]["eventType"] as? String, "SignalImpression")
+        XCTAssertEqual(events[1]["eventType"] as? String, "SignalCartItemInstantPurchaseInitiated")
+    }
+
     func test_insert_ProcessedEvent() {
         let eventRequest = EventRequest(
             sessionId: "session1",


### PR DESCRIPTION
## Summary

- `rokt-ux-helper-ios` emits `SignalCartItemForwardPayment{Initiated,Success,Failure}` which `/v2/events` rejects as `InvalidEventType` (422).
- Intercept the event payload in `PlatformEventProcessor.process` and rewrite/drop before dispatch:
  - `Initiated` → `SignalCartItemInstantPurchaseInitiated` (already accepted backend-side, matches DCUI web parity)
  - `Success` / `Failure` → dropped, since `upsells/3p-retail-provider` already emits `SignalCartItemInstantPurchase` / `SignalCartItemInstantPurchaseFailure` directly to Kafka when `orchestrator.HandlePurchase()` completes

No ux-helper release required — fix is fully contained in the SDK.

### Behavior change note
The rewritten `Initiated` signal now flows through `processInstantPurchase`, which calls `stateBagManager.initiateInstantPurchase(id:)` for forward-payment flows (previously a no-op because the signal 422'd before reaching any state-tracking). This aligns forward-payment state handling with the existing instant-purchase path.

## Ticket

[UTYP-1422](https://rokt.atlassian.net/browse/UTYP-1422)

## Stage Test

https://github.com/user-attachments/assets/908bc929-d928-469b-b4a6-79ad94b9aa61



## Test plan

- [x] New unit tests in `TestPlatformEventProcessor`:
  - `test_forwardPaymentInitiated_rewrittenToInstantPurchaseInitiated`
  - `test_forwardPaymentInitiated_triggersInitiateInstantPurchaseState`
  - `test_forwardPaymentSuccessAndFailure_droppedFromPayload`
  - `test_nonForwardPaymentEvents_passThroughUnchanged`
- [x] Full `TestPlatformEventProcessor` suite passes (18/18)
- [ ] Stage E2E: trigger forward-payment flow, confirm single `POST /v2/events` with `SignalCartItemInstantPurchaseInitiated` → 200; downstream `SignalCartItemInstantPurchase` / `SignalCartItemInstantPurchaseFailure` arrive from 3p-retail-provider, not client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UTYP-1422]: https://rokt.atlassian.net/browse/UTYP-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ