### PR TITLE
fix(example): forward payment return URLs to SDK

### DIFF
--- a/Example/rokt/AppDelegate.swift
+++ b/Example/rokt/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Rokt_Widget
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -6,6 +7,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         print(url)
-        return true
+        return Rokt.handleURLCallback(with: url)
     }
 }


### PR DESCRIPTION
## Background

The example app receives redirect URLs after browser-based payment authorization, including Afterpay/Clearpay returns from Stripe. Before this change, `AppDelegate` printed the incoming URL and returned `true`, but did not forward it to the Rokt SDK, so registered payment extensions never received the callback.

## What Has Changed

- Imported `Rokt_Widget` in `Example/rokt/AppDelegate.swift`.
- Forwarded incoming application URLs to `Rokt.handleURLCallback(with:)` so payment extensions can complete redirect-based flows.

## How Has This Been Tested

- `trunk check Example/rokt/AppDelegate.swift` passed.
- `xcodebuild -project Example/rokt.xcodeproj -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -quiet build CODE_SIGNING_ALLOWED=NO` passed.
- Full `trunk check` was blocked by unrelated untracked `.playwright-mcp` logs with detected JWTs.
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -skipPackagePluginValidation` ran 433 tests with one unrelated existing `TestShoppableAds` assertion failure (`adsExperience` vs `adExperience`).

## Notes

No visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.