### PR TITLE
test: stabilize mocked UI tests

### DIFF
--- a/Example/Tests/APIErrorTests.swift
+++ b/Example/Tests/APIErrorTests.swift
@@ -90,8 +90,7 @@ class APIErrorTests: QuickSpec {
 
                 testVC = TestViewController()
 
-                UIApplication.shared.keyWindow!.rootViewController = testVC
-                _ = testVC.view
+                testVC.installInTestWindow()
             }
 
             it("is not shown after widget call retries") {
@@ -102,7 +101,7 @@ class APIErrorTests: QuickSpec {
 
             afterEach {
                 testVC = nil
-                UIApplication.shared.keyWindow!.rootViewController = nil
+                UIViewController.clearTestWindowRoot()
             }
         }
     }

--- a/Example/Tests/InvalidWidgetTests.swift
+++ b/Example/Tests/InvalidWidgetTests.swift
@@ -33,8 +33,7 @@ class InvalidWidgetTests: QuickSpec {
 
                 testVC = TestViewController()
 
-                UIApplication.shared.keyWindow!.rootViewController = testVC
-                _ = testVC.view
+                testVC.installInTestWindow()
 
             }
 
@@ -49,7 +48,7 @@ class InvalidWidgetTests: QuickSpec {
 
             afterEach {
                 testVC = nil
-                UIApplication.shared.keyWindow!.rootViewController = nil
+                UIViewController.clearTestWindowRoot()
             }
         }
     }

--- a/Example/Tests/ValidLayoutBottomSheetTests.swift
+++ b/Example/Tests/ValidLayoutBottomSheetTests.swift
@@ -91,8 +91,7 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
                     partnerEvents = []
                     testVC = TestViewController()
 
