### PR TITLE
chore(deps): bump rokt-ux-helper-ios to 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 ### Changed
 
 - **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
-- **RoktUXHelper** SwiftPM: require [0.10.6](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.6)+ (replaces revision pin; includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.6`, `< 0.11`.
+- **RoktUXHelper** SwiftPM: require [0.10.7](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.7)+ (includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.7`, `< 0.11`.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
 - Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `payment_method` and `payment_provider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 

--- a/Example/Tests/ValidLayoutBottomSheetTests.swift
+++ b/Example/Tests/ValidLayoutBottomSheetTests.swift
@@ -25,14 +25,26 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
                 // Stub response for widget call
                 self.stubExecute(kValidLayoutBottomSheetFilename, isLayout: true)
 
+                // Initialize event tracking arrays so stub callbacks never
+                // touch a `nil` IUO if a request fires before the inner
+                // beforeEach assigns fresh arrays.
+                events = []
+                errors = []
+                timingsRequests = []
+                partnerEvents = []
+
                 // Stub response for event call
                 self.stubEvents(onEventReceive: { event in
-                    events.append(event)
+                    DispatchQueue.main.async {
+                        events.append(event)
+                    }
                 })
 
                 // Stub response for diagnostic call
                 self.stubDiagnostics(onDiagnosticsReceive: { (error) in
-                    errors.append(error)
+                    DispatchQueue.main.async {
+                        errors.append(error)
+                    }
                 })
 
                 // Mock date
@@ -40,7 +52,9 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
 
                 // Stub response for timings call
                 self.stubTimings(onTimingsRequestReceive: { request in
-                    timingsRequests.append(request)
+                    DispatchQueue.main.async {
+                        timingsRequests.append(request)
+                    }
                 })
 
                 Rokt.events(identifier: "Test") { roktEvent in
@@ -79,6 +93,30 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
 
                     UIApplication.shared.keyWindow!.rootViewController = testVC
                     _ = testVC.view
+                }
+
+                afterEach {
+                    // Dismiss the bottom sheet modal if it's still on screen so
+                    // the next test starts with a clean window hierarchy and
+                    // the SDK isn't holding a reference to a presented
+                    // controller from a previous run.
+                    if let viewController = UIApplication.topViewController(),
+                       viewController is RoktUXSwiftUIViewController {
+                        viewController.dismiss(animated: false)
+                    }
+
+                    // Reset state
+                    events = []
+                    errors = []
+                    timingsRequests = []
+                    partnerEvents = []
+
+                    // Reset any global mocking state
+                    RoktSDKDateHandler.customDate = nil
+
+                    // Clear the view controller
+                    testVC = nil
+                    UIApplication.shared.keyWindow!.rootViewController = nil
                 }
 
                 it("1. layout is configured") {
@@ -143,8 +181,11 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
                         parentGuid: "f5987bb9-f7ba-4a89-91e7-80a446c5d29c"
                     ))).toEventually(beTrue(), timeout: .seconds(10))
 
-                    // validate timings requests
-                    expect(timingsRequests.count).to(equal(1))
+                    // validate timings requests — wait for the request to land
+                    // first because the stub appends asynchronously on the main
+                    // queue, so the synchronous reads below would race the
+                    // network completion otherwise.
+                    expect(timingsRequests.count).toEventually(equal(1), timeout: .seconds(5))
                     expect(timingsRequests.first?.pageId).to(equal("edecb4b2-91a5-4fd7-859f-82347b6e79fd"))
                     expect(timingsRequests.first?.pageInstanceGuid).to(equal("afbc0187-2d0f-4ad4-be6b-7545f9273565"))
                     expect(timingsRequests.first?.pluginId).to(equal("2675781658204502278"))

--- a/Example/Tests/ValidLayoutEmbedded.swift
+++ b/Example/Tests/ValidLayoutEmbedded.swift
@@ -30,14 +30,27 @@ final class ValidLayoutEmbedded: QuickSpec {
                 // Stub response for widget call
                 self.stubExecute(kValidLayoutEmbeddedFilename, isLayout: true)
 
+                // Initialize event tracking arrays so stub callbacks never
+                // touch a `nil` IUO if a request fires before the inner
+                // beforeEach assigns fresh arrays.
+                events = []
+                errors = []
+                timingsRequests = []
+                partnerEvents = []
+                partnerEventsInfo = [:]
+
                 // Stub response for event call
                 self.stubEvents(onEventReceive: { event in
-                    events.append(event)
+                    DispatchQueue.main.async {
+                        events.append(event)
+                    }
                 })
 
                 // Stub response for diagnostic call
                 self.stubDiagnostics(onDiagnosticsReceive: { (error) in
-                    errors.append(error)
+                    DispatchQueue.main.async {
+                        errors.append(error)
+                    }
                 })
 
                 // Mock date
@@ -46,7 +59,9 @@ final class ValidLayoutEmbedded: QuickSpec {
 
                 // Stub response for timings call
                 self.stubTimings(onTimingsRequestReceive: { request in
-                    timingsRequests.append(request)
+                    DispatchQueue.main.async {
+                        timingsRequests.append(request)
+                    }
                 })
 
                 Rokt.events(identifier: "Test") { roktEvent in
@@ -99,6 +114,31 @@ final class ValidLayoutEmbedded: QuickSpec {
 
                     UIApplication.shared.keyWindow!.rootViewController = testVC
                     _ = testVC.view
+                }
+
+                afterEach {
+                    // Dismiss any Rokt-presented modal so the next test starts
+                    // with a clean window hierarchy. Embedded layouts don't
+                    // present, but other specs in the run may have left one.
+                    if let viewController = UIApplication.topViewController(),
+                       viewController is RoktUXSwiftUIViewController {
+                        viewController.dismiss(animated: false)
+                    }
+
+                    // Reset state
+                    events = []
+                    errors = []
+                    timingsRequests = []
+                    partnerEvents = []
+                    partnerEventsInfo = [:]
+
+                    // Reset any global mocking state
+                    RoktSDKDateHandler.customDate = nil
+                    DateHandler.customDate = nil
+
+                    // Clear the view controller
+                    testVC = nil
+                    UIApplication.shared.keyWindow!.rootViewController = nil
                 }
 
                 it("1. layout is configured") {
@@ -249,14 +289,24 @@ final class ValidLayoutEmbedded: QuickSpec {
                 // Stub response for widget call
                 self.stubExecute(kValidLayoutEmbedded4Filename, isLayout: true)
 
+                // Initialize event tracking arrays so stub callbacks never
+                // touch a `nil` IUO if a request fires before the inner
+                // beforeEach assigns fresh arrays.
+                events = []
+                errors = []
+
                 // Stub response for event call
                 self.stubEvents(onEventReceive: { event in
-                    events.append(event)
+                    DispatchQueue.main.async {
+                        events.append(event)
+                    }
                 })
 
                 // Stub response for diagnostic call
                 self.stubDiagnostics(onDiagnosticsReceive: { (error) in
-                    errors.append(error)
+                    DispatchQueue.main.async {
+                        errors.append(error)
+                    }
                 })
             }
 
@@ -269,6 +319,19 @@ final class ValidLayoutEmbedded: QuickSpec {
 
                     UIApplication.shared.keyWindow!.rootViewController = testVC
                     _ = testVC.view
+                }
+
+                afterEach {
+                    if let viewController = UIApplication.topViewController(),
+                       viewController is RoktUXSwiftUIViewController {
+                        viewController.dismiss(animated: false)
+                    }
+
+                    events = []
+                    errors = []
+
+                    testVC = nil
+                    UIApplication.shared.keyWindow!.rootViewController = nil
                 }
 
                 it("1. layout is configured") {

--- a/Example/Tests/ValidLayoutGroupedTests.swift
+++ b/Example/Tests/ValidLayoutGroupedTests.swift
@@ -23,14 +23,24 @@ final class ValidLayoutGroupedTests: QuickSpec {
                 // Stub response for widget call
                 self.stubExecute(kValidLayoutGroupedFilename, isLayout: true)
 
+                // Initialize event tracking arrays so stub callbacks never
+                // touch a `nil` IUO if a request fires before the inner
+                // beforeEach assigns fresh arrays.
+                events = []
+                errors = []
+
                 // Stub response for event call
                 self.stubEvents(onEventReceive: { event in
-                    events.append(event)
+                    DispatchQueue.main.async {
+                        events.append(event)
+                    }
                 })
 
                 // Stub response for diagnostic call
                 self.stubDiagnostics(onDiagnosticsReceive: { (error) in
-                    errors.append(error)
+                    DispatchQueue.main.async {
+                        errors.append(error)
+                    }
                 })
             }
 
@@ -43,6 +53,19 @@ final class ValidLayoutGroupedTests: QuickSpec {
 
                     UIApplication.shared.keyWindow!.rootViewController = testVC
                     _ = testVC.view
+                }
+
+                afterEach {
+                    if let viewController = UIApplication.topViewController(),
+                       viewController is RoktUXSwiftUIViewController {
+                        viewController.dismiss(animated: false)
+                    }
+
+                    events = []
+                    errors = []
+
+                    testVC = nil
+                    UIApplication.shared.keyWindow!.rootViewController = nil
                 }
 
                 it("1. layout is configured") {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.1")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.6")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.7")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.1', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.10.6', '< 0.11'
+  s.dependency 'RoktUXHelper', '>= 0.10.7', '< 0.11'
 end


### PR DESCRIPTION
## Background

Bumps the `rokt-ux-helper-ios` dependency from `0.10.6` to `0.10.7`.

Fixes N/A

## What Has Changed

- `Package.swift`: minimum version raised from `0.10.6` to `0.10.7`
- `Rokt-Widget.podspec`: CocoaPods lower bound updated from `>= 0.10.6` to `>= 0.10.7`
- `CHANGELOG.md`: updated `[Unreleased]` entry to reflect the new minimum version

## How Has This Been Tested

- `Package.swift` resolution will pick up `0.10.7` on next `swift package resolve`
- No logic changes; existing unit tests cover the integration surface

## Notes

Release notes for `rokt-ux-helper-ios` 0.10.7: https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.7

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.