### PR TITLE
feat: Check Shoppable feature flag depending on attribute

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -758,6 +758,13 @@ class RoktInternalImplementation {
             trackingConsent = ATTrackingManager.trackingAuthorizationStatus.rawValue
         }
 
+        if attributes[keyAdsExperienceType] == valueAdsExperienceShoppable {
+            guard isShoppableFeatureFlagGatePassed(identifier: viewName, onFailure: composedEventHandler),
+                  isShoppablePaymentGatePassed(identifier: viewName, onFailure: composedEventHandler) else {
+                return
+            }
+        }
+
         isExecuting = true
         self.placements = placements
         let startDate = Date()
@@ -1058,21 +1065,8 @@ class RoktInternalImplementation {
         config: RoktConfig?,
         onRoktEvent: ((RoktEvent) -> Void)?
     ) {
-        if isInitialized && !initFeatureFlags.isShoppableAdsEnabled() {
-            RoktLogger.shared.verbose(
-                "Rokt: selectShoppableAds skipped — Shoppable Ads feature flags are disabled for this account."
-            )
-            onRoktEvent?(RoktEvent.PlacementFailure(identifier: nil))
-            return
-        }
-
-        guard paymentOrchestrator.hasRegisteredExtension else {
-            RoktLogger.shared.error(
-                "Rokt: No PaymentExtension registered. Call registerPaymentExtension() before selectShoppableAds()."
-            )
-            onRoktEvent?(RoktEvent.PlacementFailure(identifier: nil))
-            return
-        }
+        if isInitialized && !isShoppableFeatureFlagGatePassed(identifier: identifier, onFailure: onRoktEvent) { return }
+        guard isShoppablePaymentGatePassed(identifier: identifier, onFailure: onRoktEvent) else { return }
 
         var enrichedAttributes = attributes
         if enrichedAttributes[keyAdsExperienceType] == nil {
@@ -1088,6 +1082,28 @@ class RoktInternalImplementation {
             placementOptions: nil,
             onRoktEvent: onRoktEvent
         )
+    }
+
+    private func isShoppableFeatureFlagGatePassed(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
+        guard initFeatureFlags.isShoppableAdsEnabled() else {
+            RoktLogger.shared.verbose(
+                "Rokt: Shoppable Ads feature flags are disabled for this account."
+            )
+            onFailure?(RoktEvent.PlacementFailure(identifier: identifier))
+            return false
+        }
+        return true
+    }
+
+    private func isShoppablePaymentGatePassed(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
+        guard paymentOrchestrator.hasRegisteredExtension else {
+            RoktLogger.shared.error(
+                "Rokt: No PaymentExtension registered. Call registerPaymentExtension() before using Shoppable Ads."
+            )
+            onFailure?(RoktEvent.PlacementFailure(identifier: identifier))
+            return false
+        }
+        return true
     }
 
     private func decodeOnSeparateThread<T: Decodable>(_ type: T.Type, _ data: Data) throws -> T {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -759,8 +759,8 @@ class RoktInternalImplementation {
         }
 
         if attributes[keyAdsExperienceType] == valueAdsExperienceShoppable {
-            guard isShoppableFeatureFlagGatePassed(identifier: viewName, onFailure: composedEventHandler),
-                  isShoppablePaymentGatePassed(identifier: viewName, onFailure: composedEventHandler) else {
+            guard validateShoppableAdsFeatureFlag(identifier: viewName, onFailure: composedEventHandler),
+                  validateShoppableAdsPaymentExtension(identifier: viewName, onFailure: composedEventHandler) else {
                 return
             }
         }
@@ -1065,8 +1065,8 @@ class RoktInternalImplementation {
         config: RoktConfig?,
         onRoktEvent: ((RoktEvent) -> Void)?
     ) {
-        if isInitialized && !isShoppableFeatureFlagGatePassed(identifier: identifier, onFailure: onRoktEvent) { return }
-        guard isShoppablePaymentGatePassed(identifier: identifier, onFailure: onRoktEvent) else { return }
+        if isInitialized && !validateShoppableAdsFeatureFlag(identifier: identifier, onFailure: onRoktEvent) { return }
+        guard validateShoppableAdsPaymentExtension(identifier: identifier, onFailure: onRoktEvent) else { return }
 
         var enrichedAttributes = attributes
         if enrichedAttributes[keyAdsExperienceType] == nil {
@@ -1084,7 +1084,7 @@ class RoktInternalImplementation {
         )
     }
 
-    private func isShoppableFeatureFlagGatePassed(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
+    private func validateShoppableAdsFeatureFlag(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
         guard initFeatureFlags.isShoppableAdsEnabled() else {
             RoktLogger.shared.verbose(
                 "Rokt: Shoppable Ads feature flags are disabled for this account."
@@ -1095,7 +1095,7 @@ class RoktInternalImplementation {
         return true
     }
 
-    private func isShoppablePaymentGatePassed(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
+    private func validateShoppableAdsPaymentExtension(identifier: String?, onFailure: ((RoktEvent) -> Void)?) -> Bool {
         guard paymentOrchestrator.hasRegisteredExtension else {
             RoktLogger.shared.error(
                 "Rokt: No PaymentExtension registered. Call registerPaymentExtension() before using Shoppable Ads."

--- a/Tests/Rokt_WidgetTests/TestShoppableAds.swift
+++ b/Tests/Rokt_WidgetTests/TestShoppableAds.swift
@@ -171,6 +171,18 @@ final class TestShoppableAds: XCTestCase {
         XCTAssertTrue(receivedEvents.contains { $0 is RoktEvent.PlacementFailure })
     }
 
+    func test_selectPlacements_withShoppableAttribute_proceedsToExecute_whenFlagsEnabledAndExtensionRegistered() {
+        mockImplementation.initFeatureFlags = Self.featureFlags(postPurchase: true, minimumSchema: true)
+        mockImplementation.registerPaymentExtension(StubPaymentExtension(), config: [:])
+
+        Rokt.selectPlacements(
+            identifier: "test",
+            attributes: ["adsExperience": "shoppable"]
+        )
+
+        XCTAssertEqual(mockImplementation.executeCallCount, 1)
+    }
+
     func test_selectPlacements_withoutShoppableAttribute_doesNotApplyShoppableGate() {
         // Feature flags and payment extension are both invalid for shoppable,
         // but the gate must NOT apply for non-shoppable attributes.

--- a/Tests/Rokt_WidgetTests/TestShoppableAds.swift
+++ b/Tests/Rokt_WidgetTests/TestShoppableAds.swift
@@ -135,6 +135,56 @@ final class TestShoppableAds: XCTestCase {
         XCTAssertTrue(receivedEvents.contains { $0 is RoktEvent.PlacementFailure })
     }
 
+    // MARK: - selectPlacements with shoppable attribute
+
+    func test_selectPlacements_withShoppableAttribute_emitsPlacementFailure_whenFeatureFlagsDisabled() {
+        let impl = RoktInternalImplementation()
+        impl.isInitialized = true
+        impl.initFeatureFlags = Self.featureFlags(postPurchase: false, minimumSchema: true)
+        impl.registerPaymentExtension(StubPaymentExtension(), config: [:])
+        Rokt.shared.roktImplementation = impl
+
+        var receivedEvents: [RoktEvent] = []
+        Rokt.selectPlacements(
+            identifier: "test",
+            attributes: ["adsExperience": "shoppable"],
+            onEvent: { receivedEvents.append($0) }
+        )
+
+        XCTAssertTrue(receivedEvents.contains { $0 is RoktEvent.PlacementFailure })
+    }
+
+    func test_selectPlacements_withShoppableAttribute_emitsPlacementFailure_whenNoPaymentExtension() {
+        let impl = RoktInternalImplementation()
+        impl.isInitialized = true
+        impl.initFeatureFlags = Self.featureFlags(postPurchase: true, minimumSchema: true)
+        // no payment extension registered
+        Rokt.shared.roktImplementation = impl
+
+        var receivedEvents: [RoktEvent] = []
+        Rokt.selectPlacements(
+            identifier: "test",
+            attributes: ["adsExperience": "shoppable"],
+            onEvent: { receivedEvents.append($0) }
+        )
+
+        XCTAssertTrue(receivedEvents.contains { $0 is RoktEvent.PlacementFailure })
+    }
+
+    func test_selectPlacements_withoutShoppableAttribute_doesNotApplyShoppableGate() {
+        // Feature flags and payment extension are both invalid for shoppable,
+        // but the gate must NOT apply for non-shoppable attributes.
+        mockImplementation.initFeatureFlags = Self.featureFlags(postPurchase: false, minimumSchema: false)
+        // no payment extension registered
+
+        Rokt.selectPlacements(
+            identifier: "test",
+            attributes: ["email": "test@example.com"]
+        )
+
+        XCTAssertEqual(mockImplementation.executeCallCount, 1)
+    }
+
     // MARK: - Helpers
 
     private static func featureFlags(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Currently selectPlacements will fire even when we know there are no Shoppable Ads for a partner

## What Has Changed

- Adds a check for a specific attribute and checks for extension registration and feature flag before calling a shoppable experience

## How Has This Been Tested

- All local tests pass

## Notes

N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
