### PR TITLE
feat(payments): support built-in card forward payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 ### Changed
 
 - **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
-- **RoktUXHelper** SwiftPM: require [0.10.5](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.5)+ (replaces revision pin; includes PayPal confirmation / `devicePayShowConfirmation` from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.5`, `< 0.11`.
+- **RoktUXHelper** SwiftPM: require [0.10.6](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.6)+ (replaces revision pin; includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.6`, `< 0.11`.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
 - Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `payment_method` and `payment_provider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.1")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.5")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.6")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.1', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.10.5', '< 0.11'
+  s.dependency 'RoktUXHelper', '>= 0.10.6', '< 0.11'
 end

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -2,8 +2,11 @@ import Foundation
 import UIKit
 import RoktContracts
 
-/// Layout context and confirmation hook for built-in PayPal **device pay** (from the execute / device-pay path).
-struct BuiltInPayPalDevicePaySession {
+/// Layout context and confirmation hook for built-in **two-step device pay** flows (PayPal, Card).
+///
+/// Used to drive ``RoktUX/devicePayShowConfirmation`` from the orchestrator after Step-1
+/// (`initialize-purchase`) resolves, so the layout can transition to the Step-2 confirm button.
+struct BuiltInTwoStepDevicePaySession {
     let layoutId: String
     let catalogItemId: String
     let showConfirmation: (_ layoutId: String, _ catalogItemId: String, _ catalogRuntimeData: [String: String]) -> Void
@@ -28,7 +31,9 @@ final class PaymentOrchestrator {
     private static let builtInPayPalInitializePurchaseMethod = "PAYPAL"
     private static let builtInPayPalInitializePurchaseProvider = "PAYPAL"
 
-    private static let pendingBuiltInPayPalLock = NSLock()
+    private static let pendingBuiltInTwoStepLock = NSLock()
+
+    /// PayPal Step-1 cache: WebView context + deferred Step-1 completion fired on Step-2 resolve.
     private struct PendingBuiltInPayPalWebCheckout {
         weak var owner: PaymentOrchestrator?
         let approvalURL: URL
@@ -38,7 +43,20 @@ final class PaymentOrchestrator {
         let completion: (PaymentSheetResult) -> Void
     }
 
-    private static var pendingBuiltInPayPalWebCheckout: PendingBuiltInPayPalWebCheckout?
+    /// Card Step-1 cache: just the deferred completion. Step-2 dispatch lives in
+    /// ``RoktInternalImplementation.handleForwardPayment`` (POST `/v1/cart/purchase`); the
+    /// orchestrator only holds the completion so it can fire alongside ``forwardPaymentFinalized``.
+    private struct PendingBuiltInCardCheckout {
+        weak var owner: PaymentOrchestrator?
+        let completion: (PaymentSheetResult) -> Void
+    }
+
+    private enum PendingBuiltInTwoStepCheckout {
+        case paypal(PendingBuiltInPayPalWebCheckout)
+        case card(PendingBuiltInCardCheckout)
+    }
+
+    private static var pendingBuiltInTwoStepCheckout: PendingBuiltInTwoStepCheckout?
 
     static let builtInPayPalMissingDeferredSessionMessage =
         "Built-in PayPal device pay requires a layout session for confirmation (device pay hook)."
@@ -136,7 +154,8 @@ final class PaymentOrchestrator {
         context: PaymentContext,
         cartItemId: String,
         from viewController: UIViewController,
-        builtInPayPalDevicePaySession: BuiltInPayPalDevicePaySession? = nil,
+        builtInPayPalDevicePaySession: BuiltInTwoStepDevicePaySession? = nil,
+        builtInCardDevicePaySession: BuiltInTwoStepDevicePaySession? = nil,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         if method == .paypal {
@@ -146,6 +165,17 @@ final class PaymentOrchestrator {
                 cartItemId: cartItemId,
                 from: viewController,
                 devicePaySession: builtInPayPalDevicePaySession,
+                completion: completion
+            )
+            return
+        }
+
+        if method == .card, let cardSession = builtInCardDevicePaySession {
+            processBuiltInCardPayment(
+                item: item,
+                context: context,
+                cartItemId: cartItemId,
+                devicePaySession: cardSession,
                 completion: completion
             )
             return
@@ -194,14 +224,14 @@ final class PaymentOrchestrator {
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
     /// and `payment_method` / `payment_provider` as `PAYPAL` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
-    /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInPayPalDevicePaySession``) and defers the hosted
+    /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInTwoStepDevicePaySession``) and defers the hosted
     /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.
     private func processBuiltInPayPalPayment(
         item: PaymentItem,
         context: PaymentContext,
         cartItemId: String,
         from viewController: UIViewController,
-        devicePaySession: BuiltInPayPalDevicePaySession?,
+        devicePaySession: BuiltInTwoStepDevicePaySession?,
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         let contactAddress = Self.contactAddressForInitializePurchase(context: context)
@@ -238,7 +268,7 @@ final class PaymentOrchestrator {
                       !returnURL.isEmpty,
                       URL(string: returnURL) != nil
                 else {
-                    Self.clearPendingBuiltInPayPalStateUnderLock()
+                    Self.clearPendingBuiltInTwoStepStateUnderLock()
                     DispatchQueue.main.async {
                         completion(.failed(error: Self.payPalReturnURLMissingMessage))
                     }
@@ -256,9 +286,9 @@ final class PaymentOrchestrator {
                     presentingViewController: viewController,
                     completion: completion
                 )
-                Self.pendingBuiltInPayPalLock.lock()
-                Self.pendingBuiltInPayPalWebCheckout = pending
-                Self.pendingBuiltInPayPalLock.unlock()
+                Self.pendingBuiltInTwoStepLock.lock()
+                Self.pendingBuiltInTwoStepCheckout = .paypal(pending)
+                Self.pendingBuiltInTwoStepLock.unlock()
             case .failure(let error):
                 DispatchQueue.main.async {
                     completion(.failed(error: error.localizedDescription))
@@ -281,14 +311,16 @@ final class PaymentOrchestrator {
     func presentPendingBuiltInPayPalForForwardPayment(
         onCompletion: @escaping (PaymentSheetResult) -> Void
     ) -> Bool {
-        Self.pendingBuiltInPayPalLock.lock()
-        let snapshot = Self.pendingBuiltInPayPalWebCheckout
-        guard let snapshot, snapshot.owner === self else {
-            Self.pendingBuiltInPayPalLock.unlock()
+        Self.pendingBuiltInTwoStepLock.lock()
+        // Only consume PayPal entries; leave a card entry intact for ``popPendingBuiltInCardCompletion``.
+        guard case let .paypal(snapshot) = Self.pendingBuiltInTwoStepCheckout,
+              snapshot.owner === self
+        else {
+            Self.pendingBuiltInTwoStepLock.unlock()
             return false
         }
-        Self.pendingBuiltInPayPalWebCheckout = nil
-        Self.pendingBuiltInPayPalLock.unlock()
+        Self.pendingBuiltInTwoStepCheckout = nil
+        Self.pendingBuiltInTwoStepLock.unlock()
 
         DispatchQueue.main.async { [weak self] in
             guard let self else {
@@ -326,30 +358,98 @@ final class PaymentOrchestrator {
         return true
     }
 
-    /// Called when forward-payment fails or cannot run, so a deferred built-in PayPal session does not leak.
-    func cancelPendingBuiltInPayPalIfNeeded() {
-        Self.pendingBuiltInPayPalLock.lock()
-        let snapshot = Self.pendingBuiltInPayPalWebCheckout
-        Self.pendingBuiltInPayPalWebCheckout = nil
-        Self.pendingBuiltInPayPalLock.unlock()
+    /// Called when forward-payment fails or cannot run, so a deferred two-step session does not leak.
+    /// Fires the cached completion with a provider-appropriate cancellation message.
+    func cancelPendingBuiltInTwoStepIfNeeded() {
+        Self.pendingBuiltInTwoStepLock.lock()
+        let snapshot = Self.pendingBuiltInTwoStepCheckout
+        Self.pendingBuiltInTwoStepCheckout = nil
+        Self.pendingBuiltInTwoStepLock.unlock()
         guard let snapshot else { return }
         DispatchQueue.main.async {
-            snapshot.completion(.failed(error: "PayPal checkout was canceled."))
+            switch snapshot {
+            case .paypal(let pending):
+                pending.completion(.failed(error: "PayPal checkout was canceled."))
+            case .card(let pending):
+                pending.completion(.failed(error: "Card checkout was canceled."))
+            }
         }
+    }
+
+    // MARK: - Built-in Card forwarding (no PaymentExtension)
+
+    /// Entry point for Card device-pay (Step-1 of the two-step Card forward-payment flow).
+    ///
+    /// Runs the same cart ``initializePurchase`` preparation as PayPal but without `paymentMethod` /
+    /// `paymentProvider` overrides or return/cancel URLs (no hosted approval step). After cart prepare,
+    /// triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions to the Step-2 confirm
+    /// button, and caches `completion` so it can fire alongside ``forwardPaymentFinalized`` once
+    /// ``handleForwardPayment`` posts to `/v1/cart/purchase`.
+    private func processBuiltInCardPayment(
+        item: PaymentItem,
+        context: PaymentContext,
+        cartItemId: String,
+        devicePaySession: BuiltInTwoStepDevicePaySession,
+        completion: @escaping (PaymentSheetResult) -> Void
+    ) {
+        let contactAddress = Self.contactAddressForInitializePurchase(context: context)
+        preparePaymentForItem(
+            item: item,
+            cartItemId: cartItemId,
+            contactAddress: contactAddress,
+            returnURL: nil,
+            cancelURL: nil
+        ) { result in
+            switch result {
+            case .success(let preparation):
+                let catalogRuntimeData = Self.catalogRuntimeDataForDevicePayConfirmation(item: item, preparation: preparation)
+                devicePaySession.showConfirmation(devicePaySession.layoutId, devicePaySession.catalogItemId, catalogRuntimeData)
+
+                let pending = PendingBuiltInCardCheckout(owner: self, completion: completion)
+                Self.pendingBuiltInTwoStepLock.lock()
+                Self.pendingBuiltInTwoStepCheckout = .card(pending)
+                Self.pendingBuiltInTwoStepLock.unlock()
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    completion(.failed(error: error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    /// Card-only forward-payment hook: pop the cached Step-1 completion so the caller can
+    /// fire it after `/v1/cart/purchase` resolves.
+    ///
+    /// Card has no orchestrator-driven Step-2 (no WebView). ``handleForwardPayment`` runs the
+    /// standard `/v1/cart/purchase` path; this method just hands back the deferred completion
+    /// so device-pay finalization can chain off the same response.
+    ///
+    /// - Returns: the cached completion when the pending checkout was a card flow owned by
+    ///   this orchestrator; `nil` otherwise (so PayPal entries are left intact).
+    func popPendingBuiltInCardCompletion() -> ((PaymentSheetResult) -> Void)? {
+        Self.pendingBuiltInTwoStepLock.lock()
+        defer { Self.pendingBuiltInTwoStepLock.unlock() }
+        guard case let .card(snapshot) = Self.pendingBuiltInTwoStepCheckout,
+              snapshot.owner === self
+        else {
+            return nil
+        }
+        Self.pendingBuiltInTwoStepCheckout = nil
+        return snapshot.completion
     }
 
     // Clears static deferred state without invoking a completion (unit tests).
     // periphery:ignore
-    static func resetBuiltInPayPalDeferredStateForTesting() {
-        pendingBuiltInPayPalLock.lock()
-        pendingBuiltInPayPalWebCheckout = nil
-        pendingBuiltInPayPalLock.unlock()
+    static func resetBuiltInTwoStepDeferredStateForTesting() {
+        pendingBuiltInTwoStepLock.lock()
+        pendingBuiltInTwoStepCheckout = nil
+        pendingBuiltInTwoStepLock.unlock()
     }
 
-    private static func clearPendingBuiltInPayPalStateUnderLock() {
-        pendingBuiltInPayPalLock.lock()
-        pendingBuiltInPayPalWebCheckout = nil
-        pendingBuiltInPayPalLock.unlock()
+    private static func clearPendingBuiltInTwoStepStateUnderLock() {
+        pendingBuiltInTwoStepLock.lock()
+        pendingBuiltInTwoStepCheckout = nil
+        pendingBuiltInTwoStepLock.unlock()
     }
 
     private static func catalogRuntimeDataForDevicePayConfirmation(

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -412,6 +412,9 @@ class RoktInternalImplementation {
             // rawValue) makes a future schema rename a compile-time error rather than a
             // silent .default; @unknown default covers cases added in newer DcuiSchema versions.
             let paymentMethod: PaymentMethodType
+            // Card schema and Stripe schema both map to PaymentMethodType.card today;
+            // routes diverge in processPayment via builtInCardDevicePaySession (set only for `.card`).
+            let isBuiltInCardForwarding = (event.paymentProvider == .card)
             switch event.paymentProvider {
             case .applePay:
                 paymentMethod = .applePay
@@ -421,6 +424,8 @@ class RoktInternalImplementation {
                 paymentMethod = .afterpay
             case .paypal:
                 paymentMethod = .paypal
+            case .card:
+                paymentMethod = .card
             case .googlePay:
                 RoktLogger.shared.error("GooglePay device-pay not supported on iOS")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
@@ -474,6 +479,19 @@ class RoktInternalImplementation {
                     returnURL: returnURL,
                     cancelURL: cancelURL
                 )
+            case .card where isBuiltInCardForwarding:
+                // Built-in card forwarding needs shipping/billing for /v1/cart/purchase but
+                // no hosted-approval return/cancel URLs (Step-2 is a direct API call).
+                let billing = buildContactAddress(from: event.transactionData?.billingAddress)
+                    ?? buildContactAddressFromAttributes()
+                let shipping = buildContactAddress(from: event.transactionData?.shippingAddress)
+                    ?? buildContactAddressFromAttributes()
+                context = PaymentContext(
+                    billingAddress: billing,
+                    shippingAddress: shipping,
+                    returnURL: nil,
+                    cancelURL: nil
+                )
             default:
                 context = PaymentContext()
             }
@@ -486,8 +504,8 @@ class RoktInternalImplementation {
                 return
             }
 
-            let paypalSession: BuiltInPayPalDevicePaySession? = paymentMethod == .paypal
-                ? BuiltInPayPalDevicePaySession(
+            let twoStepSessionFactory: (() -> BuiltInTwoStepDevicePaySession) = {
+                BuiltInTwoStepDevicePaySession(
                     layoutId: event.layoutId,
                     catalogItemId: event.catalogItemId,
                     showConfirmation: { [weak self] layoutId, catalogItemId, catalogRuntimeData in
@@ -501,16 +519,23 @@ class RoktInternalImplementation {
                         )
                     }
                 )
+            }
+            let paypalSession: BuiltInTwoStepDevicePaySession? = paymentMethod == .paypal
+                ? twoStepSessionFactory()
+                : nil
+            let cardSession: BuiltInTwoStepDevicePaySession? = isBuiltInCardForwarding
+                ? twoStepSessionFactory()
                 : nil
 
-            // Process the payment via the registered extension
+            // Process the payment via the registered extension or built-in two-step flow
             paymentOrchestrator.processPayment(
                 method: paymentMethod,
                 item: item,
                 context: context,
                 cartItemId: event.cartItemId,
                 from: viewController,
-                builtInPayPalDevicePaySession: paypalSession
+                builtInPayPalDevicePaySession: paypalSession,
+                builtInCardDevicePaySession: cardSession
             ) { [weak self] result in
                 let success = result.outcome == .succeeded
                 if success {
@@ -667,6 +692,10 @@ class RoktInternalImplementation {
             return
         }
 
+        // Built-in card forwarding caches its Step-1 completion in PaymentOrchestrator;
+        // pop it here so device-pay finalization can chain off the same `/v1/cart/purchase` outcome.
+        let cardStepOneCompletion = paymentOrchestrator.popPendingBuiltInCardCompletion()
+
         let fulfillmentDetails = event.transactionData?.shippingAddress.map {
             FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
         }
@@ -677,7 +706,8 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
-            paymentOrchestrator.cancelPendingBuiltInPayPalIfNeeded()
+            paymentOrchestrator.cancelPendingBuiltInTwoStepIfNeeded()
+            cardStepOneCompletion?(.failed(error: Self.missingForwardPaymentPriceReason))
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -696,6 +726,11 @@ class RoktInternalImplementation {
                 guard let self else { return }
                 self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(from: response)
+                if finalization.success {
+                    cardStepOneCompletion?(.succeeded(transactionId: ""))
+                } else {
+                    cardStepOneCompletion?(.failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason))
+                }
                 self.forwardPaymentFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,
@@ -710,6 +745,7 @@ class RoktInternalImplementation {
                 let finalization = Self.resolveForwardPaymentFinalization(
                     fromFailureMessage: message
                 )
+                cardStepOneCompletion?(.failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason))
                 self.forwardPaymentFinalized(
                     executeId: executeId,
                     layoutId: event.layoutId,

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -109,22 +109,22 @@ class TestPaymentOrchestrator: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        PaymentOrchestrator.resetBuiltInPayPalDeferredStateForTesting()
+        PaymentOrchestrator.resetBuiltInTwoStepDeferredStateForTesting()
         sut = PaymentOrchestrator()
         PaymentOrchestratorAPIHelperSpy.reset()
     }
 
     override func tearDown() {
         sut = nil
-        PaymentOrchestrator.resetBuiltInPayPalDeferredStateForTesting()
+        PaymentOrchestrator.resetBuiltInTwoStepDeferredStateForTesting()
         PaymentOrchestratorAPIHelperSpy.reset()
         super.tearDown()
     }
 
     private func paypalDeviceSessionForTests(
         onConfirmation: ((String, String, [String: String]) -> Void)? = nil
-    ) -> BuiltInPayPalDevicePaySession {
-        BuiltInPayPalDevicePaySession(layoutId: "test_layout", catalogItemId: "test_catalog") { lid, cid, data in
+    ) -> BuiltInTwoStepDevicePaySession {
+        BuiltInTwoStepDevicePaySession(layoutId: "test_layout", catalogItemId: "test_catalog") { lid, cid, data in
             onConfirmation?(lid, cid, data)
         }
     }
@@ -671,6 +671,111 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
+    }
+
+    // MARK: - Built-in Card forwarding (two-step)
+
+    func test_processPayment_card_routesToBuiltInCardFlowWithoutExtension() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let confirmationExpectation = expectation(description: "Card showConfirmation fires after prepare")
+        var confirmationData: [String: String]?
+        let cardSession = BuiltInTwoStepDevicePaySession(
+            layoutId: "test_layout",
+            catalogItemId: "test_catalog"
+        ) { _, _, data in
+            confirmationData = data
+            confirmationExpectation.fulfill()
+        }
+
+        let item = PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD")
+        sut.processPayment(
+            method: .card,
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-card:canal",
+            from: UIViewController(),
+            builtInCardDevicePaySession: cardSession
+        ) { _ in
+            // Step-1 completion is held until popPendingBuiltInCardCompletion fires it.
+            XCTFail("Card Step-1 completion fired before Step-2 popped it")
+        }
+
+        wait(for: [confirmationExpectation], timeout: 1.0)
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
+        // Card flow does NOT pass payment_method/payment_provider overrides — those are PayPal-specific.
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL)
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL)
+        XCTAssertNotNil(confirmationData)
+    }
+
+    func test_popPendingBuiltInCardCompletion_returnsCompletionAndClearsCache() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let confirmationExpectation = expectation(description: "Card showConfirmation fires")
+        let cardSession = BuiltInTwoStepDevicePaySession(
+            layoutId: "test_layout",
+            catalogItemId: "test_catalog"
+        ) { _, _, _ in
+            confirmationExpectation.fulfill()
+        }
+
+        let stepOneCompletionExpectation = expectation(description: "Step-1 completion fires once popped")
+        sut.processPayment(
+            method: .card,
+            item: PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD"),
+            context: PaymentContext(),
+            cartItemId: "v1:cart-card:canal",
+            from: UIViewController(),
+            builtInCardDevicePaySession: cardSession
+        ) { result in
+            XCTAssertEqual(result.outcome, .succeeded)
+            stepOneCompletionExpectation.fulfill()
+        }
+        wait(for: [confirmationExpectation], timeout: 1.0)
+
+        guard let popped = sut.popPendingBuiltInCardCompletion() else {
+            XCTFail("Expected card Step-1 completion to be available after prepare")
+            return
+        }
+        // Second pop should return nil — cache is one-shot.
+        XCTAssertNil(sut.popPendingBuiltInCardCompletion())
+
+        popped(.succeeded(transactionId: "card_txn"))
+        wait(for: [stepOneCompletionExpectation], timeout: 1.0)
+    }
+
+    func test_popPendingBuiltInCardCompletion_returnsNilWhenCacheHoldsPayPal() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let viewController = UIViewController()
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "item-pp", name: "Widget", amount: 9.99, currency: "USD"),
+            context: PaymentContext(
+                billingAddress: nil,
+                shippingAddress: nil,
+                returnURL: "myapp://paypal/success",
+                cancelURL: "myapp://paypal/cancel"
+            ),
+            cartItemId: "v1:cart-pp:canal",
+            from: viewController,
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
+        ) { _ in }
+
+        // PayPal cache is set; popPendingBuiltInCardCompletion must NOT consume it.
+        XCTAssertNil(sut.popPendingBuiltInCardCompletion())
+        XCTAssertTrue(sut.presentPendingBuiltInPayPalForForwardPayment { _ in })
     }
 
     private static func validInitializePurchaseResponse() -> InitializePurchaseResponse {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Add built-in two-step card handling alongside the existing PayPal device-pay flow so card confirmation can be deferred until forward payment completes.

## What Has Changed

Update the SwiftPM and CocoaPods dependency requirements to RoktUXHelper 0.10.6 now that the needed UXHelper changes are available in a tagged release, and document the new minimum in the changelog.

## How Has This Been Tested

Tested locally

## Notes


## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
