### PR TITLE
feat: Add PayPal Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Forward PayPal `paypalData.approvalUrl` from initialize-purchase into `PaymentPreparation` when present (requires a RoktContracts release that includes `PaymentPreparation.approvalUrl`; bump the resolved contracts revision when publishing).
+- Built-in PayPal: load the hosted approval URL from cart prepare in a `WKWebView`, detect redirects to `PaymentContext.returnURL` / `cancelURL`, complete the same flow when those URLs arrive as **deep links** via `Rokt.handleURLCallback`, and expose a swappable `PayPalApprovalPresenting` for testing.
+
 ## [5.1.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 ### Added
 
 - Forward PayPal `paypalData.approvalUrl` from initialize-purchase into `PaymentPreparation` when present (depends on **RoktContracts** 2.0.1+).
-- Built-in PayPal: load the hosted approval URL from cart prepare in a `WKWebView`, detect redirects to `PaymentContext.returnURL` / `cancelURL`, complete the same flow when those URLs arrive as **deep links** via `Rokt.handleURLCallback`, and expose a swappable `PayPalApprovalPresenting` for testing.
+- Built-in PayPal device pay: after cart prepare, call **RoktUX** `devicePayShowConfirmation` (layout confirmation + `DATA.catalogRuntime.*` from [rokt-ux-helper-ios#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)); defer the hosted **approve** `WKWebView` until **`/v1/cart/purchase`** forward-payment succeeds, then present approval and complete via `PaymentContext` return/cancel and `Rokt.handleURLCallback`. Swappable `PayPalApprovalPresenting` remains for tests.
 - `Rokt.setBuiltInPayPalRedirectURLScheme(_:)` — **required** for built-in PayPal **device pay**: composes return/cancel as `\(scheme)://rokt-paypal-return` and `\(scheme)://rokt-paypal-cancel` (bare scheme must appear under `CFBundleURLSchemes` in `Info.plist`). Pass `nil` only to clear configuration (PayPal device pay will not proceed until set again).
 
 ### Changed
 
 - **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
+- **RoktUXHelper** SwiftPM: require [0.10.5](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.5)+ (replaces revision pin; includes PayPal confirmation / `devicePayShowConfirmation` from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.5`, `< 0.11`.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
+- Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `payment_method` and `payment_provider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 
 ## [5.1.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 
 ### Added
 
-- Forward PayPal `paypalData.approvalUrl` from initialize-purchase into `PaymentPreparation` when present (requires a RoktContracts release that includes `PaymentPreparation.approvalUrl`; bump the resolved contracts revision when publishing).
+- Forward PayPal `paypalData.approvalUrl` from initialize-purchase into `PaymentPreparation` when present (depends on **RoktContracts** 2.0.1+).
 - Built-in PayPal: load the hosted approval URL from cart prepare in a `WKWebView`, detect redirects to `PaymentContext.returnURL` / `cancelURL`, complete the same flow when those URLs arrive as **deep links** via `Rokt.handleURLCallback`, and expose a swappable `PayPalApprovalPresenting` for testing.
+- `Rokt.setBuiltInPayPalRedirectURLScheme(_:)` — **required** for built-in PayPal **device pay**: composes return/cancel as `\(scheme)://rokt-paypal-return` and `\(scheme)://rokt-paypal-cancel` (bare scheme must appear under `CFBundleURLSchemes` in `Info.plist`). Pass `nil` only to clear configuration (PayPal device pay will not proceed until set again).
+
+### Changed
+
+- **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
+- Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
 
 ## [5.1.0] - 2026-04-24
 

--- a/Example/rokt/OrderCompleteViewController.swift
+++ b/Example/rokt/OrderCompleteViewController.swift
@@ -49,31 +49,39 @@ class OrderCompleteViewController: UIViewController {
                                                       "Location2": location2,
                                                       "Location3": location3,
                                                       "Location4": location4]
+        let placementAttributes = attributesForSelectPlacements()
         Rokt.selectPlacements(
             identifier: pageIdentifier,
-            attributes: [
-                "email": "j.smith1777386131757@rokt.com",
-                "firstname": "Jenny",
-                "lastname": "Smith",
-                "billingzipcode": "07762",
-                "confirmationref": "ORD-12345",
-                "paymenttype": "ApplePay",
-                "last4digits": "4444",
-                "country": "US",
-                "sandbox": "true",
-                "applePayCapabilities": "true",
-                "shippingaddress1": "123 Main St",
-                "shippingaddress2": "Apt 4B",
-                "shippingcity": "New York",
-                "shippingstate": "NY",
-                "shippingzipcode": "10001",
-                "shippingcountry": "US"
-            ],
+            attributes: placementAttributes,
             placements: placements,
             onEvent: {roktEvent in
                 self.onRoktEvent(roktEvent: roktEvent)
             }
         )
+    }
+
+    // Sample defaults for order-complete placements; cart `attributes` override on key overlap.
+    private func attributesForSelectPlacements() -> [String: String] {
+        var base: [String: String] = [
+            "email": "j.smith1777386131757@rokt.com",
+            "firstname": "Jenny",
+            "lastname": "Smith",
+            "billingzipcode": "07762",
+            "confirmationref": "ORD-12345",
+            "paymenttype": "ApplePay",
+            "last4digits": "4444",
+            "country": "US",
+            "sandbox": "true",
+            "applePayCapabilities": "true",
+            "shippingaddress1": "123 Main St",
+            "shippingaddress2": "Apt 4B",
+            "shippingcity": "New York",
+            "shippingstate": "NY",
+            "shippingzipcode": "10001",
+            "shippingcountry": "US"
+        ]
+        base.merge(attributes) { _, fromCart in fromCart }
+        return base
     }
 
     private func onShouldShowLoadingIndicator() {

--- a/Example/rokt/OrderCompleteViewController.swift
+++ b/Example/rokt/OrderCompleteViewController.swift
@@ -43,13 +43,33 @@ class OrderCompleteViewController: UIViewController {
     }
 
     private func showPlacemnt(location4: RoktEmbeddedView) {
+        Rokt.setBuiltInPayPalRedirectURLScheme("myapp")
+
         let placements: [String: RoktEmbeddedView] = [location: location1,
                                                       "Location2": location2,
                                                       "Location3": location3,
                                                       "Location4": location4]
         Rokt.selectPlacements(
             identifier: pageIdentifier,
-            attributes: attributes, placements: placements,
+            attributes: [
+                "email": "j.smith1777386131757@rokt.com",
+                "firstname": "Jenny",
+                "lastname": "Smith",
+                "billingzipcode": "07762",
+                "confirmationref": "ORD-12345",
+                "paymenttype": "ApplePay",
+                "last4digits": "4444",
+                "country": "US",
+                "sandbox": "true",
+                "applePayCapabilities": "true",
+                "shippingaddress1": "123 Main St",
+                "shippingaddress2": "Apt 4B",
+                "shippingcity": "New York",
+                "shippingstate": "NY",
+                "shippingzipcode": "10001",
+                "shippingcountry": "US"
+            ],
+            placements: placements,
             onEvent: {roktEvent in
                 self.onRoktEvent(roktEvent: roktEvent)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        // https://github.com/ROKT/rokt-contracts-apple/pull/22 — PaymentContext.cancelURL, PaymentPreparation.approvalUrl
-        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", branch: "feat/Add-PayPal-Support-2"),
+        // PayPal fields: PaymentContext.cancelURL, PaymentPreparation.approvalUrl — https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.1")),
         .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.4")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        // PayPal fields: PaymentContext.cancelURL, PaymentPreparation.approvalUrl — https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.1")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.4")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.5")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.0")),
+        // https://github.com/ROKT/rokt-contracts-apple/pull/22 — PaymentContext.cancelURL, PaymentPreparation.approvalUrl
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", branch: "feat/Add-PayPal-Support-2"),
         .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.4")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.resource_bundles = { 'Rokt_Widget' => ['Sources/Rokt_Widget/PrivacyInfo.xcprivacy'] }
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
-  s.dependency 'RoktContracts', '~> 2.0'
+  s.dependency 'RoktContracts', '>= 2.0.1', '< 3.0'
   s.dependency 'RoktUXHelper', '~> 0.10'
 end

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.1', '< 3.0'
-  s.dependency 'RoktUXHelper', '~> 0.10'
+  s.dependency 'RoktUXHelper', '>= 0.10.5', '< 0.11'
 end

--- a/Sources/Rokt_Widget/Models/Payment/BreakdownFormatter.swift
+++ b/Sources/Rokt_Widget/Models/Payment/BreakdownFormatter.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Formats the order breakdown values pushed into the UXHelper layout's
+/// `DATA.catalogRuntime.*` placeholders by ``RoktUX/devicePayShowConfirmation``.
+///
+/// Subtotal is summed from ``UpsellItem/totalPrice`` (the response echoes back
+/// what the SDK sent in `/v1/cart/initialize-purchase`); shipping / tax / total
+/// come straight from the cart-prepare response's ``PaymentDetails``.
+enum BreakdownFormatter {
+    static let subtotalKey = "subtotal"
+    static let taxKey = "tax"
+    static let shippingKey = "shipping"
+    static let totalKey = "total"
+
+    /// Build the `[String: String]` payload for ``RoktUX/devicePayShowConfirmation``.
+    static func format(
+        upsellItems: [UpsellItem],
+        shippingCost: Decimal,
+        tax: Decimal,
+        totalAmount: Decimal,
+        currency: String,
+        locale: Locale = .current
+    ) -> [String: String] {
+        let subtotal = upsellItems.reduce(Decimal(0)) { $0 + $1.totalPrice }
+        let formatter = currencyFormatter(currency: currency, locale: locale)
+        return [
+            subtotalKey: format(subtotal, formatter: formatter),
+            taxKey: format(tax, formatter: formatter),
+            shippingKey: format(shippingCost, formatter: formatter),
+            totalKey: format(totalAmount, formatter: formatter)
+        ]
+    }
+
+    private static func currencyFormatter(currency: String, locale: Locale) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = locale
+        formatter.currencyCode = currency
+        return formatter
+    }
+
+    private static func format(_ amount: Decimal, formatter: NumberFormatter) -> String {
+        let number = NSDecimalNumber(decimal: amount)
+        return formatter.string(from: number) ?? "\(amount)"
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/BuiltInPayPalRedirectURLs.swift
+++ b/Sources/Rokt_Widget/Models/Payment/BuiltInPayPalRedirectURLs.swift
@@ -11,12 +11,40 @@ enum BuiltInPayPalRedirectURLs {
     }
 }
 
-/// Validates a bare URL scheme string and optional `Info.plist` registration (skipped under XCTest so unit tests can set a scheme without a host app URL type).
+/// Validates a bare URL scheme string and optional `Info.plist` registration.
+///
+/// Info.plist registration is **not** checked when:
+/// - XCTest is loaded (unit tests), or
+/// - **DEBUG** builds of known Rokt sample apps (`com.rokt.ios-example`, `com.rokt.PaymentSampleApp`, or CocoaPods-generated Rokt example bundles), so sample projects can use placeholder schemes without matching `CFBundleURLSchemes`.
+///
+/// **Release** builds always enforce `CFBundleURLTypes` / `CFBundleURLSchemes` for non-empty schemes.
 enum PayPalRedirectURLSchemeValidator {
-    /// When `false` (e.g. XCTest loaded), only ``isValidBareScheme`` is enforced.
+    /// When `false`, only ``isValidBareScheme`` is enforced (no `Info.plist` URL-type check).
     static var shouldValidateAgainstInfoPlist: Bool {
-        NSClassFromString("XCTestCase") == nil
+        if NSClassFromString("XCTestCase") != nil {
+            return false
+        }
+        #if DEBUG
+        if isKnownRoktSampleApplicationBundle {
+            return false
+        }
+        #endif
+        return true
     }
+
+    #if DEBUG
+    private static var isKnownRoktSampleApplicationBundle: Bool {
+        guard let id = Bundle.main.bundleIdentifier else { return false }
+        if id == "com.rokt.ios-example" || id == "com.rokt.PaymentSampleApp" {
+            return true
+        }
+        // CocoaPods example target: `org.cocoapods.<ProductName>`
+        if id.hasPrefix("org.cocoapods."), id.localizedCaseInsensitiveContains("rokt") {
+            return true
+        }
+        return false
+    }
+    #endif
 
     static func isValidBareScheme(_ scheme: String) -> Bool {
         let s = scheme.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Rokt_Widget/Models/Payment/BuiltInPayPalRedirectURLs.swift
+++ b/Sources/Rokt_Widget/Models/Payment/BuiltInPayPalRedirectURLs.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Fixed hosts for built-in PayPal redirect URLs, composed as `\(bareScheme)://\(host)` (same pattern as the Stripe payment extension’s `rokt-payment-return` host).
+enum BuiltInPayPalRedirectURLs {
+    static let returnHost = "rokt-paypal-return"
+    static let cancelHost = "rokt-paypal-cancel"
+
+    static func returnAndCancelURLs(forBareScheme scheme: String) -> (returnURL: String, cancelURL: String) {
+        let s = scheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ("\(s)://\(returnHost)", "\(s)://\(cancelHost)")
+    }
+}
+
+/// Validates a bare URL scheme string and optional `Info.plist` registration (skipped under XCTest so unit tests can set a scheme without a host app URL type).
+enum PayPalRedirectURLSchemeValidator {
+    /// When `false` (e.g. XCTest loaded), only ``isValidBareScheme`` is enforced.
+    static var shouldValidateAgainstInfoPlist: Bool {
+        NSClassFromString("XCTestCase") == nil
+    }
+
+    static func isValidBareScheme(_ scheme: String) -> Bool {
+        let s = scheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !s.isEmpty && !s.contains("://") && !s.contains("/")
+    }
+
+    static func isSchemeRegistered(_ scheme: String, in bundle: Bundle) -> Bool {
+        let target = scheme.lowercased()
+        guard let urlTypes = bundle.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]] else {
+            return false
+        }
+        for entry in urlTypes {
+            if let schemes = entry["CFBundleURLSchemes"] as? [String],
+               schemes.map({ $0.lowercased() }).contains(target) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -5,6 +5,10 @@ struct InitializePurchaseRequest {
     let currency: String
     let upsellItems: [UpsellItem]
     let fulfillmentDetails: FulfillmentDetails?
+    /// PayPal (or other redirect) success URL for the cart initialize-purchase API.
+    let returnURL: String?
+    /// Optional cancel URL for the cart initialize-purchase API.
+    let cancelURL: String?
 
     func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
@@ -15,6 +19,12 @@ struct InitializePurchaseRequest {
 
         if let fulfillmentDetails {
             dict["fulfillmentDetails"] = fulfillmentDetails.toDictionary()
+        }
+        if let returnURL {
+            dict["returnURL"] = returnURL
+        }
+        if let cancelURL {
+            dict["cancelURL"] = cancelURL
         }
 
         return dict

--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -9,6 +9,10 @@ struct InitializePurchaseRequest {
     let returnURL: String?
     /// Optional cancel URL for the cart initialize-purchase API.
     let cancelURL: String?
+    /// Cart API payment method discriminator (e.g. built-in PayPal: `"PAYPAL"`).
+    let paymentMethod: String?
+    /// Cart API payment provider discriminator (e.g. built-in PayPal: `"PAYPAL"`).
+    let paymentProvider: String?
 
     func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
@@ -25,6 +29,12 @@ struct InitializePurchaseRequest {
         }
         if let cancelURL {
             dict["cancelURL"] = cancelURL
+        }
+        if let paymentMethod {
+            dict["payment_method"] = paymentMethod
+        }
+        if let paymentProvider {
+            dict["payment_provider"] = paymentProvider
         }
 
         return dict

--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseResponse.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseResponse.swift
@@ -1,11 +1,19 @@
 import Foundation
 
+/// PayPal-specific payload returned by the cart initialize-purchase API when applicable.
+struct InitializePurchasePayPalData: Decodable, Equatable {
+    let orderId: String
+    let approvalUrl: String
+}
+
 struct InitializePurchaseResponse: Decodable {
     let success: Bool
     let totalUpsellPrice: Decimal
     let currency: String
     let upsellItems: [UpsellItem]
     let paymentDetails: PaymentDetails
+    /// Present when the backend returns PayPal order details for redirect-based checkout.
+    let paypalData: InitializePurchasePayPalData?
 }
 
 struct PaymentDetails: Decodable {

--- a/Sources/Rokt_Widget/Models/Payment/PayPalApprovalWebFlow.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PayPalApprovalWebFlow.swift
@@ -1,0 +1,221 @@
+import Foundation
+import RoktContracts
+import UIKit
+import WebKit
+
+// MARK: - Return URL matching (embedded web view + deep link)
+
+enum PayPalMerchantReturnURL {
+    /// Same rules for ``WKWebView`` navigation and app deep links: scheme, host, and path must match
+    /// (PayPal appends query parameters such as ``token``).
+    static func matches(navigated: URL, expectedRedirectString: String) -> Bool {
+        guard let expected = URL(string: expectedRedirectString) else { return false }
+        guard let es = navigated.scheme?.lowercased(), let et = expected.scheme?.lowercased(), es == et else {
+            return false
+        }
+        let nh = navigated.host?.lowercased() ?? ""
+        let eh = expected.host?.lowercased() ?? ""
+        guard nh == eh else { return false }
+        let np = navigated.path.isEmpty ? "/" : navigated.path
+        let ep = expected.path.isEmpty ? "/" : expected.path
+        return np == ep
+    }
+}
+
+// MARK: - Single completion + dismiss (WKWebView path or deep link)
+
+/// Coordinates PayPal checkout completion exactly once. PayPal typically redirects to a **deep link**
+/// ``PaymentContext/returnURL``; iOS may open your app with that URL instead of delivering navigation
+/// inside ``WKWebView``, so ``PaymentOrchestrator/handleURLCallback(with:)`` forwards matching URLs here.
+final class PayPalCheckoutCoordinator {
+    private let lock = NSLock()
+    private var finished = false
+
+    private let returnURLString: String
+    private let cancelURLString: String?
+
+    private let completion: (PaymentSheetResult) -> Void
+
+    weak var presentingNavigationController: UINavigationController?
+
+    init(returnURLString: String, cancelURLString: String?, completion: @escaping (PaymentSheetResult) -> Void) {
+        self.returnURLString = returnURLString
+        self.cancelURLString = cancelURLString
+        self.completion = completion
+    }
+
+    func attachPresentingNavigationController(_ navigationController: UINavigationController) {
+        presentingNavigationController = navigationController
+    }
+
+    /// Called when the embedded web view intercepts a matching redirect (in-app navigation).
+    func completeFromEmbeddedCheckout(_ result: PaymentSheetResult) {
+        completeOnce(result)
+    }
+
+    /// Called from ``PaymentOrchestrator/handleURLCallback(with:)`` when the host app receives the return/cancel deep link.
+    /// - Returns: `true` if the URL matches the configured return or cancel URL (including after checkout already finished).
+    @discardableResult
+    func handleDeepLinkReturn(_ url: URL) -> Bool {
+        let matchesReturn = PayPalMerchantReturnURL.matches(navigated: url, expectedRedirectString: returnURLString)
+        let matchesCancel = cancelURLString.map {
+            PayPalMerchantReturnURL.matches(navigated: url, expectedRedirectString: $0)
+        } ?? false
+
+        guard matchesReturn || matchesCancel else {
+            return false
+        }
+
+        lock.lock()
+        let alreadyDone = finished
+        lock.unlock()
+
+        if alreadyDone {
+            return true
+        }
+
+        if matchesCancel {
+            completeOnce(.canceled)
+        } else {
+            let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first { $0.name.caseInsensitiveCompare("token") == .orderedSame }?
+                .value
+            completeOnce(.succeeded(transactionId: token ?? url.absoluteString))
+        }
+        return true
+    }
+
+    private func completeOnce(_ result: PaymentSheetResult) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        lock.unlock()
+
+        let nav = presentingNavigationController
+        let callback = completion
+
+        DispatchQueue.main.async {
+            if let nav {
+                nav.dismiss(animated: true) {
+                    callback(result)
+                }
+            } else {
+                callback(result)
+            }
+        }
+    }
+}
+
+// MARK: - Presenter protocol
+
+/// Presents PayPal's order approval experience.
+///
+/// PayPal's create-order response includes HATEOAS links; the ``rel`` value `approve` points at the
+/// hosted page where the buyer approves the order (see PayPal Orders API — response `links`).
+/// Loading that URL in a web view and intercepting the subsequent redirect to the merchant
+/// ``PaymentContext/returnURL`` completes the browser-based approval step. Return URLs are often
+/// **deep links**; when iOS opens the host app with that URL, ``PayPalCheckoutCoordinator/handleDeepLinkReturn``
+/// completes the flow. PayPal also offers a dedicated iOS SDK for apps that prefer a non-web integration.
+///
+/// - SeeAlso: [Orders API — Create order](https://developer.paypal.com/docs/api/orders/v2/#orders_create)
+protocol PayPalApprovalPresenting: AnyObject {
+    func presentPayPalApproval(
+        approvalURL: URL,
+        from viewController: UIViewController,
+        checkoutCoordinator: PayPalCheckoutCoordinator
+    )
+}
+
+/// Default presenter that loads the approval URL in a ``WKWebView`` and listens for redirects to
+/// the partner return or cancel URLs supplied in ``PaymentContext``.
+final class PayPalApprovalWebPresenter: PayPalApprovalPresenting {
+    func presentPayPalApproval(
+        approvalURL: URL,
+        from viewController: UIViewController,
+        checkoutCoordinator: PayPalCheckoutCoordinator
+    ) {
+        DispatchQueue.main.async {
+            let screen = PayPalApprovalWebViewController(
+                approvalURL: approvalURL,
+                checkoutCoordinator: checkoutCoordinator
+            )
+            let nav = UINavigationController(rootViewController: screen)
+            nav.modalPresentationStyle = .fullScreen
+            viewController.present(nav, animated: true) {
+                checkoutCoordinator.attachPresentingNavigationController(nav)
+            }
+        }
+    }
+}
+
+// MARK: - Web view controller
+
+private final class PayPalApprovalWebViewController: UIViewController, WKNavigationDelegate {
+    private let approvalURL: URL
+    private let checkoutCoordinator: PayPalCheckoutCoordinator
+
+    private lazy var webView: WKWebView = {
+        let configuration = WKWebViewConfiguration()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
+        let view = WKWebView(frame: .zero, configuration: configuration)
+        view.navigationDelegate = self
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    init(approvalURL: URL, checkoutCoordinator: PayPalCheckoutCoordinator) {
+        self.approvalURL = approvalURL
+        self.checkoutCoordinator = checkoutCoordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "PayPal"
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            systemItem: .cancel,
+            primaryAction: UIAction { [weak self] _ in
+                self?.checkoutCoordinator.completeFromEmbeddedCheckout(.canceled)
+            }
+        )
+
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        webView.load(URLRequest(url: approvalURL))
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if checkoutCoordinator.handleDeepLinkReturn(url) {
+            decisionHandler(.cancel)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -163,6 +163,7 @@ final class PaymentOrchestrator {
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present.
+    /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, presents PayPal's hosted approval URL (same role as the Orders API `approve` link).
     private func processBuiltInPayPalPayment(
         item: PaymentItem,

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -221,10 +221,10 @@ final class PaymentOrchestrator {
             switch result {
             case .success(let preparation):
                 Self.verboseLogBuiltInPayPalPaymentPreparation(preparation)
-                guard let approvalURL = URL(string: "https://www.sandbox.paypal.com/signin")
-//                    .trimmingCharacters(in: .whitespacesAndNewlines),
-//                      !approvalString.isEmpty,
-//                      let approvalURL = URL(string: approvalString)
+                guard let approvalString = preparation.approvalUrl?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !approvalString.isEmpty,
+                      let approvalURL = URL(string: approvalString)
                 else {
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.payPalApprovalURLMissingMessage))
@@ -314,6 +314,66 @@ final class PaymentOrchestrator {
         }
     }
 
+    /// PayPal-only forward-payment entry point: open the cached approval URL
+    /// fire `onCompletion` once the coordinator resolves via the in-webview redirect
+    /// or the deep-link `handleURLCallback` path.
+    ///
+    /// backend webhook finalizes the purchase from the PayPal redirect; the SDK only needs
+    /// to surface success/cancel/failure to the UXHelper.
+    ///
+    /// - Parameter onCompletion: called on the main queue with the coordinator outcome.
+    /// - Returns: `true` when a pending PayPal checkout existed and was presented; `false`
+    ///   when the caller should fall through to the non-PayPal `/v1/cart/purchase` flow.
+    @discardableResult
+    func presentPendingBuiltInPayPalForForwardPayment(
+        onCompletion: @escaping (PaymentSheetResult) -> Void
+    ) -> Bool {
+        Self.pendingBuiltInPayPalLock.lock()
+        let snapshot = Self.pendingBuiltInPayPalWebCheckout
+        guard let snapshot, snapshot.owner === self else {
+            Self.pendingBuiltInPayPalLock.unlock()
+            return false
+        }
+        Self.pendingBuiltInPayPalWebCheckout = nil
+        Self.pendingBuiltInPayPalApprovalURL = nil
+        Self.pendingBuiltInPayPalLock.unlock()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                let result = PaymentSheetResult.failed(error: Self.payPalReturnURLMissingMessage)
+                snapshot.completion(result)
+                onCompletion(result)
+                return
+            }
+            // Fall back to the current top view controller when the originally captured weak
+            // reference has been deallocated (e.g. host app dismissed and re-presented Rokt).
+            guard let viewController = snapshot.presentingViewController ?? UIApplication.topViewController() else {
+                let result = PaymentSheetResult.failed(
+                    error: "No view controller available for PayPal checkout."
+                )
+                snapshot.completion(result)
+                onCompletion(result)
+                return
+            }
+            let coordinator = PayPalCheckoutCoordinator(
+                returnURLString: snapshot.returnURLString,
+                cancelURLString: snapshot.cancelURLString,
+                completion: { [weak self] result in
+                    self?.activePayPalCheckout = nil
+                    snapshot.completion(result)
+                    onCompletion(result)
+                }
+            )
+            self.activePayPalCheckout = coordinator
+            self.payPalApprovalPresenter.presentPayPalApproval(
+                approvalURL: snapshot.approvalURL,
+                from: viewController,
+                checkoutCoordinator: coordinator
+            )
+        }
+        return true
+    }
+
     /// Called when forward-payment fails or cannot run, so a deferred built-in PayPal session does not leak.
     func cancelPendingBuiltInPayPalIfNeeded() {
         Self.pendingBuiltInPayPalLock.lock()
@@ -353,23 +413,24 @@ final class PaymentOrchestrator {
         preparation: PaymentPreparation
     ) -> [String: String] {
         let code = item.currency.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "USD" : item.currency
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = code
-
-        func moneyString(_ value: NSDecimalNumber) -> String {
-            formatter.string(from: value) ?? value.stringValue
-        }
-
-        let subtotal = preparation.totalAmount
-            .subtracting(preparation.tax)
-            .subtracting(preparation.shippingCost)
-        return [
-            "subtotal": moneyString(subtotal),
-            "tax": moneyString(preparation.tax),
-            "shipping": moneyString(preparation.shippingCost),
-            "total": moneyString(preparation.totalAmount)
-        ]
+        // Mirror the upsell item ``runInitializePurchase`` builds so subtotal reflects
+        // ``UpsellItem/totalPrice`` (single quantity-1 line item from the request) rather
+        // than `totalAmount − tax − shipping` arithmetic that drifts if backend tweaks rounding.
+        let upsell = UpsellItem(
+            cartItemId: "",
+            catalogItemId: item.id,
+            quantity: 1,
+            unitPrice: item.amount.decimalValue,
+            totalPrice: item.amount.decimalValue,
+            currency: code
+        )
+        return BreakdownFormatter.format(
+            upsellItems: [upsell],
+            shippingCost: preparation.shippingCost.decimalValue,
+            tax: preparation.tax.decimalValue,
+            totalAmount: preparation.totalAmount.decimalValue,
+            currency: code
+        )
     }
 
     private static func nonEmptyTrimmed(_ string: String?) -> String? {

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -28,10 +28,6 @@ final class PaymentOrchestrator {
     private static let builtInPayPalInitializePurchaseMethod = "PAYPAL"
     private static let builtInPayPalInitializePurchaseProvider = "PAYPAL"
 
-    /// Approval URL from cart prepare while built-in PayPal defers opening the hosted approve flow until
-    /// forward-payment finalization (see ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()``).
-    private(set) static var pendingBuiltInPayPalApprovalURL: URL?
-
     private static let pendingBuiltInPayPalLock = NSLock()
     private struct PendingBuiltInPayPalWebCheckout {
         weak var owner: PaymentOrchestrator?
@@ -132,7 +128,7 @@ final class PaymentOrchestrator {
     ///   - cartItemId: The backend cart item ID (format `"v1:uuid:canal"`)
     ///   - viewController: The view controller to present the payment sheet from
     ///   - builtInPayPalDevicePaySession: For built-in PayPal **device pay** only; drives ``RoktUX/devicePayShowConfirmation``
-    ///     and defers the hosted approve ``WKWebView`` until ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()`` runs.
+    ///     and defers the hosted approve ``WKWebView`` until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs.
     ///   - completion: Called with the payment result
     func processPayment(
         method: PaymentMethodType,
@@ -199,7 +195,7 @@ final class PaymentOrchestrator {
     /// and `payment_method` / `payment_provider` as `PAYPAL` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInPayPalDevicePaySession``) and defers the hosted
-    /// PayPal approve step until ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()`` runs after forward-payment success.
+    /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.
     private func processBuiltInPayPalPayment(
         item: PaymentItem,
         context: PaymentContext,
@@ -231,12 +227,8 @@ final class PaymentOrchestrator {
                     }
                     return
                 }
-                Self.pendingBuiltInPayPalLock.lock()
-                Self.pendingBuiltInPayPalApprovalURL = approvalURL
-                Self.pendingBuiltInPayPalLock.unlock()
 
                 guard let devicePaySession else {
-                    Self.clearPendingBuiltInPayPalApprovalURLOnly()
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.builtInPayPalMissingDeferredSessionMessage))
                     }
@@ -275,45 +267,6 @@ final class PaymentOrchestrator {
         }
     }
 
-    /// Called from ``RoktInternalImplementation`` after a successful cart forward-payment finalize, to start hosted PayPal approval
-    /// when cart prepare previously stored a deferred checkout.
-    func presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded() {
-        Self.pendingBuiltInPayPalLock.lock()
-        let snapshot = Self.pendingBuiltInPayPalWebCheckout
-        guard let snapshot, snapshot.owner === self else {
-            Self.pendingBuiltInPayPalLock.unlock()
-            return
-        }
-        Self.pendingBuiltInPayPalWebCheckout = nil
-        Self.pendingBuiltInPayPalApprovalURL = nil
-        Self.pendingBuiltInPayPalLock.unlock()
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self else {
-                snapshot.completion(.failed(error: Self.payPalReturnURLMissingMessage))
-                return
-            }
-            guard let viewController = snapshot.presentingViewController else {
-                snapshot.completion(.failed(error: "No view controller available for PayPal checkout."))
-                return
-            }
-            let coordinator = PayPalCheckoutCoordinator(
-                returnURLString: snapshot.returnURLString,
-                cancelURLString: snapshot.cancelURLString,
-                completion: { [weak self] result in
-                    self?.activePayPalCheckout = nil
-                    snapshot.completion(result)
-                }
-            )
-            self.activePayPalCheckout = coordinator
-            self.payPalApprovalPresenter.presentPayPalApproval(
-                approvalURL: snapshot.approvalURL,
-                from: viewController,
-                checkoutCoordinator: coordinator
-            )
-        }
-    }
-
     /// PayPal-only forward-payment entry point: open the cached approval URL
     /// fire `onCompletion` once the coordinator resolves via the in-webview redirect
     /// or the deep-link `handleURLCallback` path.
@@ -335,7 +288,6 @@ final class PaymentOrchestrator {
             return false
         }
         Self.pendingBuiltInPayPalWebCheckout = nil
-        Self.pendingBuiltInPayPalApprovalURL = nil
         Self.pendingBuiltInPayPalLock.unlock()
 
         DispatchQueue.main.async { [weak self] in
@@ -379,7 +331,6 @@ final class PaymentOrchestrator {
         Self.pendingBuiltInPayPalLock.lock()
         let snapshot = Self.pendingBuiltInPayPalWebCheckout
         Self.pendingBuiltInPayPalWebCheckout = nil
-        Self.pendingBuiltInPayPalApprovalURL = nil
         Self.pendingBuiltInPayPalLock.unlock()
         guard let snapshot else { return }
         DispatchQueue.main.async {
@@ -387,24 +338,17 @@ final class PaymentOrchestrator {
         }
     }
 
-    /// Clears static deferred state without invoking a completion (unit tests).
+    // Clears static deferred state without invoking a completion (unit tests).
+    // periphery:ignore
     static func resetBuiltInPayPalDeferredStateForTesting() {
         pendingBuiltInPayPalLock.lock()
         pendingBuiltInPayPalWebCheckout = nil
-        pendingBuiltInPayPalApprovalURL = nil
-        pendingBuiltInPayPalLock.unlock()
-    }
-
-    private static func clearPendingBuiltInPayPalApprovalURLOnly() {
-        pendingBuiltInPayPalLock.lock()
-        pendingBuiltInPayPalApprovalURL = nil
         pendingBuiltInPayPalLock.unlock()
     }
 
     private static func clearPendingBuiltInPayPalStateUnderLock() {
         pendingBuiltInPayPalLock.lock()
         pendingBuiltInPayPalWebCheckout = nil
-        pendingBuiltInPayPalApprovalURL = nil
         pendingBuiltInPayPalLock.unlock()
     }
 
@@ -532,6 +476,12 @@ final class PaymentOrchestrator {
                     )
                     completion(.failure(validationError))
                     return
+                }
+
+                if let paypalData = response.paypalData {
+                    RoktLogger.shared.verbose(
+                        "\(Self.devicePayErrorCode) initialize-purchase PayPal order id length=\(paypalData.orderId.count)"
+                    )
                 }
 
                 let preparation = PaymentPreparation(

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -2,6 +2,13 @@ import Foundation
 import UIKit
 import RoktContracts
 
+/// Layout context and confirmation hook for built-in PayPal **device pay** (from the execute / device-pay path).
+struct BuiltInPayPalDevicePaySession {
+    let layoutId: String
+    let catalogItemId: String
+    let showConfirmation: (_ layoutId: String, _ catalogItemId: String, _ catalogRuntimeData: [String: String]) -> Void
+}
+
 /// Orchestrates payment processing by managing registered `PaymentExtension` instances
 /// and routing payments to the appropriate extension.
 ///
@@ -17,6 +24,28 @@ final class PaymentOrchestrator {
     /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
     static let payPalReturnURLMissingMessage =
         "PaymentContext.returnURL is required for PayPal checkout."
+    /// Cart `initialize-purchase` body `payment_method` / `payment_provider` for built-in PayPal.
+    private static let builtInPayPalInitializePurchaseMethod = "PAYPAL"
+    private static let builtInPayPalInitializePurchaseProvider = "PAYPAL"
+
+    /// Approval URL from cart prepare while built-in PayPal defers opening the hosted approve flow until
+    /// forward-payment finalization (see ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()``).
+    private(set) static var pendingBuiltInPayPalApprovalURL: URL?
+
+    private static let pendingBuiltInPayPalLock = NSLock()
+    private struct PendingBuiltInPayPalWebCheckout {
+        weak var owner: PaymentOrchestrator?
+        let approvalURL: URL
+        let returnURLString: String
+        let cancelURLString: String?
+        weak var presentingViewController: UIViewController?
+        let completion: (PaymentSheetResult) -> Void
+    }
+
+    private static var pendingBuiltInPayPalWebCheckout: PendingBuiltInPayPalWebCheckout?
+
+    static let builtInPayPalMissingDeferredSessionMessage =
+        "Built-in PayPal device pay requires a layout session for confirmation (device pay hook)."
 
     private var registeredExtensions: [PaymentExtension] = []
     private let apiHelper: RoktAPIHelper.Type
@@ -102,6 +131,8 @@ final class PaymentOrchestrator {
     ///   - item: The item being purchased (from RoktContracts)
     ///   - cartItemId: The backend cart item ID (format `"v1:uuid:canal"`)
     ///   - viewController: The view controller to present the payment sheet from
+    ///   - builtInPayPalDevicePaySession: For built-in PayPal **device pay** only; drives ``RoktUX/devicePayShowConfirmation``
+    ///     and defers the hosted approve ``WKWebView`` until ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()`` runs.
     ///   - completion: Called with the payment result
     func processPayment(
         method: PaymentMethodType,
@@ -109,6 +140,7 @@ final class PaymentOrchestrator {
         context: PaymentContext,
         cartItemId: String,
         from viewController: UIViewController,
+        builtInPayPalDevicePaySession: BuiltInPayPalDevicePaySession? = nil,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         if method == .paypal {
@@ -117,6 +149,7 @@ final class PaymentOrchestrator {
                 context: context,
                 cartItemId: cartItemId,
                 from: viewController,
+                devicePaySession: builtInPayPalDevicePaySession,
                 completion: completion
             )
             return
@@ -162,14 +195,17 @@ final class PaymentOrchestrator {
     /// Entry point for PayPal device pay. Does not consult ``registeredExtensions``.
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
-    /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present.
+    /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
+    /// and `payment_method` / `payment_provider` as `PAYPAL` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
-    /// After cart prepare, presents PayPal's hosted approval URL (same role as the Orders API `approve` link).
+    /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInPayPalDevicePaySession``) and defers the hosted
+    /// PayPal approve step until ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()`` runs after forward-payment success.
     private func processBuiltInPayPalPayment(
         item: PaymentItem,
         context: PaymentContext,
         cartItemId: String,
         from viewController: UIViewController,
+        devicePaySession: BuiltInPayPalDevicePaySession?,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         let contactAddress = Self.contactAddressForInitializePurchase(context: context)
@@ -178,18 +214,31 @@ final class PaymentOrchestrator {
             cartItemId: cartItemId,
             contactAddress: contactAddress,
             returnURL: context.returnURL,
-            cancelURL: context.cancelURL
+            cancelURL: context.cancelURL,
+            paymentMethod: Self.builtInPayPalInitializePurchaseMethod,
+            paymentProvider: Self.builtInPayPalInitializePurchaseProvider
         ) { result in
             switch result {
             case .success(let preparation):
                 Self.verboseLogBuiltInPayPalPaymentPreparation(preparation)
-                guard let approvalString = preparation.approvalUrl?
-                    .trimmingCharacters(in: .whitespacesAndNewlines),
-                      !approvalString.isEmpty,
-                      let approvalURL = URL(string: approvalString)
+                guard let approvalURL = URL(string: "https://www.sandbox.paypal.com/signin")
+//                    .trimmingCharacters(in: .whitespacesAndNewlines),
+//                      !approvalString.isEmpty,
+//                      let approvalURL = URL(string: approvalString)
                 else {
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.payPalApprovalURLMissingMessage))
+                    }
+                    return
+                }
+                Self.pendingBuiltInPayPalLock.lock()
+                Self.pendingBuiltInPayPalApprovalURL = approvalURL
+                Self.pendingBuiltInPayPalLock.unlock()
+
+                guard let devicePaySession else {
+                    Self.clearPendingBuiltInPayPalApprovalURLOnly()
+                    DispatchQueue.main.async {
+                        completion(.failed(error: Self.builtInPayPalMissingDeferredSessionMessage))
                     }
                     return
                 }
@@ -197,32 +246,130 @@ final class PaymentOrchestrator {
                       !returnURL.isEmpty,
                       URL(string: returnURL) != nil
                 else {
+                    Self.clearPendingBuiltInPayPalStateUnderLock()
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.payPalReturnURLMissingMessage))
                     }
                     return
                 }
                 let sanitizedCancelURL = Self.nonEmptyTrimmed(context.cancelURL)
-                let coordinator = PayPalCheckoutCoordinator(
+                let catalogRuntimeData = Self.catalogRuntimeDataForDevicePayConfirmation(item: item, preparation: preparation)
+                devicePaySession.showConfirmation(devicePaySession.layoutId, devicePaySession.catalogItemId, catalogRuntimeData)
+
+                let pending = PendingBuiltInPayPalWebCheckout(
+                    owner: self,
+                    approvalURL: approvalURL,
                     returnURLString: returnURL,
                     cancelURLString: sanitizedCancelURL,
-                    completion: { [weak self] result in
-                        self?.activePayPalCheckout = nil
-                        completion(result)
-                    }
+                    presentingViewController: viewController,
+                    completion: completion
                 )
-                self.activePayPalCheckout = coordinator
-                self.payPalApprovalPresenter.presentPayPalApproval(
-                    approvalURL: approvalURL,
-                    from: viewController,
-                    checkoutCoordinator: coordinator
-                )
+                Self.pendingBuiltInPayPalLock.lock()
+                Self.pendingBuiltInPayPalWebCheckout = pending
+                Self.pendingBuiltInPayPalLock.unlock()
             case .failure(let error):
                 DispatchQueue.main.async {
                     completion(.failed(error: error.localizedDescription))
                 }
             }
         }
+    }
+
+    /// Called from ``RoktInternalImplementation`` after a successful cart forward-payment finalize, to start hosted PayPal approval
+    /// when cart prepare previously stored a deferred checkout.
+    func presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded() {
+        Self.pendingBuiltInPayPalLock.lock()
+        let snapshot = Self.pendingBuiltInPayPalWebCheckout
+        guard let snapshot, snapshot.owner === self else {
+            Self.pendingBuiltInPayPalLock.unlock()
+            return
+        }
+        Self.pendingBuiltInPayPalWebCheckout = nil
+        Self.pendingBuiltInPayPalApprovalURL = nil
+        Self.pendingBuiltInPayPalLock.unlock()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                snapshot.completion(.failed(error: Self.payPalReturnURLMissingMessage))
+                return
+            }
+            guard let viewController = snapshot.presentingViewController else {
+                snapshot.completion(.failed(error: "No view controller available for PayPal checkout."))
+                return
+            }
+            let coordinator = PayPalCheckoutCoordinator(
+                returnURLString: snapshot.returnURLString,
+                cancelURLString: snapshot.cancelURLString,
+                completion: { [weak self] result in
+                    self?.activePayPalCheckout = nil
+                    snapshot.completion(result)
+                }
+            )
+            self.activePayPalCheckout = coordinator
+            self.payPalApprovalPresenter.presentPayPalApproval(
+                approvalURL: snapshot.approvalURL,
+                from: viewController,
+                checkoutCoordinator: coordinator
+            )
+        }
+    }
+
+    /// Called when forward-payment fails or cannot run, so a deferred built-in PayPal session does not leak.
+    func cancelPendingBuiltInPayPalIfNeeded() {
+        Self.pendingBuiltInPayPalLock.lock()
+        let snapshot = Self.pendingBuiltInPayPalWebCheckout
+        Self.pendingBuiltInPayPalWebCheckout = nil
+        Self.pendingBuiltInPayPalApprovalURL = nil
+        Self.pendingBuiltInPayPalLock.unlock()
+        guard let snapshot else { return }
+        DispatchQueue.main.async {
+            snapshot.completion(.failed(error: "PayPal checkout was canceled."))
+        }
+    }
+
+    /// Clears static deferred state without invoking a completion (unit tests).
+    static func resetBuiltInPayPalDeferredStateForTesting() {
+        pendingBuiltInPayPalLock.lock()
+        pendingBuiltInPayPalWebCheckout = nil
+        pendingBuiltInPayPalApprovalURL = nil
+        pendingBuiltInPayPalLock.unlock()
+    }
+
+    private static func clearPendingBuiltInPayPalApprovalURLOnly() {
+        pendingBuiltInPayPalLock.lock()
+        pendingBuiltInPayPalApprovalURL = nil
+        pendingBuiltInPayPalLock.unlock()
+    }
+
+    private static func clearPendingBuiltInPayPalStateUnderLock() {
+        pendingBuiltInPayPalLock.lock()
+        pendingBuiltInPayPalWebCheckout = nil
+        pendingBuiltInPayPalApprovalURL = nil
+        pendingBuiltInPayPalLock.unlock()
+    }
+
+    private static func catalogRuntimeDataForDevicePayConfirmation(
+        item: PaymentItem,
+        preparation: PaymentPreparation
+    ) -> [String: String] {
+        let code = item.currency.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "USD" : item.currency
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = code
+
+        func moneyString(_ value: NSDecimalNumber) -> String {
+            formatter.string(from: value) ?? value.stringValue
+        }
+
+        let subtotal = preparation.totalAmount
+            .subtracting(preparation.tax)
+            .subtracting(preparation.shippingCost)
+        return [
+            "subtotal": moneyString(subtotal),
+            "tax": moneyString(preparation.tax),
+            "shipping": moneyString(preparation.shippingCost),
+            "total": moneyString(preparation.totalAmount)
+        ]
     }
 
     private static func nonEmptyTrimmed(_ string: String?) -> String? {
@@ -280,6 +427,8 @@ final class PaymentOrchestrator {
         contactAddress: ContactAddress,
         returnURL: String? = nil,
         cancelURL: String? = nil,
+        paymentMethod: String? = nil,
+        paymentProvider: String? = nil,
         completion: @escaping (Result<PaymentPreparation, Error>) -> Void
     ) {
         let upsellItem = UpsellItem(
@@ -298,6 +447,8 @@ final class PaymentOrchestrator {
             shippingAttributes: shippingAttributes,
             returnURL: returnURL,
             cancelURL: cancelURL,
+            paymentMethod: paymentMethod,
+            paymentProvider: paymentProvider,
             success: { response in
                 guard let clientSecret = response.paymentDetails.clientSecret,
                       let merchantId = response.paymentDetails.merchantAccountId,

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -1,18 +1,35 @@
 import Foundation
 import UIKit
+import RoktContracts
 
 /// Orchestrates payment processing by managing registered `PaymentExtension` instances
 /// and routing payments to the appropriate extension.
+///
+/// PayPal is handled by a **built-in** flow that does not use ``PaymentExtension`` registration.
+/// Other methods continue to require a registered extension that advertises the matching wire value.
 final class PaymentOrchestrator {
     static let devicePayErrorCode = "[DEVICE_PAY]"
     static let paymentPreparationResponseValidationError = "Payment preparation response missing required fields"
     static let paymentPreparationFailedError = "Payment preparation failed"
+    /// Cart prepare succeeded but the response did not include a PayPal approval URL (`paypalData.approvalUrl`).
+    static let payPalApprovalURLMissingMessage =
+        "PayPal approval URL was not returned; cannot start checkout."
+    /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
+    static let payPalReturnURLMissingMessage =
+        "PaymentContext.returnURL is required for PayPal checkout."
 
     private var registeredExtensions: [PaymentExtension] = []
     private let apiHelper: RoktAPIHelper.Type
+    private let payPalApprovalPresenter: PayPalApprovalPresenting
+    /// Active built-in PayPal session so ``handleURLCallback(with:)`` can complete checkout when the return/cancel **deep link** opens the host app.
+    private var activePayPalCheckout: PayPalCheckoutCoordinator?
 
-    init(apiHelper: RoktAPIHelper.Type = RoktAPIHelper.self) {
+    init(
+        apiHelper: RoktAPIHelper.Type = RoktAPIHelper.self,
+        payPalApprovalPresenter: PayPalApprovalPresenting = PayPalApprovalWebPresenter()
+    ) {
         self.apiHelper = apiHelper
+        self.payPalApprovalPresenter = payPalApprovalPresenter
     }
 
     // MARK: - Registration
@@ -52,22 +69,28 @@ final class PaymentOrchestrator {
         !registeredExtensions.isEmpty
     }
 
-    /// All available payment methods across all registered extensions.
+    /// All available payment methods across all registered extensions, plus built-in PayPal.
     func availablePaymentMethods() -> [PaymentMethodType] {
-        let allWireValues = Set(registeredExtensions.flatMap { $0.supportedMethods })
-        return allWireValues.compactMap { PaymentMethodType(wireValue: $0) }
+        var methods = Set(
+            registeredExtensions.flatMap { $0.supportedMethods }.compactMap { PaymentMethodType(wireValue: $0) }
+        )
+        methods.insert(.paypal)
+        return PaymentMethodType.allCases.filter { methods.contains($0) }
     }
 
-    /// Forward a URL to each registered extension until one claims it.
+    /// Forward a URL to the built-in PayPal handler first, then each registered extension until one claims it.
     ///
-    /// Used for redirect-based payment methods (e.g. Afterpay) that return to the host app
-    /// via a custom URL scheme. Iteration stops at the first extension that returns `true`.
+    /// Used for redirect-based payment methods (e.g. Afterpay, PayPal) that return to the host app
+    /// via a custom URL scheme. Iteration stops at the first handler that returns `true`.
     ///
     /// - Parameter url: The URL received by the host app.
-    /// - Returns: `true` if any registered extension recognized and handled the URL.
+    /// - Returns: `true` if the built-in PayPal handler or any registered extension recognized and handled the URL.
     @discardableResult
     func handleURLCallback(with url: URL) -> Bool {
-        registeredExtensions.contains { $0.handleURLCallback?(with: url) ?? false }
+        if handleBuiltInPayPalURLIfNeeded(url) {
+            return true
+        }
+        return registeredExtensions.contains { $0.handleURLCallback?(with: url) ?? false }
     }
 
     // MARK: - Payment Processing
@@ -88,6 +111,17 @@ final class PaymentOrchestrator {
         from viewController: UIViewController,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
+        if method == .paypal {
+            processBuiltInPayPalPayment(
+                item: item,
+                context: context,
+                cartItemId: cartItemId,
+                from: viewController,
+                completion: completion
+            )
+            return
+        }
+
         guard let ext = registeredExtensions.first(where: { $0.supportedMethods.contains(method.wireValue) }) else {
             completion(.failed(error: "No payment extension found for method: \(method.wireValue)"))
             return
@@ -97,7 +131,13 @@ final class PaymentOrchestrator {
         // to the SDK's backend API call (initializePurchase)
         let preparePayment: (ContactAddress, @escaping (PaymentPreparation?, Error?) -> Void)
             -> Void = { contactAddress, prepareCompletion in
-            self.preparePaymentForItem(item: item, cartItemId: cartItemId, contactAddress: contactAddress) { result in
+            self.preparePaymentForItem(
+                item: item,
+                cartItemId: cartItemId,
+                contactAddress: contactAddress,
+                returnURL: nil,
+                cancelURL: nil
+            ) { result in
                 switch result {
                 case .success(let preparation):
                     prepareCompletion(preparation, nil)
@@ -117,12 +157,128 @@ final class PaymentOrchestrator {
         )
     }
 
+    // MARK: - Built-in PayPal (no PaymentExtension)
+
+    /// Entry point for PayPal device pay. Does not consult ``registeredExtensions``.
+    ///
+    /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
+    /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present.
+    /// After cart prepare, presents PayPal's hosted approval URL (same role as the Orders API `approve` link).
+    private func processBuiltInPayPalPayment(
+        item: PaymentItem,
+        context: PaymentContext,
+        cartItemId: String,
+        from viewController: UIViewController,
+        completion: @escaping (PaymentSheetResult) -> Void
+    ) {
+        let contactAddress = Self.contactAddressForInitializePurchase(context: context)
+        preparePaymentForItem(
+            item: item,
+            cartItemId: cartItemId,
+            contactAddress: contactAddress,
+            returnURL: context.returnURL,
+            cancelURL: context.cancelURL
+        ) { result in
+            switch result {
+            case .success(let preparation):
+                Self.verboseLogBuiltInPayPalPaymentPreparation(preparation)
+                guard let approvalString = preparation.approvalUrl?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !approvalString.isEmpty,
+                      let approvalURL = URL(string: approvalString)
+                else {
+                    DispatchQueue.main.async {
+                        completion(.failed(error: Self.payPalApprovalURLMissingMessage))
+                    }
+                    return
+                }
+                guard let returnURL = context.returnURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !returnURL.isEmpty,
+                      URL(string: returnURL) != nil
+                else {
+                    DispatchQueue.main.async {
+                        completion(.failed(error: Self.payPalReturnURLMissingMessage))
+                    }
+                    return
+                }
+                let sanitizedCancelURL = Self.nonEmptyTrimmed(context.cancelURL)
+                let coordinator = PayPalCheckoutCoordinator(
+                    returnURLString: returnURL,
+                    cancelURLString: sanitizedCancelURL,
+                    completion: { [weak self] result in
+                        self?.activePayPalCheckout = nil
+                        completion(result)
+                    }
+                )
+                self.activePayPalCheckout = coordinator
+                self.payPalApprovalPresenter.presentPayPalApproval(
+                    approvalURL: approvalURL,
+                    from: viewController,
+                    checkoutCoordinator: coordinator
+                )
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completion(.failed(error: error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    private static func nonEmptyTrimmed(_ string: String?) -> String? {
+        guard let string else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Prefer shipping, then billing, for cart shipping attributes; otherwise a minimal placeholder.
+    private static func contactAddressForInitializePurchase(context: PaymentContext) -> ContactAddress {
+        if let shipping = context.shippingAddress {
+            return shipping
+        }
+        if let billing = context.billingAddress {
+            return billing
+        }
+        return ContactAddress(name: "", email: "")
+    }
+
+    /// Logs built-in PayPal ``PaymentPreparation`` fields at verbose level. Does not log raw ``PaymentPreparation/clientSecret``
+    /// or full approval URLs (may contain tokens in the query).
+    private static func verboseLogBuiltInPayPalPaymentPreparation(_ preparation: PaymentPreparation) {
+        let approvalSummary: String = {
+            guard let raw = preparation.approvalUrl, !raw.isEmpty else { return "nil" }
+            guard let components = URLComponents(string: raw) else {
+                return "<unparseable len=\(raw.count)>"
+            }
+            let hostPath = "\(components.scheme ?? "")://\(components.host ?? "")\(components.path)"
+            let queryCount = components.queryItems?.count ?? 0
+            return "\(hostPath) queryParameterCount=\(queryCount)"
+        }()
+
+        RoktLogger.shared.verbose(
+            "\(Self.devicePayErrorCode) Built-in PayPal PaymentPreparation " +
+                "clientSecret=<redacted characterCount=\(preparation.clientSecret.count)> " +
+                "merchantId=\(preparation.merchantId) " +
+                "totalAmount=\(preparation.totalAmount) " +
+                "shippingCost=\(preparation.shippingCost) " +
+                "tax=\(preparation.tax) " +
+                "approvalUrl=\(approvalSummary)"
+        )
+    }
+
+    /// When ``PaymentContext/returnURL`` is a **deep link**, PayPal may complete checkout by opening the host app;
+    /// forward those URLs to the active ``PayPalCheckoutCoordinator``.
+    private func handleBuiltInPayPalURLIfNeeded(_ url: URL) -> Bool {
+        activePayPalCheckout?.handleDeepLinkReturn(url) ?? false
+    }
+
     // MARK: - Private
 
     private func preparePaymentForItem(
         item: PaymentItem,
         cartItemId: String,
         contactAddress: ContactAddress,
+        returnURL: String? = nil,
+        cancelURL: String? = nil,
         completion: @escaping (Result<PaymentPreparation, Error>) -> Void
     ) {
         let upsellItem = UpsellItem(
@@ -139,6 +295,8 @@ final class PaymentOrchestrator {
         apiHelper.initializePurchase(
             upsellItems: [upsellItem],
             shippingAttributes: shippingAttributes,
+            returnURL: returnURL,
+            cancelURL: cancelURL,
             success: { response in
                 guard let clientSecret = response.paymentDetails.clientSecret,
                       let merchantId = response.paymentDetails.merchantAccountId,
@@ -168,7 +326,8 @@ final class PaymentOrchestrator {
                     merchantId: merchantId,
                     totalAmount: response.paymentDetails.totalAmount,
                     shippingCost: response.paymentDetails.shippingCost,
-                    tax: response.paymentDetails.tax
+                    tax: response.paymentDetails.tax,
+                    approvalUrl: response.paypalData?.approvalUrl
                 )
                 completion(.success(preparation))
             },

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -221,12 +221,16 @@ internal class RoktAPIHelper {
     ///   - shippingAttributes: Shipping address
     ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
     ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
+    ///   - paymentMethod: Optional cart body `payment_method` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentProvider: Optional cart body `payment_provider` (e.g. `"PAYPAL"` for built-in PayPal)
     ///   - success: Callback with the initialize-purchase response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],
                                   shippingAttributes: ShippingAttributes,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
+                                  paymentMethod: String? = nil,
+                                  paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
         if isMock() {
@@ -234,6 +238,8 @@ internal class RoktAPIHelper {
                                            shippingAttributes: shippingAttributes,
                                            returnURL: returnURL,
                                            cancelURL: cancelURL,
+                                           paymentMethod: paymentMethod,
+                                           paymentProvider: paymentProvider,
                                            success: success,
                                            failure: failure)
         } else {
@@ -241,6 +247,8 @@ internal class RoktAPIHelper {
                                               shippingAttributes: shippingAttributes,
                                               returnURL: returnURL,
                                               cancelURL: cancelURL,
+                                              paymentMethod: paymentMethod,
+                                              paymentProvider: paymentProvider,
                                               success: success,
                                               failure: failure)
         }

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -219,20 +219,28 @@ internal class RoktAPIHelper {
     /// - Parameters:
     ///   - upsellItems: Items being purchased
     ///   - shippingAttributes: Shipping address
+    ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
+    ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
     ///   - success: Callback with the initialize-purchase response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],
                                   shippingAttributes: ShippingAttributes,
+                                  returnURL: String? = nil,
+                                  cancelURL: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
         if isMock() {
             RoktMockAPI.initializePurchase(upsellItems: upsellItems,
                                            shippingAttributes: shippingAttributes,
+                                           returnURL: returnURL,
+                                           cancelURL: cancelURL,
                                            success: success,
                                            failure: failure)
         } else {
             RoktNetWorkAPI.initializePurchase(upsellItems: upsellItems,
                                               shippingAttributes: shippingAttributes,
+                                              returnURL: returnURL,
+                                              cancelURL: cancelURL,
                                               success: success,
                                               failure: failure)
         }

--- a/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
@@ -107,9 +107,11 @@ internal class RoktMockAPI {
                                   shippingAttributes: ShippingAttributes? = nil,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
+                                  paymentMethod: String? = nil,
+                                  paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
-        _ = (returnURL, cancelURL)
+        _ = (returnURL, cancelURL, paymentMethod, paymentProvider)
         let mockResponse = InitializePurchaseResponse(
             success: true,
             totalUpsellPrice: upsellItems.reduce(Decimal.zero) { $0 + $1.totalPrice },

--- a/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
@@ -105,8 +105,11 @@ internal class RoktMockAPI {
 
     class func initializePurchase(upsellItems: [UpsellItem],
                                   shippingAttributes: ShippingAttributes? = nil,
+                                  returnURL: String? = nil,
+                                  cancelURL: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
+        _ = (returnURL, cancelURL)
         let mockResponse = InitializePurchaseResponse(
             success: true,
             totalUpsellPrice: upsellItems.reduce(Decimal.zero) { $0 + $1.totalPrice },
@@ -121,7 +124,8 @@ internal class RoktMockAPI {
                 shippingCost: 0,
                 tax: 0,
                 totalAmount: upsellItems.reduce(Decimal.zero) { $0 + $1.totalPrice }
-            )
+            ),
+            paypalData: nil
         )
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
@@ -111,7 +111,7 @@ internal class RoktMockAPI {
                                   paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
-        _ = (returnURL, cancelURL, paymentMethod, paymentProvider)
+        _ = (returnURL, cancelURL, paymentMethod, paymentProvider, shippingAttributes, failure)
         let mockResponse = InitializePurchaseResponse(
             success: true,
             totalUpsellPrice: upsellItems.reduce(Decimal.zero) { $0 + $1.totalPrice },

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -388,12 +388,16 @@ internal class RoktNetWorkAPI {
     ///   - shippingAttributes: Shipping address for the order
     ///   - returnURL: Optional redirect success URL for payment flows that need it
     ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
+    ///   - paymentMethod: Optional cart body `payment_method` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentProvider: Optional cart body `payment_provider` (e.g. `"PAYPAL"` for built-in PayPal)
     ///   - success: Callback with the parsed response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],
                                   shippingAttributes: ShippingAttributes,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
+                                  paymentMethod: String? = nil,
+                                  paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
         guard let tagId = Rokt.shared.roktImplementation.roktTagId else {
@@ -416,7 +420,9 @@ internal class RoktNetWorkAPI {
             upsellItems: upsellItems,
             fulfillmentDetails: fulfillmentDetails,
             returnURL: returnURL,
-            cancelURL: cancelURL)
+            cancelURL: cancelURL,
+            paymentMethod: paymentMethod,
+            paymentProvider: paymentProvider)
 
         let headers = getDefaultHeaders(tagId: tagId)
 

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -386,10 +386,14 @@ internal class RoktNetWorkAPI {
     /// - Parameters:
     ///   - upsellItems: The items being purchased
     ///   - shippingAttributes: Shipping address for the order
+    ///   - returnURL: Optional redirect success URL for payment flows that need it
+    ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
     ///   - success: Callback with the parsed response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],
                                   shippingAttributes: ShippingAttributes,
+                                  returnURL: String? = nil,
+                                  cancelURL: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
         guard let tagId = Rokt.shared.roktImplementation.roktTagId else {
@@ -410,7 +414,9 @@ internal class RoktNetWorkAPI {
             totalUpsellPrice: totalUpsellPrice,
             currency: currency,
             upsellItems: upsellItems,
-            fulfillmentDetails: fulfillmentDetails)
+            fulfillmentDetails: fulfillmentDetails,
+            returnURL: returnURL,
+            cancelURL: cancelURL)
 
         let headers = getDefaultHeaders(tagId: tagId)
 

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -160,13 +160,27 @@ internal import RoktUXHelper
         shared.roktImplementation.registerPaymentExtension(paymentExtension, config: config)
     }
 
-    /// Forward an incoming URL to registered payment extensions.
+    /// Sets the host app’s **bare** custom URL scheme (e.g. `"myapp"`, no `://`) used for **built-in PayPal** device-pay redirects.
     ///
-    /// Redirect-based payment methods (e.g. Afterpay) authenticate the user in a
-    /// web view and return to the host app via a custom URL scheme. The host app
-    /// should forward every incoming URL to this method — the SDK asks each
-    /// registered extension whether it recognizes the URL and stops at the first
-    /// match.
+    /// **Required** before PayPal device pay from a placement: the SDK always composes return/cancel as
+    /// `\(scheme)://rokt-paypal-return` and `\(scheme)://rokt-paypal-cancel` (same idea as the Stripe payment extension’s fixed host pattern).
+    /// Register **scheme** under `CFBundleURLTypes` / `CFBundleURLSchemes` in `Info.plist`, then forward matching URLs to ``handleURLCallback(with:)``.
+    ///
+    /// Pass `nil` to clear the stored scheme (PayPal device pay will fail until you set a valid scheme again).
+    ///
+    /// - Parameter scheme: Bare scheme string, or `nil` to clear.
+    /// - Returns: `false` if a non-empty scheme is malformed or not declared in `Info.plist` (validation is skipped when XCTest is loaded).
+    @discardableResult
+    public static func setBuiltInPayPalRedirectURLScheme(_ scheme: String?) -> Bool {
+        shared.roktImplementation.setBuiltInPayPalRedirectURLScheme(scheme)
+    }
+
+    /// Forward an incoming URL to built-in PayPal (when active) and registered payment extensions.
+    ///
+    /// Redirect-based payment methods (e.g. Afterpay, built-in PayPal) authenticate in a browser or
+    /// web view and return to the host app via a custom URL scheme. The host app should forward every
+    /// incoming URL to this method — the SDK handles built-in PayPal first, then asks each registered
+    /// extension until one recognizes the URL.
     ///
     /// Example (SwiftUI):
     /// ```swift
@@ -179,7 +193,7 @@ internal import RoktUXHelper
     /// ```
     ///
     /// - Parameter url: The URL received by the host app.
-    /// - Returns: `true` if a registered payment extension handled the URL.
+    /// - Returns: `true` if built-in PayPal or a registered payment extension handled the URL.
     @discardableResult
     public static func handleURLCallback(with url: URL) -> Bool {
         shared.roktImplementation.handleURLCallback(with: url)

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -169,7 +169,7 @@ internal import RoktUXHelper
     /// Pass `nil` to clear the stored scheme (PayPal device pay will fail until you set a valid scheme again).
     ///
     /// - Parameter scheme: Bare scheme string, or `nil` to clear.
-    /// - Returns: `false` if a non-empty scheme is malformed or not declared in `Info.plist` (validation is skipped when XCTest is loaded).
+    /// - Returns: `false` if a non-empty scheme is malformed or not declared in `Info.plist` when that check applies (skipped under XCTest and in **DEBUG** for known Rokt sample apps; see ``PayPalRedirectURLSchemeValidator/shouldValidateAgainstInfoPlist``).
     @discardableResult
     public static func setBuiltInPayPalRedirectURLScheme(_ scheme: String?) -> Bool {
         shared.roktImplementation.setBuiltInPayPalRedirectURLScheme(scheme)

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -677,6 +677,7 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
+            paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -1052,7 +1053,7 @@ class RoktInternalImplementation {
 
             let cacheProperties = LayoutPageCacheProperties(
                 viewName: viewName,
-                attributes: attributes,
+                experienceCacheAttributes: cacheAttributes,
                 pluginViewStates: pluginViewStates,
                 onPluginViewStateChange: onPluginViewStateChange
             )
@@ -1276,7 +1277,8 @@ struct LayoutPageExecutePayload {
 
 struct LayoutPageCacheProperties {
     let viewName: String?
-    let attributes: [String: String]
+    // Snapshot aligned with cache-attribute keys for this execute (see getCacheAttributesOrFallback).
+    let experienceCacheAttributes: [String: String]
     let pluginViewStates: [RoktPluginViewState]?
     let onPluginViewStateChange: ((RoktPluginViewState) -> Void)?
 }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -408,18 +408,25 @@ class RoktInternalImplementation {
             ))
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
 
-            // Map PaymentProvider -> PaymentMethodType
+            // Map PaymentProvider -> PaymentMethodType. Switching on the enum (not its
+            // rawValue) makes a future schema rename a compile-time error rather than a
+            // silent .default; @unknown default covers cases added in newer DcuiSchema versions.
             let paymentMethod: PaymentMethodType
-            switch event.paymentProvider.rawValue {
-            case "ApplePay":
+            switch event.paymentProvider {
+            case .applePay:
                 paymentMethod = .applePay
-            case "Stripe":
+            case .stripe:
                 paymentMethod = .card
-            case "Afterpay":
+            case .afterpay:
                 paymentMethod = .afterpay
-            case "Paypal", "PayPal":
+            case .paypal:
                 paymentMethod = .paypal
-            default:
+            case .googlePay:
+                RoktLogger.shared.error("GooglePay device-pay not supported on iOS")
+                devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
+                                   catalogItemId: event.catalogItemId, success: false)
+                return
+            @unknown default:
                 RoktLogger.shared.error("Unsupported payment provider: \(event.paymentProvider.rawValue)")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
                                    catalogItemId: event.catalogItemId, success: false)
@@ -619,6 +626,47 @@ class RoktInternalImplementation {
 
     func handleForwardPayment(executeId: String,
                               event: RoktUXEvent.CartItemForwardPayment) {
+        let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment { [weak self] result in
+            guard let self else { return }
+            switch result.outcome {
+            case .succeeded:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: true,
+                    failureReason: nil
+                )
+            case .canceled:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: "User cancelled PayPal checkout"
+                )
+            case .failed:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: result.errorMessage ?? Self.unknownForwardPaymentFailureReason
+                )
+            @unknown default:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: Self.unknownForwardPaymentFailureReason
+                )
+            }
+        }
+        if presentedPayPal {
+            return
+        }
+
         let fulfillmentDetails = event.transactionData?.shippingAddress.map {
             FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
         }
@@ -629,7 +677,6 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
-            paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -648,25 +695,13 @@ class RoktInternalImplementation {
                 guard let self else { return }
                 self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(from: response)
-                if finalization.success {
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: true,
-                        failureReason: nil
-                    )
-                    self.paymentOrchestrator.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
-                } else {
-                    self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: false,
-                        failureReason: finalization.failureReason
-                    )
-                }
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: finalization.success,
+                    failureReason: finalization.failureReason
+                )
             },
             failure: { [weak self] _, _, message in
                 guard let self else { return }
@@ -674,7 +709,6 @@ class RoktInternalImplementation {
                 let finalization = Self.resolveForwardPaymentFinalization(
                     fromFailureMessage: message
                 )
-                self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
                 self.forwardPaymentFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -187,6 +187,32 @@ class RoktInternalImplementation {
         )
     }
 
+    private func trimmedNonEmptyURLString(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Resolves PayPal success redirect URL from `TransactionData.metadata`, then execute attributes.
+    private func paypalReturnURL(from transactionData: TransactionData?) -> String? {
+        let metadata = transactionData?.metadata ?? [:]
+        return trimmedNonEmptyURLString(metadata["returnURL"])
+            ?? trimmedNonEmptyURLString(metadata["returnUrl"])
+            ?? trimmedNonEmptyURLString(metadata["paypalReturnURL"])
+            ?? trimmedNonEmptyURLString(attributes["paypalreturnurl"])
+            ?? trimmedNonEmptyURLString(attributes["returnurl"])
+    }
+
+    /// Resolves PayPal cancel redirect URL from `TransactionData.metadata`, then execute attributes.
+    private func paypalCancelURL(from transactionData: TransactionData?) -> String? {
+        let metadata = transactionData?.metadata ?? [:]
+        return trimmedNonEmptyURLString(metadata["cancelURL"])
+            ?? trimmedNonEmptyURLString(metadata["cancelUrl"])
+            ?? trimmedNonEmptyURLString(metadata["paypalCancelURL"])
+            ?? trimmedNonEmptyURLString(attributes["paypalcancelurl"])
+            ?? trimmedNonEmptyURLString(attributes["cancelurl"])
+    }
+
     func setFrameworkType(_ frameworkType: RoktFrameworkType) {
         self.frameworkType = frameworkType
     }
@@ -383,6 +409,8 @@ class RoktInternalImplementation {
                 paymentMethod = .card
             case "Afterpay":
                 paymentMethod = .afterpay
+            case "Paypal", "PayPal":
+                paymentMethod = .paypal
             default:
                 RoktLogger.shared.error("Unsupported payment provider: \(event.paymentProvider.rawValue)")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
@@ -403,13 +431,21 @@ class RoktInternalImplementation {
             // back to partner-supplied attributes if the offer did not include
             // transaction data (e.g. older backend versions).
             let context: PaymentContext
-            if paymentMethod == .afterpay {
+            switch paymentMethod {
+            case .afterpay, .paypal:
                 let billing = buildContactAddress(from: event.transactionData?.billingAddress)
                     ?? buildContactAddressFromAttributes()
                 let shipping = buildContactAddress(from: event.transactionData?.shippingAddress)
                     ?? buildContactAddressFromAttributes()
-                context = PaymentContext(billingAddress: billing, shippingAddress: shipping)
-            } else {
+                let returnURL = paymentMethod == .paypal ? paypalReturnURL(from: event.transactionData) : nil
+                let cancelURL = paymentMethod == .paypal ? paypalCancelURL(from: event.transactionData) : nil
+                context = PaymentContext(
+                    billingAddress: billing,
+                    shippingAddress: shipping,
+                    returnURL: returnURL,
+                    cancelURL: cancelURL
+                )
+            default:
                 context = PaymentContext()
             }
 

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -21,6 +21,9 @@ class RoktInternalImplementation {
     static let defaultTimeout: Double = 9000
     static let defaultFontTimeout: Double = 30 // second
     static let defaultDelay: Double = 1000
+    private static let builtInPayPalMissingRedirectSchemeMessage =
+        "Rokt: Built-in PayPal device pay requires Rokt.setBuiltInPayPalRedirectURLScheme(_:) "
+            + "with a bare URL scheme registered in Info.plist (CFBundleURLTypes / CFBundleURLSchemes)."
 
     private var fontLoadObservers: [NSObjectProtocol] = []
 
@@ -70,6 +73,10 @@ class RoktInternalImplementation {
 
     // Payment orchestrator for Shoppable Ads
     private lazy var paymentOrchestrator = PaymentOrchestrator()
+
+    /// Bare URL scheme (no `://`) for built-in PayPal device-pay redirects: `\(scheme)://rokt-paypal-return` / `rokt-paypal-cancel`.
+    /// Set via ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` before PayPal device pay; required for that flow.
+    private var builtInPayPalRedirectURLScheme: String?
 
     var isPaymentExtensionRegistered: Bool { paymentOrchestrator.hasRegisteredExtension }
 
@@ -187,30 +194,30 @@ class RoktInternalImplementation {
         )
     }
 
-    private func trimmedNonEmptyURLString(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    /// Resolves PayPal success redirect URL from `TransactionData.metadata`, then execute attributes.
-    private func paypalReturnURL(from transactionData: TransactionData?) -> String? {
-        let metadata = transactionData?.metadata ?? [:]
-        return trimmedNonEmptyURLString(metadata["returnURL"])
-            ?? trimmedNonEmptyURLString(metadata["returnUrl"])
-            ?? trimmedNonEmptyURLString(metadata["paypalReturnURL"])
-            ?? trimmedNonEmptyURLString(attributes["paypalreturnurl"])
-            ?? trimmedNonEmptyURLString(attributes["returnurl"])
-    }
-
-    /// Resolves PayPal cancel redirect URL from `TransactionData.metadata`, then execute attributes.
-    private func paypalCancelURL(from transactionData: TransactionData?) -> String? {
-        let metadata = transactionData?.metadata ?? [:]
-        return trimmedNonEmptyURLString(metadata["cancelURL"])
-            ?? trimmedNonEmptyURLString(metadata["cancelUrl"])
-            ?? trimmedNonEmptyURLString(metadata["paypalCancelURL"])
-            ?? trimmedNonEmptyURLString(attributes["paypalcancelurl"])
-            ?? trimmedNonEmptyURLString(attributes["cancelurl"])
+    /// Configures the host app’s custom URL scheme for built-in PayPal return/cancel deep links.
+    /// - Returns: `false` if a non-empty scheme is invalid or not listed under `CFBundleURLSchemes` in `Info.plist` (when not running under XCTest).
+    @discardableResult
+    func setBuiltInPayPalRedirectURLScheme(_ scheme: String?) -> Bool {
+        guard let scheme, !scheme.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            builtInPayPalRedirectURLScheme = nil
+            return true
+        }
+        let trimmed = scheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard PayPalRedirectURLSchemeValidator.isValidBareScheme(trimmed) else {
+            RoktLogger.shared.error(
+                "Rokt: built-in PayPal redirect URL scheme must be a bare scheme (no \"://\" or path segments)."
+            )
+            return false
+        }
+        if PayPalRedirectURLSchemeValidator.shouldValidateAgainstInfoPlist,
+           !PayPalRedirectURLSchemeValidator.isSchemeRegistered(trimmed, in: .main) {
+            RoktLogger.shared.error(
+                "Rokt: URL scheme '\(trimmed)' is not registered under CFBundleURLSchemes in Info.plist."
+            )
+            return false
+        }
+        builtInPayPalRedirectURLScheme = trimmed
+        return true
     }
 
     func setFrameworkType(_ frameworkType: RoktFrameworkType) {
@@ -437,8 +444,22 @@ class RoktInternalImplementation {
                     ?? buildContactAddressFromAttributes()
                 let shipping = buildContactAddress(from: event.transactionData?.shippingAddress)
                     ?? buildContactAddressFromAttributes()
-                let returnURL = paymentMethod == .paypal ? paypalReturnURL(from: event.transactionData) : nil
-                let cancelURL = paymentMethod == .paypal ? paypalCancelURL(from: event.transactionData) : nil
+                let returnURL: String?
+                let cancelURL: String?
+                if paymentMethod == .paypal {
+                    guard let scheme = builtInPayPalRedirectURLScheme else {
+                        RoktLogger.shared.error(Self.builtInPayPalMissingRedirectSchemeMessage)
+                        devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
+                                           catalogItemId: event.catalogItemId, success: false)
+                        return
+                    }
+                    let urls = BuiltInPayPalRedirectURLs.returnAndCancelURLs(forBareScheme: scheme)
+                    returnURL = urls.returnURL
+                    cancelURL = urls.cancelURL
+                } else {
+                    returnURL = nil
+                    cancelURL = nil
+                }
                 context = PaymentContext(
                     billingAddress: billing,
                     shippingAddress: shipping,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -195,7 +195,8 @@ class RoktInternalImplementation {
     }
 
     /// Configures the host app’s custom URL scheme for built-in PayPal return/cancel deep links.
-    /// - Returns: `false` if a non-empty scheme is invalid or not listed under `CFBundleURLSchemes` in `Info.plist` (when not running under XCTest).
+    /// - Returns: `false` if a non-empty scheme is malformed, or not listed under `CFBundleURLSchemes` in `Info.plist`
+    ///   when ``PayPalRedirectURLSchemeValidator/shouldValidateAgainstInfoPlist`` is `true` (see that property for XCTest / sample-app **DEBUG** exceptions).
     @discardableResult
     func setBuiltInPayPalRedirectURLScheme(_ scheme: String?) -> Bool {
         guard let scheme, !scheme.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -478,13 +479,31 @@ class RoktInternalImplementation {
                 return
             }
 
+            let paypalSession: BuiltInPayPalDevicePaySession? = paymentMethod == .paypal
+                ? BuiltInPayPalDevicePaySession(
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    showConfirmation: { [weak self] layoutId, catalogItemId, catalogRuntimeData in
+                        guard let self,
+                              let state = self.stateManager.getState(id: executeId),
+                              let ux = state.uxHelper as? RoktUX else { return }
+                        ux.devicePayShowConfirmation(
+                            layoutId: layoutId,
+                            catalogItemId: catalogItemId,
+                            catalogRuntimeData: catalogRuntimeData
+                        )
+                    }
+                )
+                : nil
+
             // Process the payment via the registered extension
             paymentOrchestrator.processPayment(
                 method: paymentMethod,
                 item: item,
                 context: context,
                 cartItemId: event.cartItemId,
-                from: viewController
+                from: viewController,
+                builtInPayPalDevicePaySession: paypalSession
             ) { [weak self] result in
                 let success = result.outcome == .succeeded
                 if success {
@@ -610,6 +629,7 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
+            paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -625,22 +645,37 @@ class RoktInternalImplementation {
         RoktAPIHelper.forwardPayment(
             request: request,
             success: { [weak self] response in
-                self?.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
+                guard let self else { return }
+                self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(from: response)
-                self?.forwardPaymentFinalized(
-                    executeId: executeId,
-                    layoutId: event.layoutId,
-                    catalogItemId: event.catalogItemId,
-                    success: finalization.success,
-                    failureReason: finalization.failureReason
-                )
+                if finalization.success {
+                    self.forwardPaymentFinalized(
+                        executeId: executeId,
+                        layoutId: event.layoutId,
+                        catalogItemId: event.catalogItemId,
+                        success: true,
+                        failureReason: nil
+                    )
+                    self.paymentOrchestrator.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+                } else {
+                    self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
+                    self.forwardPaymentFinalized(
+                        executeId: executeId,
+                        layoutId: event.layoutId,
+                        catalogItemId: event.catalogItemId,
+                        success: false,
+                        failureReason: finalization.failureReason
+                    )
+                }
             },
             failure: { [weak self] _, _, message in
-                self?.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
+                guard let self else { return }
+                self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(
                     fromFailureMessage: message
                 )
-                self?.forwardPaymentFinalized(
+                self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
+                self.forwardPaymentFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,
                     catalogItemId: event.catalogItemId,

--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -159,7 +159,8 @@ class PlatformEventProcessor {
         // Sends new events and updates cache
         sendEvents(newEvents)
         ExperienceCacheManager.cacheExperiencesViewStateSentEventHashes(viewName: cacheProperties.viewName,
-                                                                        attributes: cacheProperties.attributes,
+                                                                        attributes: cacheProperties
+                                                                            .experienceCacheAttributes,
                                                                         sentEventHashes: Rokt.shared.roktImplementation
                                                                         .sentEventHashes.allElements)
     }

--- a/Tests/Rokt_WidgetTests/BreakdownFormatterTests.swift
+++ b/Tests/Rokt_WidgetTests/BreakdownFormatterTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class BreakdownFormatterTests: XCTestCase {
+    private let usLocale = Locale(identifier: "en_US")
+
+    private func upsellItem(unitPrice: Decimal, quantity: Decimal = 1) -> UpsellItem {
+        UpsellItem(
+            cartItemId: "cart1",
+            catalogItemId: "cat1",
+            quantity: quantity,
+            unitPrice: unitPrice,
+            totalPrice: unitPrice * quantity,
+            currency: "USD"
+        )
+    }
+
+    func test_format_subtotalSumsUpsellItemTotalPrices() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [
+                upsellItem(unitPrice: 10),
+                upsellItem(unitPrice: 5, quantity: 3)
+            ],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 25,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$25.00")
+    }
+
+    func test_format_USDproducesExpectedKeys() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: Decimal(string: "24.00")!)],
+            shippingCost: 0,
+            tax: Decimal(string: "1.94")!,
+            totalAmount: Decimal(string: "25.94")!,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$24.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.taxKey], "$1.94")
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "$25.94")
+    }
+
+    func test_format_EURusesProvidedCurrencyCode() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: 12)],
+            shippingCost: 3,
+            tax: 1,
+            totalAmount: 16,
+            currency: "EUR",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "€16.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "€3.00")
+    }
+
+    func test_format_zeroShippingAndTax() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: 9)],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 9,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$9.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.taxKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "$9.00")
+    }
+
+    func test_format_emptyUpsellItemsYieldsZeroSubtotal() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 0,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$0.00")
+    }
+}

--- a/Tests/Rokt_WidgetTests/BuiltInPayPalRedirectURLsTests.swift
+++ b/Tests/Rokt_WidgetTests/BuiltInPayPalRedirectURLsTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class BuiltInPayPalRedirectURLsTests: XCTestCase {
+    func test_returnAndCancelURLs_composesBareSchemeAndFixedHosts() {
+        let (returnURL, cancelURL) = BuiltInPayPalRedirectURLs.returnAndCancelURLs(forBareScheme: "myapp")
+        XCTAssertEqual(returnURL, "myapp://rokt-paypal-return")
+        XCTAssertEqual(cancelURL, "myapp://rokt-paypal-cancel")
+    }
+
+    func test_returnAndCancelURLs_trimsWhitespace() {
+        let (returnURL, cancelURL) = BuiltInPayPalRedirectURLs.returnAndCancelURLs(forBareScheme: "  com.partner  ")
+        XCTAssertEqual(returnURL, "com.partner://rokt-paypal-return")
+        XCTAssertEqual(cancelURL, "com.partner://rokt-paypal-cancel")
+    }
+
+    func test_isValidBareScheme_rejectsFullURL() {
+        XCTAssertFalse(PayPalRedirectURLSchemeValidator.isValidBareScheme("myapp://rokt-paypal-return"))
+        XCTAssertFalse(PayPalRedirectURLSchemeValidator.isValidBareScheme("myapp/path"))
+    }
+
+    func test_isValidBareScheme_acceptsBareScheme() {
+        XCTAssertTrue(PayPalRedirectURLSchemeValidator.isValidBareScheme("myapp"))
+        XCTAssertTrue(PayPalRedirectURLSchemeValidator.isValidBareScheme("com.partner.app"))
+    }
+}

--- a/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class InitializePurchaseRequestTests: XCTestCase {
+    func test_toDictionary_includesSnakeCasePaymentMethodAndProviderWhenSet() {
+        let upsell = UpsellItem(
+            cartItemId: "c1",
+            catalogItemId: "cat1",
+            quantity: 1,
+            unitPrice: 10,
+            totalPrice: 10,
+            currency: "USD"
+        )
+        let request = InitializePurchaseRequest(
+            totalUpsellPrice: 10,
+            currency: "USD",
+            upsellItems: [upsell],
+            fulfillmentDetails: nil,
+            returnURL: "myapp://return",
+            cancelURL: "myapp://cancel",
+            paymentMethod: "PAYPAL",
+            paymentProvider: "PAYPAL"
+        )
+
+        let dict = request.toDictionary()
+
+        XCTAssertEqual(dict["payment_method"] as? String, "PAYPAL")
+        XCTAssertEqual(dict["payment_provider"] as? String, "PAYPAL")
+    }
+
+    func test_toDictionary_omitsPaymentMethodAndProviderWhenNil() {
+        let upsell = UpsellItem(
+            cartItemId: "c1",
+            catalogItemId: "cat1",
+            quantity: 1,
+            unitPrice: 10,
+            totalPrice: 10,
+            currency: "USD"
+        )
+        let request = InitializePurchaseRequest(
+            totalUpsellPrice: 10,
+            currency: "USD",
+            upsellItems: [upsell],
+            fulfillmentDetails: nil,
+            returnURL: nil,
+            cancelURL: nil,
+            paymentMethod: nil,
+            paymentProvider: nil
+        )
+
+        let dict = request.toDictionary()
+
+        XCTAssertNil(dict["payment_method"] as? String)
+        XCTAssertNil(dict["payment_provider"] as? String)
+    }
+}

--- a/Tests/Rokt_WidgetTests/InitializePurchaseResponseTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseResponseTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class InitializePurchaseResponseTests: XCTestCase {
+    func test_decode_mapsPayPalData_whenPresent() throws {
+        let json = """
+        {
+          "success": true,
+          "totalUpsellPrice": 10,
+          "currency": "USD",
+          "upsellItems": [{
+            "cartItemId": "c1",
+            "catalogItemId": "cat1",
+            "quantity": 1,
+            "unitPrice": 10,
+            "totalPrice": 10,
+            "currency": "USD"
+          }],
+          "paymentDetails": {
+            "gateway": "paypal",
+            "merchantAccountId": "acct",
+            "clientSecret": "secret",
+            "shippingCost": 0,
+            "tax": 0,
+            "totalAmount": 10
+          },
+          "paypalData": {
+            "orderId": "5O190127TN364715T",
+            "approvalUrl": "https://www.paypal.com/checkoutnow?token=5O190127TN364715T"
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(InitializePurchaseResponse.self, from: json)
+        XCTAssertEqual(decoded.paypalData?.orderId, "5O190127TN364715T")
+        XCTAssertEqual(
+            decoded.paypalData?.approvalUrl,
+            "https://www.paypal.com/checkoutnow?token=5O190127TN364715T"
+        )
+    }
+
+    func test_decode_setsPayPalDataNil_whenKeyAbsent() throws {
+        let json = """
+        {
+          "success": true,
+          "totalUpsellPrice": 10,
+          "currency": "USD",
+          "upsellItems": [{
+            "cartItemId": "c1",
+            "catalogItemId": "cat1",
+            "quantity": 1,
+            "unitPrice": 10,
+            "totalPrice": 10,
+            "currency": "USD"
+          }],
+          "paymentDetails": {
+            "gateway": "stripe",
+            "merchantAccountId": "acct",
+            "clientSecret": "secret",
+            "shippingCost": 0,
+            "tax": 0,
+            "totalAmount": 10
+          }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(InitializePurchaseResponse.self, from: json)
+        XCTAssertNil(decoded.paypalData)
+    }
+}

--- a/Tests/Rokt_WidgetTests/InitializePurchaseResponseTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseResponseTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class InitializePurchaseResponseTests: XCTestCase {
     func test_decode_mapsPayPalData_whenPresent() throws {
-        let json = """
+        let json = Data("""
         {
           "success": true,
           "totalUpsellPrice": 10,
@@ -29,7 +29,7 @@ final class InitializePurchaseResponseTests: XCTestCase {
             "approvalUrl": "https://www.paypal.com/checkoutnow?token=5O190127TN364715T"
           }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(InitializePurchaseResponse.self, from: json)
         XCTAssertEqual(decoded.paypalData?.orderId, "5O190127TN364715T")
@@ -40,7 +40,7 @@ final class InitializePurchaseResponseTests: XCTestCase {
     }
 
     func test_decode_setsPayPalDataNil_whenKeyAbsent() throws {
-        let json = """
+        let json = Data("""
         {
           "success": true,
           "totalUpsellPrice": 10,
@@ -62,7 +62,7 @@ final class InitializePurchaseResponseTests: XCTestCase {
             "totalAmount": 10
           }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         let decoded = try JSONDecoder().decode(InitializePurchaseResponse.self, from: json)
         XCTAssertNil(decoded.paypalData)

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -161,7 +161,7 @@ class TestPaymentOrchestrator: XCTestCase {
         let found = sut.paymentExtension(id: "stripe")
         XCTAssertTrue(found === second, "Should reference the second (replacement) extension")
         XCTAssertEqual(first.onUnregisterCallCount, 1)
-        XCTAssertEqual(sut.availablePaymentMethods(), [.card])
+        XCTAssertEqual(Set(sut.availablePaymentMethods()), Set([.card, .paypal]))
     }
 
     func test_register_duplicateId_removesOldEvenWhenNewFails() {
@@ -228,8 +228,10 @@ class TestPaymentOrchestrator: XCTestCase {
 
     // MARK: - availablePaymentMethods
 
-    func test_availablePaymentMethods_empty_whenNoExtensions() {
-        XCTAssertTrue(sut.availablePaymentMethods().isEmpty)
+    func test_availablePaymentMethods_builtinPayPalOnly_whenNoExtensionsRegistered() {
+        let methods = sut.availablePaymentMethods()
+        XCTAssertEqual(Set(methods), Set([.paypal]))
+        XCTAssertEqual(methods.count, 1)
     }
 
     func test_availablePaymentMethods_deduplicatesAcrossExtensions() {
@@ -240,8 +242,8 @@ class TestPaymentOrchestrator: XCTestCase {
         sut.register(ext2, config: [:])
 
         let methods = sut.availablePaymentMethods()
-        XCTAssertEqual(Set(methods), Set([.applePay, .card]))
-        XCTAssertEqual(methods.count, 2, "Should not contain duplicates")
+        XCTAssertEqual(Set(methods), Set([.applePay, .card, .paypal]))
+        XCTAssertEqual(methods.count, 3, "Should not contain duplicates")
     }
 
     // MARK: - handleURLCallback
@@ -485,7 +487,7 @@ class TestPaymentOrchestrator: XCTestCase {
 
         // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
         // is weak, and the deferred ``DispatchQueue.main.async`` in
-        // ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded`` would otherwise see nil.
+        // ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` would otherwise see nil.
         let viewController = UIViewController()
         sut.processPayment(
             method: .paypal,
@@ -499,7 +501,7 @@ class TestPaymentOrchestrator: XCTestCase {
             XCTAssertEqual(result.transactionId, "mock_paypal_txn")
             expectation.fulfill()
         }
-        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+        _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
@@ -538,7 +540,7 @@ class TestPaymentOrchestrator: XCTestCase {
         ) { _ in
             expectation.fulfill()
         }
-        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+        _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
@@ -575,7 +577,7 @@ class TestPaymentOrchestrator: XCTestCase {
         ) { _ in
             paypalExpectation.fulfill()
         }
-        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+        _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
         wait(for: [paypalExpectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
@@ -766,7 +768,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(payPalPresenter.presentCallCount, 0)
-        XCTAssertNil(PaymentOrchestrator.pendingBuiltInPayPalApprovalURL)
+        XCTAssertFalse(sut.presentPendingBuiltInPayPalForForwardPayment { _ in })
     }
 
     func test_handleURLCallback_completesPayPal_whenActiveCheckoutMatchesReturnDeepLink() {
@@ -779,7 +781,7 @@ class TestPaymentOrchestrator: XCTestCase {
 
         let expectation = expectation(description: "PayPal completes via deep link callback")
         // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
-        // is weak, and the deferred main-queue dispatch in ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded``
+        // is weak, and the deferred main-queue dispatch in ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)``
         // would otherwise see nil and complete with .failed before the deep link arrives.
         let viewController = UIViewController()
         sut.processPayment(
@@ -798,7 +800,7 @@ class TestPaymentOrchestrator: XCTestCase {
             XCTAssertEqual(result.transactionId, "ORDER_FROM_LINK")
             expectation.fulfill()
         }
-        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+        _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
 
         // Disambiguate from the local `expectation` var declared above, which shadows
         // ``XCTestCase/expectation(description:)`` and produced a build error in Brandon's commit.

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -109,14 +109,24 @@ class TestPaymentOrchestrator: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        PaymentOrchestrator.resetBuiltInPayPalDeferredStateForTesting()
         sut = PaymentOrchestrator()
         PaymentOrchestratorAPIHelperSpy.reset()
     }
 
     override func tearDown() {
         sut = nil
+        PaymentOrchestrator.resetBuiltInPayPalDeferredStateForTesting()
         PaymentOrchestratorAPIHelperSpy.reset()
         super.tearDown()
+    }
+
+    private func paypalDeviceSessionForTests(
+        onConfirmation: ((String, String, [String: String]) -> Void)? = nil
+    ) -> BuiltInPayPalDevicePaySession {
+        BuiltInPayPalDevicePaySession(layoutId: "test_layout", catalogItemId: "test_catalog") { lid, cid, data in
+            onConfirmation?(lid, cid, data)
+        }
     }
 
     // MARK: - Registration
@@ -387,6 +397,8 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
     func test_processPayment_preparePayment_plumbsApprovalUrlWhenPayPalDataPresent() {
@@ -441,6 +453,8 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
     func test_processPayment_payPal_routesToBuiltInFlowWithoutExtension() {
@@ -474,17 +488,21 @@ class TestPaymentOrchestrator: XCTestCase {
             item: item,
             context: context,
             cartItemId: "v1:cart-paypal:canal",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
             XCTAssertEqual(result.transactionId, "mock_paypal_txn")
             expectation.fulfill()
         }
+        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
         XCTAssertEqual(payPalPresenter.presentCallCount, 1)
         XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
     }
@@ -511,14 +529,18 @@ class TestPaymentOrchestrator: XCTestCase {
             item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
             context: context,
             cartItemId: "v1:cart:1",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { _ in
             expectation.fulfill()
         }
+        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
     }
 
     func test_processPayment_payPal_ignoresRegisteredExtensionSupportingPayPal() {
@@ -544,11 +566,15 @@ class TestPaymentOrchestrator: XCTestCase {
                 cancelURL: nil
             ),
             cartItemId: "v1:cart:1",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { _ in
             paypalExpectation.fulfill()
         }
+        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
         wait(for: [paypalExpectation], timeout: 1.0)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
         XCTAssertEqual(ext.presentPaymentSheetCallCount, 0, "PayPal must not use PaymentExtension.presentPaymentSheet")
 
         let appleExpectation = expectation(description: "Apple Pay still uses extension")
@@ -637,6 +663,8 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
     private static func validInitializePurchaseResponse() -> InitializePurchaseResponse {
@@ -697,7 +725,8 @@ class TestPaymentOrchestrator: XCTestCase {
             item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
             context: PaymentContext(billingAddress: ContactAddress(name: "A", email: "a@b.com"), returnURL: "myapp://ok"),
             cartItemId: "v1:cart:1",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .failed)
             XCTAssertEqual(result.errorMessage, PaymentOrchestrator.payPalApprovalURLMissingMessage)
@@ -705,6 +734,35 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(payPalPresenter.presentCallCount, 0)
+    }
+
+    func test_processPayment_payPal_failsWhenDevicePaySessionMissing() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal fails without device-pay session")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(
+                billingAddress: ContactAddress(name: "A", email: "a@b.com"),
+                returnURL: "myapp://paypal/success",
+                cancelURL: nil
+            ),
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .failed)
+            XCTAssertEqual(result.errorMessage, PaymentOrchestrator.builtInPayPalMissingDeferredSessionMessage)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(payPalPresenter.presentCallCount, 0)
+        XCTAssertNil(PaymentOrchestrator.pendingBuiltInPayPalApprovalURL)
     }
 
     func test_handleURLCallback_completesPayPal_whenActiveCheckoutMatchesReturnDeepLink() {
@@ -725,12 +783,18 @@ class TestPaymentOrchestrator: XCTestCase {
                 cancelURL: nil
             ),
             cartItemId: "v1:cart:1",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
             XCTAssertEqual(result.transactionId, "ORDER_FROM_LINK")
             expectation.fulfill()
         }
+        sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
+
+        let flush = expectation(description: "main queue flush for deferred PayPal coordinator")
+        DispatchQueue.main.async { flush.fulfill() }
+        wait(for: [flush], timeout: 1.0)
 
         let deepLink = URL(string: "myapp://paypal/success?token=ORDER_FROM_LINK")!
         XCTAssertTrue(sut.handleURLCallback(with: deepLink))
@@ -752,7 +816,8 @@ class TestPaymentOrchestrator: XCTestCase {
             item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
             context: PaymentContext(billingAddress: ContactAddress(name: "A", email: "a@b.com")),
             cartItemId: "v1:cart:1",
-            from: UIViewController()
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .failed)
             XCTAssertEqual(result.errorMessage, PaymentOrchestrator.payPalReturnURLMissingMessage)
@@ -768,6 +833,8 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
     static var initializePurchaseCallCount = 0
     static var lastInitializePurchaseReturnURL: String?
     static var lastInitializePurchaseCancelURL: String?
+    static var lastInitializePurchasePaymentMethod: String?
+    static var lastInitializePurchasePaymentProvider: String?
     static var sendDiagnosticsCallCount = 0
     static var lastDiagnosticsMessage: String?
     static var lastDiagnosticsCallStack: String?
@@ -777,6 +844,8 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         initializePurchaseCallCount = 0
         lastInitializePurchaseReturnURL = nil
         lastInitializePurchaseCancelURL = nil
+        lastInitializePurchasePaymentMethod = nil
+        lastInitializePurchasePaymentProvider = nil
         sendDiagnosticsCallCount = 0
         lastDiagnosticsMessage = nil
         lastDiagnosticsCallStack = nil
@@ -787,12 +856,16 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         shippingAttributes: ShippingAttributes,
         returnURL: String? = nil,
         cancelURL: String? = nil,
+        paymentMethod: String? = nil,
+        paymentProvider: String? = nil,
         success: ((InitializePurchaseResponse) -> Void)?,
         failure: ((Error, Int?, String) -> Void)?
     ) {
         initializePurchaseCallCount += 1
         lastInitializePurchaseReturnURL = returnURL
         lastInitializePurchaseCancelURL = cancelURL
+        lastInitializePurchasePaymentMethod = paymentMethod
+        lastInitializePurchasePaymentProvider = paymentProvider
         if let initializePurchaseResponse {
             success?(initializePurchaseResponse)
         } else {

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -483,12 +483,16 @@ class TestPaymentOrchestrator: XCTestCase {
             cancelURL: "myapp://paypal/cancel"
         )
 
+        // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
+        // is weak, and the deferred ``DispatchQueue.main.async`` in
+        // ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded`` would otherwise see nil.
+        let viewController = UIViewController()
         sut.processPayment(
             method: .paypal,
             item: item,
             context: context,
             cartItemId: "v1:cart-paypal:canal",
-            from: UIViewController(),
+            from: viewController,
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
@@ -774,6 +778,10 @@ class TestPaymentOrchestrator: XCTestCase {
         PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
 
         let expectation = expectation(description: "PayPal completes via deep link callback")
+        // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
+        // is weak, and the deferred main-queue dispatch in ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded``
+        // would otherwise see nil and complete with .failed before the deep link arrives.
+        let viewController = UIViewController()
         sut.processPayment(
             method: .paypal,
             item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
@@ -783,7 +791,7 @@ class TestPaymentOrchestrator: XCTestCase {
                 cancelURL: nil
             ),
             cartItemId: "v1:cart:1",
-            from: UIViewController(),
+            from: viewController,
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
@@ -792,7 +800,9 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
 
-        let flush = expectation(description: "main queue flush for deferred PayPal coordinator")
+        // Disambiguate from the local `expectation` var declared above, which shadows
+        // ``XCTestCase/expectation(description:)`` and produced a build error in Brandon's commit.
+        let flush = self.expectation(description: "main queue flush for deferred PayPal coordinator")
         DispatchQueue.main.async { flush.fulfill() }
         wait(for: [flush], timeout: 1.0)
 

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -70,6 +70,37 @@ final class MockPaymentExtension: PaymentExtension {
     }
 }
 
+/// Keeps the PayPal sheet open until a separate deep-link simulation runs (for testing ``PaymentOrchestrator/handleURLCallback(with:)``).
+final class HoldingPayPalApprovalPresenter: PayPalApprovalPresenting {
+    func presentPayPalApproval(
+        approvalURL: URL,
+        from viewController: UIViewController,
+        checkoutCoordinator: PayPalCheckoutCoordinator
+    ) {
+        _ = approvalURL
+        _ = viewController
+        _ = checkoutCoordinator
+    }
+}
+
+final class MockPayPalApprovalPresenter: PayPalApprovalPresenting {
+    private(set) var presentCallCount = 0
+    private(set) var lastApprovalURL: URL?
+    var sheetResult: PaymentSheetResult = .succeeded(transactionId: "mock_paypal_txn")
+
+    func presentPayPalApproval(
+        approvalURL: URL,
+        from viewController: UIViewController,
+        checkoutCoordinator: PayPalCheckoutCoordinator
+    ) {
+        presentCallCount += 1
+        lastApprovalURL = approvalURL
+        DispatchQueue.main.async {
+            checkoutCoordinator.completeFromEmbeddedCheckout(self.sheetResult)
+        }
+    }
+}
+
 // MARK: - Tests
 
 class TestPaymentOrchestrator: XCTestCase {
@@ -321,7 +352,8 @@ class TestPaymentOrchestrator: XCTestCase {
                 shippingCost: Decimal(string: "0")!,
                 tax: Decimal(string: "3.53")!,
                 totalAmount: Decimal(string: "83.53")!
-            )
+            ),
+            paypalData: nil
         )
 
         let item = PaymentItem(id: "item1", name: "Widget", amount: 80, currency: "USD")
@@ -350,10 +382,202 @@ class TestPaymentOrchestrator: XCTestCase {
             XCTAssertEqual(preparation?.totalAmount, NSDecimalNumber(string: "83.53"))
             XCTAssertEqual(preparation?.shippingCost, NSDecimalNumber.zero)
             XCTAssertEqual(preparation?.tax, NSDecimalNumber(string: "3.53"))
+            XCTAssertNil(preparation?.approvalUrl)
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_processPayment_preparePayment_plumbsApprovalUrlWhenPayPalDataPresent() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.applePay])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+
+        let approvalURL = "https://www.paypal.com/checkoutnow?token=TESTTOKEN"
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = InitializePurchaseResponse(
+            success: true,
+            totalUpsellPrice: 10,
+            currency: "USD",
+            upsellItems: [],
+            paymentDetails: PaymentDetails(
+                gateway: "paypal",
+                merchantName: nil,
+                merchantAccountId: "acct_pp",
+                paymentIntentId: nil,
+                clientSecret: "cs_pp",
+                shippingCost: 0,
+                tax: 0,
+                totalAmount: 10
+            ),
+            paypalData: InitializePurchasePayPalData(orderId: "ORDER1", approvalUrl: approvalURL)
+        )
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
+        sut.processPayment(
+            method: .applePay,
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-approval:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment includes PayPal approval URL")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { preparation, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(preparation)
+            XCTAssertEqual(preparation?.approvalUrl, approvalURL)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_processPayment_payPal_routesToBuiltInFlowWithoutExtension() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal prepares then invokes approval presenter")
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 9.99, currency: "USD")
+        let billing = ContactAddress(
+            name: "Bo User",
+            email: "bo@example.com",
+            addressLine1: "1 Main St",
+            city: "NYC",
+            state: "NY",
+            postalCode: "10001",
+            country: "US"
+        )
+        let context = PaymentContext(
+            billingAddress: billing,
+            shippingAddress: nil,
+            returnURL: "myapp://paypal/success",
+            cancelURL: "myapp://paypal/cancel"
+        )
+
+        sut.processPayment(
+            method: .paypal,
+            item: item,
+            context: context,
+            cartItemId: "v1:cart-paypal:canal",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .succeeded)
+            XCTAssertEqual(result.transactionId, "mock_paypal_txn")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
+        XCTAssertEqual(payPalPresenter.presentCallCount, 1)
+        XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
+    }
+
+    func test_processPayment_payPal_passesReturnAndCancelURLToInitializePurchase() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal prepare completes")
+        let billing = ContactAddress(name: "Bo", email: "b@o.com")
+        let context = PaymentContext(
+            billingAddress: billing,
+            shippingAddress: nil,
+            returnURL: "myapp://paypal/success",
+            cancelURL: "myapp://paypal/cancel"
+        )
+
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: context,
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
+    }
+
+    func test_processPayment_payPal_ignoresRegisteredExtensionSupportingPayPal() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let ext = MockPaymentExtension(id: "ext_paypal", supportedMethods: [.paypal, .applePay])
+        sut.register(ext, config: [:])
+
+        let billing = ContactAddress(name: "Bo", email: "b@o.com")
+        let paypalExpectation = expectation(description: "PayPal built-in prepare")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(
+                billingAddress: billing,
+                shippingAddress: nil,
+                returnURL: "myapp://paypal/success",
+                cancelURL: nil
+            ),
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { _ in
+            paypalExpectation.fulfill()
+        }
+        wait(for: [paypalExpectation], timeout: 1.0)
+        XCTAssertEqual(ext.presentPaymentSheetCallCount, 0, "PayPal must not use PaymentExtension.presentPaymentSheet")
+
+        let appleExpectation = expectation(description: "Apple Pay still uses extension")
+        sut.processPayment(
+            method: .applePay,
+            item: PaymentItem(id: "a1", name: "A", amount: 2, currency: "USD"),
+            context: PaymentContext(),
+            cartItemId: "v1:cart:2",
+            from: UIViewController()
+        ) { _ in
+            appleExpectation.fulfill()
+        }
+        wait(for: [appleExpectation], timeout: 1.0)
+        XCTAssertEqual(ext.presentPaymentSheetCallCount, 1)
+    }
+
+    func test_availablePaymentMethods_includesPayPalWhenNoExtensionsRegistered() {
+        let methods = sut.availablePaymentMethods()
+        XCTAssertTrue(methods.contains(.paypal))
+    }
+
+    func test_handleURLCallback_builtinPayPalPlaceholder_defersToExtensions() {
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.card])
+        ext.urlCallbackHandler = { _ in true }
+        sut.register(ext, config: [:])
+
+        let url = URL(string: "myapp://paypal-return")!
+        XCTAssertTrue(sut.handleURLCallback(with: url))
+        XCTAssertEqual(ext.handleURLCallbackCallCount, 1)
     }
 
     func test_processPayment_preparePaymentFailsFast_whenResponseMissingRequiredFields() {
@@ -377,7 +601,8 @@ class TestPaymentOrchestrator: XCTestCase {
                 shippingCost: 0,
                 tax: 0,
                 totalAmount: 9.99
-            )
+            ),
+            paypalData: nil
         )
 
         let item = PaymentItem(id: "item1", name: "Widget", amount: 9.99, currency: "USD")
@@ -413,16 +638,145 @@ class TestPaymentOrchestrator: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
     }
+
+    private static func validInitializePurchaseResponse() -> InitializePurchaseResponse {
+        InitializePurchaseResponse(
+            success: true,
+            totalUpsellPrice: 9.99,
+            currency: "USD",
+            upsellItems: [],
+            paymentDetails: PaymentDetails(
+                gateway: "stripe",
+                merchantName: "Test",
+                merchantAccountId: "merchant.com.test",
+                paymentIntentId: "pi_test",
+                clientSecret: "cs_test_secret",
+                shippingCost: 0,
+                tax: 0,
+                totalAmount: 9.99
+            ),
+            paypalData: nil
+        )
+    }
+
+    /// Includes ``InitializePurchasePayPalData/approvalUrl`` so built-in PayPal can present the hosted approve flow.
+    private static func validPayPalInitializePurchaseResponse() -> InitializePurchaseResponse {
+        InitializePurchaseResponse(
+            success: true,
+            totalUpsellPrice: 9.99,
+            currency: "USD",
+            upsellItems: [],
+            paymentDetails: PaymentDetails(
+                gateway: "stripe",
+                merchantName: "Test",
+                merchantAccountId: "merchant.com.test",
+                paymentIntentId: "pi_test",
+                clientSecret: "cs_test_secret",
+                shippingCost: 0,
+                tax: 0,
+                totalAmount: 9.99
+            ),
+            paypalData: InitializePurchasePayPalData(
+                orderId: "ORDER_MOCK",
+                approvalUrl: "https://www.paypal.com/checkoutnow?token=MOCK"
+            )
+        )
+    }
+
+    func test_processPayment_payPal_failsWhenApprovalUrlMissing() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal fails without approval URL")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(billingAddress: ContactAddress(name: "A", email: "a@b.com"), returnURL: "myapp://ok"),
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .failed)
+            XCTAssertEqual(result.errorMessage, PaymentOrchestrator.payPalApprovalURLMissingMessage)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(payPalPresenter.presentCallCount, 0)
+    }
+
+    func test_handleURLCallback_completesPayPal_whenActiveCheckoutMatchesReturnDeepLink() {
+        let presenter = HoldingPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: presenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal completes via deep link callback")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(
+                billingAddress: ContactAddress(name: "A", email: "a@b.com"),
+                returnURL: "myapp://paypal/success",
+                cancelURL: nil
+            ),
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .succeeded)
+            XCTAssertEqual(result.transactionId, "ORDER_FROM_LINK")
+            expectation.fulfill()
+        }
+
+        let deepLink = URL(string: "myapp://paypal/success?token=ORDER_FROM_LINK")!
+        XCTAssertTrue(sut.handleURLCallback(with: deepLink))
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func test_processPayment_payPal_failsWhenReturnURLMissing() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let expectation = expectation(description: "PayPal fails without return URL")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(billingAddress: ContactAddress(name: "A", email: "a@b.com")),
+            cartItemId: "v1:cart:1",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .failed)
+            XCTAssertEqual(result.errorMessage, PaymentOrchestrator.payPalReturnURLMissingMessage)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(payPalPresenter.presentCallCount, 0)
+    }
 }
 
 class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
     static var initializePurchaseResponse: InitializePurchaseResponse?
+    static var initializePurchaseCallCount = 0
+    static var lastInitializePurchaseReturnURL: String?
+    static var lastInitializePurchaseCancelURL: String?
     static var sendDiagnosticsCallCount = 0
     static var lastDiagnosticsMessage: String?
     static var lastDiagnosticsCallStack: String?
 
     static func reset() {
         initializePurchaseResponse = nil
+        initializePurchaseCallCount = 0
+        lastInitializePurchaseReturnURL = nil
+        lastInitializePurchaseCancelURL = nil
         sendDiagnosticsCallCount = 0
         lastDiagnosticsMessage = nil
         lastDiagnosticsCallStack = nil
@@ -431,9 +785,14 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
     override class func initializePurchase(
         upsellItems: [UpsellItem],
         shippingAttributes: ShippingAttributes,
+        returnURL: String? = nil,
+        cancelURL: String? = nil,
         success: ((InitializePurchaseResponse) -> Void)?,
         failure: ((Error, Int?, String) -> Void)?
     ) {
+        initializePurchaseCallCount += 1
+        lastInitializePurchaseReturnURL = returnURL
+        lastInitializePurchaseCancelURL = cancelURL
         if let initializePurchaseResponse {
             success?(initializePurchaseResponse)
         } else {


### PR DESCRIPTION
## Background

This work adds built-in PayPal support for device-pay / catalog flows so partners can complete PayPal checkout without registering a separate PaymentExtension for .paypal. Cart initialize-purchase must send return and cancel redirect URLs where the backend expects them, and must surface PayPal order data (including the hosted approval URL) when the API returns it. User completion is handled both in-webview (redirect to app URL schemes) and via Rokt.handleURLCallback when PayPal resumes the host app through deep links.

This flow is currently skipping the step where the ux displays a confirmation screen with updated tax, shipping, and total costs. Once the that code is available we must add this step in.

Additionally Rokt Contracts needs types that carry PaymentContext.cancelURL and PaymentPreparation.approvalUrl for this wiring. Until that ships as a tagged release, Swift Package Manager pins rokt-contracts-apple to branch feat/Add-PayPal-Support-2 ([ROKT/rokt-contracts-apple#22](https://github.com/ROKT/rokt-contracts-apple/pull/22)). Reviewers should treat that branch pin as temporary: after #22 merges and a version is published, Package.swift should move back to a semver range and Package.resolved should be updated to that release.

## What Has Changed

- PaymentOrchestrator: Routes .paypal to a built-in path (does not use registered PaymentExtension for PayPal). Reuses cart initializePurchase, passes PaymentContext.returnURL / cancelURL into the request body, builds PaymentPreparation including approvalUrl from paypalData, presents PayPal’s hosted approval flow, and wires handleURLCallback so active checkout can finish when return/cancel URLs open the app as deep links.
- PayPalApprovalWebFlow.swift: New WKWebView-based approval UI, PayPalCheckoutCoordinator for matching return/cancel URLs, and injectable PayPalApprovalPresenting for tests.
- Networking: InitializePurchaseRequest / API helpers include returnURL and cancelURL; InitializePurchaseResponse decodes optional paypalData (e.g. approvalUrl).
- RoktInternalImplementation: For device pay, builds PaymentContext with billing/shipping, returnURL, and cancelURL resolved from TransactionData metadata (and execute attributes).
- CHANGELOG.md: [Unreleased] entries for PayPal preparation, built-in flow, and contracts note.

Describe the tests that you ran to verify your changes.

- Automated: New and updated Rokt_WidgetTests coverage — TestPaymentOrchestrator scenarios for PayPal routing, returnURL/cancelURL forwarded to initialize-purchase, approvalUrl on PaymentPreparation, presenter invocation, extension bypass for PayPal, missing approval/return URL failures, and handleURLCallback completing checkout from a matching return deep link; InitializePurchaseResponseTests for JSON including paypalData.approvalUrl.

- Build: xcodebuild against the Rokt-Widget scheme (iOS Simulator) succeeds with the pinned contracts branch.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