-                    UIApplication.shared.keyWindow!.rootViewController = testVC
-                    _ = testVC.view
+                    testVC.installInTestWindow()
                 }
 
                 afterEach {
@@ -116,7 +115,7 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
 
                     // Clear the view controller
                     testVC = nil
-                    UIApplication.shared.keyWindow!.rootViewController = nil
+                    UIViewController.clearTestWindowRoot()
                 }
 
                 it("1. layout is configured") {

--- a/Example/Tests/ValidLayoutEmbedded.swift
+++ b/Example/Tests/ValidLayoutEmbedded.swift
@@ -112,8 +112,7 @@ final class ValidLayoutEmbedded: QuickSpec {
                     testVC = TestViewController()
                     testVC.pageInitAttr = invalidPageInitDateEpoch
 
-                    UIApplication.shared.keyWindow!.rootViewController = testVC
-                    _ = testVC.view
+                    testVC.installInTestWindow()
                 }
 
                 afterEach {
@@ -138,7 +137,7 @@ final class ValidLayoutEmbedded: QuickSpec {
 
                     // Clear the view controller
                     testVC = nil
-                    UIApplication.shared.keyWindow!.rootViewController = nil
+                    UIViewController.clearTestWindowRoot()
                 }
 
                 it("1. layout is configured") {
@@ -242,34 +241,34 @@ final class ValidLayoutEmbedded: QuickSpec {
                     // validate timings request sent
                     expect(timingsRequests.contains(expectedTimingsRequest)).toEventually(beTrue(), timeout: .seconds(9))
 
-                    let matchedTimingsRequest = timingsRequests[timingsRequests.lastIndex(of: expectedTimingsRequest)!]
+                    let matchedTimingsRequest = timingsRequests.first(where: { $0 == expectedTimingsRequest })
                     // validate timings request contains all expected metrics
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.initStart.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.initEnd.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.selectionStart.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.selectionEnd.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.experiencesRequestStart.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.experiencesRequestEnd.rawValue, value: timingsDateEpoch
                     )).toEventually(beTrue())
                     // only for placement interactive as this went through UXHelper, thus it gets converted from date -> String -> date -> String,
                     // since its only accurate up to millisecond, the 100th microsecond can be lost
                     let roundedDate = String(Int((timingsDate.timeIntervalSince1970 * 1000).rounded()))
-                    expect(matchedTimingsRequest.getValueInTimings(name: TimingType.placementInteractive.rawValue))
+                    expect(matchedTimingsRequest?.getValueInTimings(name: TimingType.placementInteractive.rawValue))
                         .toEventually(equal(roundedDate))
 
                     // timings request ignores pageInit timestamp outside of valid range
-                    expect(matchedTimingsRequest.containNameValueInTimings(
+                    expect(matchedTimingsRequest?.containNameValueInTimings(
                         name: TimingType.pageInit.rawValue, value: timingsDateEpoch
                     )).toEventually(beFalse())
                 }
@@ -317,8 +316,7 @@ final class ValidLayoutEmbedded: QuickSpec {
                     errors = []
                     testVC = TestViewController()
 
-                    UIApplication.shared.keyWindow!.rootViewController = testVC
-                    _ = testVC.view
+                    testVC.installInTestWindow()
                 }
 
                 afterEach {
@@ -331,7 +329,7 @@ final class ValidLayoutEmbedded: QuickSpec {
                     errors = []
 
                     testVC = nil
-                    UIApplication.shared.keyWindow!.rootViewController = nil
+                    UIViewController.clearTestWindowRoot()
                 }
 
                 it("1. layout is configured") {

--- a/Example/Tests/ValidLayoutGroupedTests.swift
+++ b/Example/Tests/ValidLayoutGroupedTests.swift
@@ -51,8 +51,7 @@ final class ValidLayoutGroupedTests: QuickSpec {
                     errors = []
                     testVC = TestViewController()
 
-                    UIApplication.shared.keyWindow!.rootViewController = testVC
-                    _ = testVC.view
+                    testVC.installInTestWindow()
                 }
 
                 afterEach {
@@ -65,7 +64,7 @@ final class ValidLayoutGroupedTests: QuickSpec {
                     errors = []
 
                     testVC = nil
-                    UIApplication.shared.keyWindow!.rootViewController = nil
+                    UIViewController.clearTestWindowRoot()
                 }
 
                 it("1. layout is configured") {

--- a/Example/Tests/ValidLayoutOverlayTests.swift
+++ b/Example/Tests/ValidLayoutOverlayTests.swift
@@ -114,8 +114,7 @@ final class ValidLayoutOverlayTests: QuickSpec {
                     testVC = TestViewController()
                     testVC.pageInitAttr = timingsDateEpoch
 
-                    UIApplication.shared.keyWindow!.rootViewController = testVC
-                    _ = testVC.view
+                    testVC.installInTestWindow()
                 }
 
                 afterEach {
@@ -139,7 +138,7 @@ final class ValidLayoutOverlayTests: QuickSpec {
 
                     // Clear the view controller
                     testVC = nil
-                    UIApplication.shared.keyWindow!.rootViewController = nil
+                    UIViewController.clearTestWindowRoot()
                 }
 
                 it("1. layout is configured") {

--- a/Example/Tests/ViewControllers/TestViewController.swift
+++ b/Example/Tests/ViewControllers/TestViewController.swift
@@ -12,6 +12,7 @@ class TestViewController: UIViewController {
     var cutOffParentSize: CGSize?
     var pageInitAttr: String?
     var embeddedLocation1, embeddedLocation2, embeddedLocation4: RoktEmbeddedView!
+    private var didStartSDKExecution = false
 
     override func viewDidLoad() {
         intitialSDK()
@@ -27,6 +28,8 @@ class TestViewController: UIViewController {
     }
 
     fileprivate func executeSDK() {
+        guard !didStartSDKExecution else { return }
+        didStartSDKExecution = true
         attachEmbeddedLocations()
         let placements: [String: RoktEmbeddedView] = ["Location1": embeddedLocation1,
                                                       "Location2": embeddedLocation2,
@@ -91,4 +94,29 @@ class TestViewController: UIViewController {
         }
     }
 
+}
+
+extension TestViewController {
+    func installInTestWindow() {
+        guard let window = UIApplication.shared.roktTestWindow else { return }
+        window.rootViewController = self
+        window.makeKeyAndVisible()
+        loadViewIfNeeded()
+        executeSDK()
+    }
+}
+
+extension UIViewController {
+    static func clearTestWindowRoot() {
+        UIApplication.shared.roktTestWindow?.rootViewController = nil
+    }
+}
+
+private extension UIApplication {
+    var roktTestWindow: UIWindow? {
+        let windows = connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+        return windows.first(where: \.isKeyWindow) ?? windows.first
+    }
 }


### PR DESCRIPTION
## Background

PR UI builds were occasionally failing in the mocked layout tests because the tests assigned `TestViewController` as the root view controller and only forced the view to load. The SDK execution path lives in `viewDidAppear`, which is not guaranteed to run from that setup in CI. When it did not run, layouts were never presented or attached, expected events/timings requests were missing, and one timing assertion could crash the test process while unwrapping a missing request.

## What Has Changed

- Added a shared test-window installation helper for `TestViewController` that deterministically starts SDK execution.
- Guarded `TestViewController` execution so UIKit appearance callbacks and the test helper cannot trigger duplicate SDK executions.
- Updated mocked layout/error tests to use the shared helper and shared root cleanup.
- Replaced the timing request force unwrap with an optional lookup so missing requests fail as assertions instead of crashing the test process.

## How Has This Been Tested

- `trunk check`
- `xcodebuild -project Example/rokt.xcodeproj -scheme Rokt-Widget -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -enableCodeCoverage YES -skipPackagePluginValidation -resultBundlePath .context/TestResult.xcresult`
- `xcodebuild test -project Example/rokt.xcodeproj -scheme rokt-Example-MOCK -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -enableCodeCoverage YES -skipPackagePluginValidation -resultBundlePath .context/UiTestResult.xcresult -retry-tests-on-failure`
- `xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"`
- `periphery scan`
- `Tests/SizeReport/measure_size.sh`

## Notes

Investigated from failing GitHub Actions job: https://github.com/ROKT/rokt-sdk-ios/actions/runs/25673619213/job/75365429197#step:4:11243

Size report:

- Baseline app bundle: 84 KB
- App bundle with SDK: 4804 KB
- SDK impact: 4720 KB

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
