### PR TITLE
feat(paypal): Add BreakdownFormatter and invoke UXHelper with the dynamic payment data

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/BreakdownFormatter.swift
+++ b/Sources/Rokt_Widget/Models/Payment/BreakdownFormatter.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Formats the order breakdown values pushed into the UXHelper layout's
+/// `DATA.catalogRuntime.*` placeholders by ``RoktUX/devicePayShowConfirmation``.
+///
+/// Subtotal is summed from ``UpsellItem/totalPrice`` (the response echoes back
+/// what the SDK sent in `/v1/cart/initialize-purchase`); shipping / tax / total
+/// come straight from the cart-prepare response's ``PaymentDetails``.
+enum BreakdownFormatter {
+    static let subtotalKey = "subtotal"
+    static let taxKey = "tax"
+    static let shippingKey = "shipping"
+    static let totalKey = "total"
+
+    /// Build the `[String: String]` payload for ``RoktUX/devicePayShowConfirmation``.
+    static func format(
+        upsellItems: [UpsellItem],
+        shippingCost: Decimal,
+        tax: Decimal,
+        totalAmount: Decimal,
+        currency: String,
+        locale: Locale = .current
+    ) -> [String: String] {
+        let subtotal = upsellItems.reduce(Decimal(0)) { $0 + $1.totalPrice }
+        let formatter = currencyFormatter(currency: currency, locale: locale)
+        return [
+            subtotalKey: format(subtotal, formatter: formatter),
+            taxKey: format(tax, formatter: formatter),
+            shippingKey: format(shippingCost, formatter: formatter),
+            totalKey: format(totalAmount, formatter: formatter)
+        ]
+    }
+
+    private static func currencyFormatter(currency: String, locale: Locale) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = locale
+        formatter.currencyCode = currency
+        return formatter
+    }
+
+    private static func format(_ amount: Decimal, formatter: NumberFormatter) -> String {
+        let number = NSDecimalNumber(decimal: amount)
+        return formatter.string(from: number) ?? "\(amount)"
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -221,10 +221,10 @@ final class PaymentOrchestrator {
             switch result {
             case .success(let preparation):
                 Self.verboseLogBuiltInPayPalPaymentPreparation(preparation)
-                guard let approvalURL = URL(string: "https://www.sandbox.paypal.com/signin")
-//                    .trimmingCharacters(in: .whitespacesAndNewlines),
-//                      !approvalString.isEmpty,
-//                      let approvalURL = URL(string: approvalString)
+                guard let approvalString = preparation.approvalUrl?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !approvalString.isEmpty,
+                      let approvalURL = URL(string: approvalString)
                 else {
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.payPalApprovalURLMissingMessage))
@@ -314,6 +314,66 @@ final class PaymentOrchestrator {
         }
     }
 
+    /// PayPal-only forward-payment entry point: open the cached approval URL
+    /// fire `onCompletion` once the coordinator resolves via the in-webview redirect
+    /// or the deep-link `handleURLCallback` path.
+    ///
+    /// backend webhook finalizes the purchase from the PayPal redirect; the SDK only needs
+    /// to surface success/cancel/failure to the UXHelper.
+    ///
+    /// - Parameter onCompletion: called on the main queue with the coordinator outcome.
+    /// - Returns: `true` when a pending PayPal checkout existed and was presented; `false`
+    ///   when the caller should fall through to the non-PayPal `/v1/cart/purchase` flow.
+    @discardableResult
+    func presentPendingBuiltInPayPalForForwardPayment(
+        onCompletion: @escaping (PaymentSheetResult) -> Void
+    ) -> Bool {
+        Self.pendingBuiltInPayPalLock.lock()
+        let snapshot = Self.pendingBuiltInPayPalWebCheckout
+        guard let snapshot, snapshot.owner === self else {
+            Self.pendingBuiltInPayPalLock.unlock()
+            return false
+        }
+        Self.pendingBuiltInPayPalWebCheckout = nil
+        Self.pendingBuiltInPayPalApprovalURL = nil
+        Self.pendingBuiltInPayPalLock.unlock()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                let result = PaymentSheetResult.failed(error: Self.payPalReturnURLMissingMessage)
+                snapshot.completion(result)
+                onCompletion(result)
+                return
+            }
+            // Fall back to the current top view controller when the originally captured weak
+            // reference has been deallocated (e.g. host app dismissed and re-presented Rokt).
+            guard let viewController = snapshot.presentingViewController ?? UIApplication.topViewController() else {
+                let result = PaymentSheetResult.failed(
+                    error: "No view controller available for PayPal checkout."
+                )
+                snapshot.completion(result)
+                onCompletion(result)
+                return
+            }
+            let coordinator = PayPalCheckoutCoordinator(
+                returnURLString: snapshot.returnURLString,
+                cancelURLString: snapshot.cancelURLString,
+                completion: { [weak self] result in
+                    self?.activePayPalCheckout = nil
+                    snapshot.completion(result)
+                    onCompletion(result)
+                }
+            )
+            self.activePayPalCheckout = coordinator
+            self.payPalApprovalPresenter.presentPayPalApproval(
+                approvalURL: snapshot.approvalURL,
+                from: viewController,
+                checkoutCoordinator: coordinator
+            )
+        }
+        return true
+    }
+
     /// Called when forward-payment fails or cannot run, so a deferred built-in PayPal session does not leak.
     func cancelPendingBuiltInPayPalIfNeeded() {
         Self.pendingBuiltInPayPalLock.lock()
@@ -353,23 +413,24 @@ final class PaymentOrchestrator {
         preparation: PaymentPreparation
     ) -> [String: String] {
         let code = item.currency.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "USD" : item.currency
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = code
-
-        func moneyString(_ value: NSDecimalNumber) -> String {
-            formatter.string(from: value) ?? value.stringValue
-        }
-
-        let subtotal = preparation.totalAmount
-            .subtracting(preparation.tax)
-            .subtracting(preparation.shippingCost)
-        return [
-            "subtotal": moneyString(subtotal),
-            "tax": moneyString(preparation.tax),
-            "shipping": moneyString(preparation.shippingCost),
-            "total": moneyString(preparation.totalAmount)
-        ]
+        // Mirror the upsell item ``runInitializePurchase`` builds so subtotal reflects
+        // ``UpsellItem/totalPrice`` (single quantity-1 line item from the request) rather
+        // than `totalAmount − tax − shipping` arithmetic that drifts if backend tweaks rounding.
+        let upsell = UpsellItem(
+            cartItemId: "",
+            catalogItemId: item.id,
+            quantity: 1,
+            unitPrice: item.amount.decimalValue,
+            totalPrice: item.amount.decimalValue,
+            currency: code
+        )
+        return BreakdownFormatter.format(
+            upsellItems: [upsell],
+            shippingCost: preparation.shippingCost.decimalValue,
+            tax: preparation.tax.decimalValue,
+            totalAmount: preparation.totalAmount.decimalValue,
+            currency: code
+        )
     }
 
     private static func nonEmptyTrimmed(_ string: String?) -> String? {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -408,18 +408,25 @@ class RoktInternalImplementation {
             ))
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
 
-            // Map PaymentProvider -> PaymentMethodType
+            // Map PaymentProvider -> PaymentMethodType. Switching on the enum (not its
+            // rawValue) makes a future schema rename a compile-time error rather than a
+            // silent .default; @unknown default covers cases added in newer DcuiSchema versions.
             let paymentMethod: PaymentMethodType
-            switch event.paymentProvider.rawValue {
-            case "ApplePay":
+            switch event.paymentProvider {
+            case .applePay:
                 paymentMethod = .applePay
-            case "Stripe":
+            case .stripe:
                 paymentMethod = .card
-            case "Afterpay":
+            case .afterpay:
                 paymentMethod = .afterpay
-            case "Paypal", "PayPal":
+            case .paypal:
                 paymentMethod = .paypal
-            default:
+            case .googlePay:
+                RoktLogger.shared.error("GooglePay device-pay not supported on iOS")
+                devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
+                                   catalogItemId: event.catalogItemId, success: false)
+                return
+            @unknown default:
                 RoktLogger.shared.error("Unsupported payment provider: \(event.paymentProvider.rawValue)")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
                                    catalogItemId: event.catalogItemId, success: false)
@@ -619,6 +626,48 @@ class RoktInternalImplementation {
 
     func handleForwardPayment(executeId: String,
                               event: RoktUXEvent.CartItemForwardPayment) {
+        let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment {
+            [weak self] result in
+            guard let self else { return }
+            switch result.outcome {
+            case .succeeded:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: true,
+                    failureReason: nil
+                )
+            case .canceled:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: "User cancelled PayPal checkout"
+                )
+            case .failed:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: result.errorMessage ?? Self.unknownForwardPaymentFailureReason
+                )
+            @unknown default:
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: false,
+                    failureReason: Self.unknownForwardPaymentFailureReason
+                )
+            }
+        }
+        if presentedPayPal {
+            return
+        }
+
         let fulfillmentDetails = event.transactionData?.shippingAddress.map {
             FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
         }
