### PR TITLE
fix: pass server totalAmount to payment preparation for Apple Pay

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.2")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.2")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.3")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'Rokt_Widget' => ['Sources/Rokt_Widget/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'RoktContracts', '~> 1.0'
+  s.dependency 'RoktContracts', '~> 2.0'
   s.dependency 'RoktUXHelper', '~> 0.10'
 end

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -165,7 +165,10 @@ final class PaymentOrchestrator {
 
                 let preparation = PaymentPreparation(
                     clientSecret: clientSecret,
-                    merchantId: merchantId
+                    merchantId: merchantId,
+                    totalAmount: response.paymentDetails.totalAmount,
+                    shippingCost: response.paymentDetails.shippingCost,
+                    tax: response.paymentDetails.tax
                 )
                 completion(.success(preparation))
             },

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -300,6 +300,62 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func test_processPayment_preparePayment_plumbsTotalAmountTaxAndShipping() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.applePay])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = InitializePurchaseResponse(
+            success: true,
+            totalUpsellPrice: 80,
+            currency: "USD",
+            upsellItems: [],
+            paymentDetails: PaymentDetails(
+                gateway: "stripe",
+                merchantName: "Test Merchant",
+                merchantAccountId: "acct_test",
+                paymentIntentId: "pi_test",
+                clientSecret: "cs_test",
+                shippingCost: Decimal(string: "0")!,
+                tax: Decimal(string: "3.53")!,
+                totalAmount: Decimal(string: "83.53")!
+            )
+        )
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 80, currency: "USD")
+        sut.processPayment(
+            method: .applePay,
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-abc:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment returns preparation with server amounts")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { preparation, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(preparation)
+            XCTAssertEqual(preparation?.clientSecret, "cs_test")
+            XCTAssertEqual(preparation?.merchantId, "acct_test")
+            XCTAssertEqual(preparation?.totalAmount, NSDecimalNumber(string: "83.53"))
+            XCTAssertEqual(preparation?.shippingCost, NSDecimalNumber.zero)
+            XCTAssertEqual(preparation?.tax, NSDecimalNumber(string: "3.53"))
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func test_processPayment_preparePaymentFailsFast_whenResponseMissingRequiredFields() {
         sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
 


### PR DESCRIPTION
## Background

When a shopper entered a shipping address in the Apple Pay sheet during a Shoppable Ads purchase, the sheet kept showing the item price instead of the server-calculated grand total (item + tax + shipping). The payment was still charged at the correct server-side amount, but the UI mismatch was confusing and eroded trust at the checkout step.

Root cause: the SDK extracted only `clientSecret` and `merchantId` from the `v1/cart/initialize-purchase` response and dropped `totalAmount`, `shippingCost`, and `tax` before handing `PaymentPreparation` back to the payment extension, so the extension had nothing to update the sheet with.

## What Has Changed

- Bump `rokt-contracts-apple` dependency to `2.0.0`, which adds `totalAmount`, `shippingCost`, and `tax` (as `NSDecimalNumber`) to `PaymentPreparation`.
- `PaymentOrchestrator.preparePaymentForItem` now forwards `response.paymentDetails.totalAmount`, `shippingCost`, and `tax` into `PaymentPreparation`, letting the payment extension render a line-itemized Apple Pay summary (Subtotal / Shipping / Tax / Total) driven by server values.
- Add `test_processPayment_preparePayment_plumbsTotalAmountTaxAndShipping` to `TestPaymentOrchestrator` to lock in the new wiring.

The corresponding payment-extension change lives in ROKT/rokt-payment-extension-ios#20.

## How Has This Been Tested

- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 17'` — all `TestPaymentOrchestrator` tests pass, including the new one.
- Manual verification against a live `initialize-purchase` response (item \$80, tax \$3.53, total \$83.53) — the Apple Pay sheet now updates to \$83.53 after shipping contact selection.

## Notes

`rokt-contracts-apple` 2.0.0 is a major version bump because it introduces new required fields on `PaymentPreparation`. Integrators that construct `PaymentPreparation` directly must supply `totalAmount` (Swift) or use the legacy `initWithClientSecret:merchantId:` initializer, which defaults the new fields to zero.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.