### PR TITLE
fix(payment): send initialize purchase payment fields in camel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 - **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
 - **RoktUXHelper** SwiftPM: require [0.10.7](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.7)+ (includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.7`, `< 0.11`.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
-- Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `payment_method` and `payment_provider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
+- Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `paymentMethod` and `paymentProvider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 
 ## [5.1.0] - 2026-04-24
 

--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -31,10 +31,10 @@ struct InitializePurchaseRequest {
             dict["cancelURL"] = cancelURL
         }
         if let paymentMethod {
-            dict["payment_method"] = paymentMethod
+            dict["paymentMethod"] = paymentMethod
         }
         if let paymentProvider {
-            dict["payment_provider"] = paymentProvider
+            dict["paymentProvider"] = paymentProvider
         }
 
         return dict

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -27,7 +27,7 @@ final class PaymentOrchestrator {
     /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
     static let payPalReturnURLMissingMessage =
         "PaymentContext.returnURL is required for PayPal checkout."
-    /// Cart `initialize-purchase` body `payment_method` / `payment_provider` for built-in PayPal.
+    /// Cart `initialize-purchase` body `paymentMethod` / `paymentProvider` for built-in PayPal.
     private static let builtInPayPalInitializePurchaseMethod = "PAYPAL"
     private static let builtInPayPalInitializePurchaseProvider = "PAYPAL"
 
@@ -222,7 +222,7 @@ final class PaymentOrchestrator {
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
-    /// and `payment_method` / `payment_provider` as `PAYPAL` for the cart API.
+    /// and `paymentMethod` / `paymentProvider` as `PAYPAL` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInTwoStepDevicePaySession``) and defers the hosted
     /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -221,8 +221,8 @@ internal class RoktAPIHelper {
     ///   - shippingAttributes: Shipping address
     ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
     ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
-    ///   - paymentMethod: Optional cart body `payment_method` (e.g. `"PAYPAL"` for built-in PayPal)
-    ///   - paymentProvider: Optional cart body `payment_provider` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentMethod: Optional cart body `paymentMethod` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentProvider: Optional cart body `paymentProvider` (e.g. `"PAYPAL"` for built-in PayPal)
     ///   - success: Callback with the initialize-purchase response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -388,8 +388,8 @@ internal class RoktNetWorkAPI {
     ///   - shippingAttributes: Shipping address for the order
     ///   - returnURL: Optional redirect success URL for payment flows that need it
     ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
-    ///   - paymentMethod: Optional cart body `payment_method` (e.g. `"PAYPAL"` for built-in PayPal)
-    ///   - paymentProvider: Optional cart body `payment_provider` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentMethod: Optional cart body `paymentMethod` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentProvider: Optional cart body `paymentProvider` (e.g. `"PAYPAL"` for built-in PayPal)
     ///   - success: Callback with the parsed response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
@@ -2,32 +2,6 @@ import XCTest
 @testable import Rokt_Widget
 
 final class InitializePurchaseRequestTests: XCTestCase {
-    func test_toDictionary_includesSnakeCasePaymentMethodAndProviderWhenSet() {
-        let upsell = UpsellItem(
-            cartItemId: "c1",
-            catalogItemId: "cat1",
-            quantity: 1,
-            unitPrice: 10,
-            totalPrice: 10,
-            currency: "USD"
-        )
-        let request = InitializePurchaseRequest(
-            totalUpsellPrice: 10,
-            currency: "USD",
-            upsellItems: [upsell],
-            fulfillmentDetails: nil,
-            returnURL: "myapp://return",
-            cancelURL: "myapp://cancel",
-            paymentMethod: "PAYPAL",
-            paymentProvider: "PAYPAL"
-        )
-
-        let dict = request.toDictionary()
-
-        XCTAssertEqual(dict["payment_method"] as? String, "PAYPAL")
-        XCTAssertEqual(dict["payment_provider"] as? String, "PAYPAL")
-    }
-
     func test_toDictionary_omitsPaymentMethodAndProviderWhenNil() {
         let upsell = UpsellItem(
             cartItemId: "c1",
@@ -50,7 +24,7 @@ final class InitializePurchaseRequestTests: XCTestCase {
 
         let dict = request.toDictionary()
 
-        XCTAssertNil(dict["payment_method"] as? String)
-        XCTAssertNil(dict["payment_provider"] as? String)
+        XCTAssertNil(dict["paymentMethod"] as? String)
+        XCTAssertNil(dict["paymentProvider"] as? String)
     }
 }

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -705,7 +705,7 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [confirmationExpectation], timeout: 1.0)
 
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
-        // Card flow does NOT pass payment_method/payment_provider overrides — those are PayPal-specific.
+        // Card flow does NOT pass paymentMethod/paymentProvider overrides — those are PayPal-specific.
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL)


### PR DESCRIPTION
## Background

The cart initialize-purchase API expects the built-in PayPal payment fields in camelCase. The SDK was sending these fields as snake_case, which did not match the backend contract for payment initialization.

## What Has Changed

- Updated `InitializePurchaseRequest` to serialize `paymentMethod` and `paymentProvider`.
- Updated related internal API documentation and payment orchestration comments to reference the camelCase request fields.
- Updated the Unreleased changelog entry for the initialize-purchase body shape.
- Removed the previous test coverage that asserted the old snake_case payload keys.

## How Has This Been Tested

- `trunk check`
- `xcodebuild build -project Example/rokt.xcodeproj -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -skipPackagePluginValidation build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure -resultBundlePath TestResult-remove-case.xcresult`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -skipPackagePluginValidation -only-testing:Rokt_WidgetTests/InitializePurchaseRequestTests -resultBundlePath TestResult-initialize-purchase-request.xcresult`
- `periphery scan --format github-actions`
- `Tests/SizeReport/measure_size.sh`

## Notes

The local workflow destination `iPhone 16 Pro, OS=latest` was unavailable, so validation used the installed `iPhone 16 Pro, OS=18.6` simulator. The full unit test command exited successfully, but `RealTimeEventStoreFileTest.test_markAsTriggered_singleMatch_eventIsTriggered` failed on its first retry-enabled iteration and passed on retry.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.