@@ -629,7 +678,6 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
-            paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -648,25 +696,13 @@ class RoktInternalImplementation {
                 guard let self else { return }
                 self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(from: response)
-                if finalization.success {
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: true,
-                        failureReason: nil
-                    )
-                    self.paymentOrchestrator.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
-                } else {
-                    self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: false,
-                        failureReason: finalization.failureReason
-                    )
-                }
+                self.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: event.layoutId,
+                    catalogItemId: event.catalogItemId,
+                    success: finalization.success,
+                    failureReason: finalization.failureReason
+                )
             },
             failure: { [weak self] _, _, message in
                 guard let self else { return }
@@ -674,7 +710,6 @@ class RoktInternalImplementation {
                 let finalization = Self.resolveForwardPaymentFinalization(
                     fromFailureMessage: message
                 )
-                self.paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
                 self.forwardPaymentFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -626,8 +626,7 @@ class RoktInternalImplementation {
 
     func handleForwardPayment(executeId: String,
                               event: RoktUXEvent.CartItemForwardPayment) {
-        let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment {
-            [weak self] result in
+        let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment { [weak self] result in
             guard let self else { return }
             switch result.outcome {
             case .succeeded:

--- a/Tests/Rokt_WidgetTests/BreakdownFormatterTests.swift
+++ b/Tests/Rokt_WidgetTests/BreakdownFormatterTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class BreakdownFormatterTests: XCTestCase {
+    private let usLocale = Locale(identifier: "en_US")
+
+    private func upsellItem(unitPrice: Decimal, quantity: Decimal = 1) -> UpsellItem {
+        UpsellItem(
+            cartItemId: "cart1",
+            catalogItemId: "cat1",
+            quantity: quantity,
+            unitPrice: unitPrice,
+            totalPrice: unitPrice * quantity,
+            currency: "USD"
+        )
+    }
+
+    func test_format_subtotalSumsUpsellItemTotalPrices() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [
+                upsellItem(unitPrice: 10),
+                upsellItem(unitPrice: 5, quantity: 3)
+            ],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 25,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$25.00")
+    }
+
+    func test_format_USDproducesExpectedKeys() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: Decimal(string: "24.00")!)],
+            shippingCost: 0,
+            tax: Decimal(string: "1.94")!,
+            totalAmount: Decimal(string: "25.94")!,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$24.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.taxKey], "$1.94")
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "$25.94")
+    }
+
+    func test_format_EURusesProvidedCurrencyCode() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: 12)],
+            shippingCost: 3,
+            tax: 1,
+            totalAmount: 16,
+            currency: "EUR",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "€16.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "€3.00")
+    }
+
+    func test_format_zeroShippingAndTax() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [upsellItem(unitPrice: 9)],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 9,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$9.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.shippingKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.taxKey], "$0.00")
+        XCTAssertEqual(breakdown[BreakdownFormatter.totalKey], "$9.00")
+    }
+
+    func test_format_emptyUpsellItemsYieldsZeroSubtotal() {
+        let breakdown = BreakdownFormatter.format(
+            upsellItems: [],
+            shippingCost: 0,
+            tax: 0,
+            totalAmount: 0,
+            currency: "USD",
+            locale: usLocale
+        )
+
+        XCTAssertEqual(breakdown[BreakdownFormatter.subtotalKey], "$0.00")
+    }
+}

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -483,12 +483,16 @@ class TestPaymentOrchestrator: XCTestCase {
             cancelURL: "myapp://paypal/cancel"
         )
 
