### PR TITLE
feat(payment): enrich available payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 - Forward PayPal `paypalData.approvalUrl` from initialize-purchase into `PaymentPreparation` when present (depends on **RoktContracts** 2.0.1+).
 - Built-in PayPal device pay: after cart prepare, call **RoktUX** `devicePayShowConfirmation` (layout confirmation + `DATA.catalogRuntime.*` from [rokt-ux-helper-ios#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)); defer the hosted **approve** `WKWebView` until **`/v1/cart/purchase`** forward-payment succeeds, then present approval and complete via `PaymentContext` return/cancel and `Rokt.handleURLCallback`. Swappable `PayPalApprovalPresenting` remains for tests.
 - `Rokt.setBuiltInPayPalRedirectURLScheme(_:)` — **required** for built-in PayPal **device pay**: composes return/cancel as `\(scheme)://rokt-paypal-return` and `\(scheme)://rokt-paypal-cancel` (bare scheme must appear under `CFBundleURLSchemes` in `Info.plist`). Pass `nil` only to clear configuration (PayPal device pay will not proceed until set again).
+- Automatically enrich experience requests with `availablePaymentMethods`, including registered extension methods, built-in card forwarding, and built-in PayPal when its redirect URL scheme is configured.
 
 ### Changed
 

--- a/Example/rokt/ShoppableAdsDemoViewController.swift
+++ b/Example/rokt/ShoppableAdsDemoViewController.swift
@@ -278,10 +278,11 @@ final class ShoppableAdsDemoViewController: UITableViewController {
             appendLog("Missing Apple Pay merchant ID.")
             return
         }
-        guard let ext = RoktPaymentExtension(applePayMerchantId: merchantId) else {
+        guard let ext = RoktPaymentExtension(applePayMerchantId: merchantId, urlScheme: "com.rokt.example") else {
             appendLog("RoktPaymentExtension init returned nil.")
             return
         }
+        Rokt.setBuiltInPayPalRedirectURLScheme("com.rokt.example")
         registeredExtension = ext
         roktClient.registerPaymentExtension(ext, config: ["stripeKey": stripeKey])
         appendLog("Registered RoktPaymentExtension (merchantId=\(merchantId)).")

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -112,12 +112,15 @@ final class PaymentOrchestrator {
         !registeredExtensions.isEmpty
     }
 
-    /// All available payment methods across all registered extensions, plus built-in PayPal.
-    func availablePaymentMethods() -> [PaymentMethodType] {
+    /// All available payment methods across registered extensions, plus enabled built-in payment forwarding methods.
+    func availablePaymentMethods(isBuiltInPayPalAvailable: Bool = true) -> [PaymentMethodType] {
         var methods = Set(
             registeredExtensions.flatMap { $0.supportedMethods }.compactMap { PaymentMethodType(wireValue: $0) }
         )
-        methods.insert(.paypal)
+        methods.insert(.card)
+        if isBuiltInPayPalAvailable {
+            methods.insert(.paypal)
+        }
         return PaymentMethodType.allCases.filter { methods.contains($0) }
     }
 

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -79,6 +79,9 @@ class RoktInternalImplementation {
     private var builtInPayPalRedirectURLScheme: String?
 
     var isPaymentExtensionRegistered: Bool { paymentOrchestrator.hasRegisteredExtension }
+    var availablePaymentMethods: [PaymentMethodType] {
+        paymentOrchestrator.availablePaymentMethods(isBuiltInPayPalAvailable: builtInPayPalRedirectURLScheme != nil)
+    }
 
     func close() {
         guard let window = UIApplication.shared.windows.filter({$0.isKeyWindow}).first,

--- a/Sources/Rokt_Widget/Util/AttributeEnrichment.swift
+++ b/Sources/Rokt_Widget/Util/AttributeEnrichment.swift
@@ -10,7 +10,10 @@ struct AttributeEnrichment {
         ApplePayAttributeEnricher(),
         ColorModeAttributeEnricher(),
         StripeAttributeEnricher(),
-        PaymentExtensionAttributeEnricher { Rokt.shared.roktImplementation.isPaymentExtensionRegistered }
+        PaymentExtensionAttributeEnricher(
+            provider: { Rokt.shared.roktImplementation.isPaymentExtensionRegistered },
+            availablePaymentMethodsProvider: { Rokt.shared.roktImplementation.availablePaymentMethods }
+        )
     ])
     let enrichers: [AttributeEnricher]
 

--- a/Sources/Rokt_Widget/Util/PaymentExtensionAttributeEnricher.swift
+++ b/Sources/Rokt_Widget/Util/PaymentExtensionAttributeEnricher.swift
@@ -1,23 +1,36 @@
 import Foundation
+import RoktContracts
 
 private let BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY = "paymentExtensionRegistered"
+private let BE_AVAILABLE_PAYMENT_METHODS_KEY = "availablePaymentMethods"
 
-/// Enriches experience requests with whether a payment extension has been registered.
+/// Enriches experience requests with payment extension availability.
 ///
-/// Downstream systems use this attribute to determine whether Shoppable Ads requiring
-/// a payment extension can be presented to the user.
+/// Downstream systems use these attributes to determine whether Shoppable Ads requiring
+/// payment handling can be presented to the user.
 ///
 /// - Returns:
-///  - `"true"` for `paymentExtensionActivated` when a payment extension is registered.
-///  - `"false"` for `paymentExtensionActivated` when no payment extension is registered.
+///  - `"true"` for `paymentExtensionRegistered` when a payment extension is registered.
+///  - `"false"` for `paymentExtensionRegistered` when no payment extension is registered.
+///  - Comma-separated method wire values for `availablePaymentMethods`.
 class PaymentExtensionAttributeEnricher: AttributeEnricher {
     private let provider: () -> Bool
+    private let availablePaymentMethodsProvider: () -> [PaymentMethodType]
 
-    init(provider: @escaping () -> Bool) {
+    init(
+        provider: @escaping () -> Bool,
+        availablePaymentMethodsProvider: @escaping () -> [PaymentMethodType]
+    ) {
         self.provider = provider
+        self.availablePaymentMethodsProvider = availablePaymentMethodsProvider
     }
 
     func enrich(config: RoktConfig?) -> [String: String] {
-        return [BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY: String(provider())]
+        return [
+            BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY: String(provider()),
+            BE_AVAILABLE_PAYMENT_METHODS_KEY: availablePaymentMethodsProvider()
+                .map(\.wireValue)
+                .joined(separator: ",")
+        ]
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestPaymentExtensionAttributeEnricher.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestPaymentExtensionAttributeEnricher.swift
@@ -1,7 +1,9 @@
 import XCTest
+import RoktContracts
 @testable import Rokt_Widget
 
 private let BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY = "paymentExtensionRegistered"
+private let BE_AVAILABLE_PAYMENT_METHODS_KEY = "availablePaymentMethods"
 
 class TestPaymentExtensionAttributeEnricher: XCTestCase {
 
@@ -19,44 +21,68 @@ class TestPaymentExtensionAttributeEnricher: XCTestCase {
 
     func testEnrich_withPaymentExtensionRegistered_shouldReturnTrue() {
         // Given
-        let sut = PaymentExtensionAttributeEnricher(provider: { true })
+        let sut = PaymentExtensionAttributeEnricher(
+            provider: { true },
+            availablePaymentMethodsProvider: { [.card, .paypal] }
+        )
 
         // When
         let attributes = sut.enrich(config: mockConfig)
 
         // Then
-        XCTAssertEqual(attributes.count, 1, "Should contain one key.")
+        XCTAssertEqual(attributes.count, 2, "Should contain payment extension and available payment method keys.")
         XCTAssertEqual(
             attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "true",
-            "paymentExtensionActivated should be true when a payment extension is registered."
+            "paymentExtensionRegistered should be true when a payment extension is registered."
         )
     }
 
     func testEnrich_withNoPaymentExtensionRegistered_shouldReturnFalse() {
         // Given
-        let sut = PaymentExtensionAttributeEnricher(provider: { false })
+        let sut = PaymentExtensionAttributeEnricher(
+            provider: { false },
+            availablePaymentMethodsProvider: { [.card, .paypal] }
+        )
 
         // When
         let attributes = sut.enrich(config: mockConfig)
 
         // Then
-        XCTAssertEqual(attributes.count, 1, "Should contain one key.")
+        XCTAssertEqual(attributes.count, 2, "Should contain payment extension and available payment method keys.")
         XCTAssertEqual(
             attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "false",
-            "paymentExtensionActivated should be false when no payment extension is registered."
+            "paymentExtensionRegistered should be false when no payment extension is registered."
         )
     }
 
     func testEnrich_withNilConfig_shouldStillReturnAttribute() {
         // Given
-        let sut = PaymentExtensionAttributeEnricher(provider: { true })
+        let sut = PaymentExtensionAttributeEnricher(
+            provider: { true },
+            availablePaymentMethodsProvider: { [.card, .paypal] }
+        )
 
         // When
         let attributes = sut.enrich(config: nil)
 
         // Then
-        XCTAssertEqual(attributes.count, 1, "Should contain one key regardless of config.")
+        XCTAssertEqual(attributes.count, 2, "Should contain both keys regardless of config.")
         XCTAssertEqual(attributes[BE_IS_PAYMENT_EXTENSION_REGISTERED_KEY], "true")
+    }
+
+    func testEnrich_withAvailablePaymentMethods_shouldReturnWireValues() {
+        // Given
+        let methods: [PaymentMethodType] = [.applePay, .card, .paypal]
+        let sut = PaymentExtensionAttributeEnricher(
+            provider: { true },
+            availablePaymentMethodsProvider: { methods }
+        )
+
+        // When
+        let attributes = sut.enrich(config: mockConfig)
+
+        // Then
+        XCTAssertEqual(attributes[BE_AVAILABLE_PAYMENT_METHODS_KEY], methods.map(\.wireValue).joined(separator: ","))
     }
 
     func testEnrich_providerIsCalledOnEachEnrich() {
@@ -65,6 +91,8 @@ class TestPaymentExtensionAttributeEnricher: XCTestCase {
         let sut = PaymentExtensionAttributeEnricher(provider: {
             callCount += 1
             return true
+        }, availablePaymentMethodsProvider: {
+            [.card, .paypal]
         })
 
         // When

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -228,9 +228,15 @@ class TestPaymentOrchestrator: XCTestCase {
 
     // MARK: - availablePaymentMethods
 
-    func test_availablePaymentMethods_builtinPayPalOnly_whenNoExtensionsRegistered() {
+    func test_availablePaymentMethods_builtinDefaults_whenNoExtensionsRegistered() {
         let methods = sut.availablePaymentMethods()
-        XCTAssertEqual(Set(methods), Set([.paypal]))
+        XCTAssertEqual(Set(methods), Set([.card, .paypal]))
+        XCTAssertEqual(methods.count, 2)
+    }
+
+    func test_availablePaymentMethods_excludesPayPalWhenBuiltInPayPalUnavailable() {
+        let methods = sut.availablePaymentMethods(isBuiltInPayPalAvailable: false)
+        XCTAssertEqual(Set(methods), Set([.card]))
         XCTAssertEqual(methods.count, 1)
     }
 
@@ -600,6 +606,11 @@ class TestPaymentOrchestrator: XCTestCase {
     func test_availablePaymentMethods_includesPayPalWhenNoExtensionsRegistered() {
         let methods = sut.availablePaymentMethods()
         XCTAssertTrue(methods.contains(.paypal))
+    }
+
+    func test_availablePaymentMethods_includesCardForwardingWhenNoExtensionsRegistered() {
+        let methods = sut.availablePaymentMethods()
+        XCTAssertTrue(methods.contains(.card))
     }
 
     func test_handleURLCallback_builtinPayPalPlaceholder_defersToExtensions() {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Foundation
+import RoktContracts
 @testable internal import RoktUXHelper
 
 @testable import Rokt_Widget
@@ -139,6 +140,33 @@ class TestRokt: XCTestCase {
             roktInternalImplementation.sessionManager.getCurrentSessionIdWithoutExpiring(),
             "existing-session-id"
         )
+    }
+
+    // MARK: - availablePaymentMethods Tests
+
+    func test_availablePaymentMethods_excludesPayPalBeforeRedirectSchemeIsSet() {
+        let roktInternalImplementation = RoktInternalImplementation()
+
+        let methods = roktInternalImplementation.availablePaymentMethods
+
+        XCTAssertEqual(Set(methods), Set([PaymentMethodType.card]))
+    }
+
+    func test_availablePaymentMethods_includesPayPalAfterRedirectSchemeIsSet() {
+        let roktInternalImplementation = RoktInternalImplementation()
+
+        XCTAssertTrue(roktInternalImplementation.setBuiltInPayPalRedirectURLScheme("myapp"))
+
+        XCTAssertEqual(Set(roktInternalImplementation.availablePaymentMethods), Set([.card, .paypal]))
+    }
+
+    func test_availablePaymentMethods_excludesPayPalAfterRedirectSchemeIsCleared() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        XCTAssertTrue(roktInternalImplementation.setBuiltInPayPalRedirectURLScheme("myapp"))
+
+        XCTAssertTrue(roktInternalImplementation.setBuiltInPayPalRedirectURLScheme(nil))
+
+        XCTAssertEqual(Set(roktInternalImplementation.availablePaymentMethods), Set([PaymentMethodType.card]))
     }
 
     // MARK: - getSessionId Tests


### PR DESCRIPTION
## Background

Experience requests currently only report whether a payment extension is registered. This change also reports which payment methods are actually available so backend selection can account for built-in card forwarding, registered extension methods, and built-in PayPal only after its redirect scheme has been configured.

Fixes N/A

## What Has Changed

- Added `availablePaymentMethods` enrichment alongside `paymentExtensionRegistered`.
- Included built-in card forwarding by default in available methods.
- Gated built-in PayPal availability on a successfully configured redirect URL scheme.
- Updated the Shoppable Ads example to register the payment extension with the URL scheme initializer.
- Added unit coverage for payment method wire values, built-in defaults, and PayPal scheme gating.
- Added an Unreleased changelog entry.

## How Has This Been Tested

- `trunk check "CHANGELOG.md" "Sources/Rokt_Widget/Util/AttributeEnrichment.swift" "Sources/Rokt_Widget/Util/PaymentExtensionAttributeEnricher.swift" "Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift" "Sources/Rokt_Widget/RoktInternalImplementation.swift" "Tests/Rokt_WidgetTests/Shared/Util/TestPaymentExtensionAttributeEnricher.swift" "Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift" "Tests/Rokt_WidgetTests/TestRokt.swift"`
- `trunk check "Example/rokt/ShoppableAdsDemoViewController.swift"`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -skipPackagePluginValidation`
- `xcodebuild -project "Example/rokt.xcodeproj" -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -quiet build CODE_SIGNING_ALLOWED=NO`
- `Tests/SizeReport/measure_size.sh`

## Notes

The working tree still contains unrelated local/untracked files that are not included in this PR.

Size report result: SDK bundle delta remains 4716 KB.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.