+        // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
+        // is weak, and the deferred ``DispatchQueue.main.async`` in
+        // ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded`` would otherwise see nil.
+        let viewController = UIViewController()
         sut.processPayment(
             method: .paypal,
             item: item,
             context: context,
             cartItemId: "v1:cart-paypal:canal",
-            from: UIViewController(),
+            from: viewController,
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
@@ -774,6 +778,10 @@ class TestPaymentOrchestrator: XCTestCase {
         PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
 
         let expectation = expectation(description: "PayPal completes via deep link callback")
+        // Hold the presenting VC strongly: ``PendingBuiltInPayPalWebCheckout/presentingViewController``
+        // is weak, and the deferred main-queue dispatch in ``presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded``
+        // would otherwise see nil and complete with .failed before the deep link arrives.
+        let viewController = UIViewController()
         sut.processPayment(
             method: .paypal,
             item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
@@ -783,7 +791,7 @@ class TestPaymentOrchestrator: XCTestCase {
                 cancelURL: nil
             ),
             cartItemId: "v1:cart:1",
-            from: UIViewController(),
+            from: viewController,
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { result in
             XCTAssertEqual(result.outcome, .succeeded)
@@ -792,7 +800,9 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         sut.presentPendingBuiltInPayPalAfterForwardPaymentSuccessIfNeeded()
 
-        let flush = expectation(description: "main queue flush for deferred PayPal coordinator")
+        // Disambiguate from the local `expectation` var declared above, which shadows
+        // ``XCTestCase/expectation(description:)`` and produced a build error in Brandon's commit.
+        let flush = self.expectation(description: "main queue flush for deferred PayPal coordinator")
         DispatchQueue.main.async { flush.fulfill() }
         wait(for: [flush], timeout: 1.0)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Immplement 

## What Has Changed

- PaymentOrchestrator: new presentPendingBuiltInPayPalForForwardPayment(onCompletion:) pops the cached pending checkout, presents the WKWebView, and falls back to UIApplication.topViewController() when the captured weak presentingViewController has been deallocated. Returns false for non-PayPal callers.
- RoktInternalImplementation.handleForwardPayment: PayPal short-circuit first; on coordinator outcome maps succeeded/canceled/failed to forwardPaymentFinalized. Card / Afterpay /v1/cart/purchase path with ShowLoadingIndicator is unchanged.
- RoktInternalImplementation: replace the dead-code String switch on paymentProvider rawValue ("Paypal", "PayPal") with an enum switch + @unknown default so future schema renames surface as compile errors instead of silent .default fallthroughs.
- PaymentOrchestrator: restore real preparation.approvalUrl extraction (the upstream commit hardcoded https://www.sandbox.paypal.com/signin and commented out URL validation). Cart prepare's paypalData.approvalUrl now flows to the WebView.
- BreakdownFormatter: extract the catalogRuntimeData formatter and switch subtotal to sum-of-upsellItems × quantity (matches what the SDK sent in cart prepare).
- TestPaymentOrchestrator: hold UIViewController strongly in two PayPal tests so the deferred async present sees a live VC (presentingViewController is weak). Disambiguate the shadowed local 'expectation' variable that broke the build.

## How Has This Been Tested

Describe the tests that you ran to verify your changes.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
