### PR TITLE
fix(payment): send contact names to payment extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
 - Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `paymentMethod` and `paymentProvider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 
+### Fixed
+
+- Populate payment extension contact names from first and last name attributes when transaction data omits the address name.
+
 ## [5.2.0] - 2026-05-07
 
 ### Added

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -167,7 +167,7 @@ class RoktInternalImplementation {
     func buildContactAddress(from address: RoktUXHelper.Address?) -> ContactAddress? {
         guard let address else { return nil }
         return ContactAddress(
-            name: address.name,
+            name: resolvedContactName(address.name),
             email: attributes["email"] ?? "",
             addressLine1: address.address1,
             city: address.city,
@@ -183,11 +183,8 @@ class RoktInternalImplementation {
     func buildContactAddressFromAttributes() -> ContactAddress? {
         let line1 = attributes["shippingaddress1"] ?? ""
         guard !line1.isEmpty else { return nil }
-        let name = [attributes["firstname"], attributes["lastname"]]
-            .compactMap { $0 }
-            .joined(separator: " ")
         return ContactAddress(
-            name: name,
+            name: contactNameFromAttributes(),
             email: attributes["email"] ?? "",
             addressLine1: line1,
             city: attributes["shippingcity"],
@@ -195,6 +192,26 @@ class RoktInternalImplementation {
             postalCode: attributes["shippingzipcode"],
             country: attributes["shippingcountry"]
         )
+    }
+
+    private func resolvedContactName(_ name: String) -> String {
+        if let trimmed = nonEmptyTrimmed(name) {
+            return trimmed
+        }
+
+        return contactNameFromAttributes()
+    }
+
+    private func contactNameFromAttributes() -> String {
+        [attributes["firstname"], attributes["lastname"]]
+            .compactMap(nonEmptyTrimmed)
+            .joined(separator: " ")
+    }
+
+    private func nonEmptyTrimmed(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed
     }
 
     /// Configures the host app’s custom URL scheme for built-in PayPal return/cancel deep links.

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -255,6 +255,40 @@ class TestRokt: XCTestCase {
         XCTAssertEqual(contactAddress?.country, "US")
     }
 
+    func test_buildContactAddress_fallsBackToAttributeNameWhenTransactionDataNameIsEmpty() throws {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.attributes = [
+            "firstname": "Jane",
+            "lastname": "Doe",
+            "email": "jane@example.com"
+        ]
+
+        let address = try JSONDecoder().decode(
+            Address.self,
+            from: Data(
+                """
+                {
+                  "name": "",
+                  "address1": "123 Test St",
+                  "address2": null,
+                  "city": "New York",
+                  "state": "New York",
+                  "stateCode": "NY",
+                  "country": "United States",
+                  "countryCode": "US",
+                  "zip": "10001"
+                }
+                """.utf8
+            )
+        )
+
+        let contactAddress = roktInternalImplementation.buildContactAddress(from: address)
+
+        XCTAssertEqual(contactAddress?.name, "Jane Doe")
+        XCTAssertEqual(contactAddress?.email, "jane@example.com")
+        XCTAssertEqual(contactAddress?.addressLine1, "123 Test St")
+    }
+
     func test_buildContactAddressFromAttributes_mapsLegacyShippingAttributes() {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.attributes = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Payment extensions can receive transaction data addresses with an empty contact name even when the host app provides first and last name attributes. This leaves downstream payment providers, including Stripe integrations, without the shipping or billing name needed for their API calls. This change fills that gap without changing the public SDK API or adding dependencies.

## What Has Changed

- Populate `ContactAddress.name` from trimmed `firstname` and `lastname` attributes when transaction data omits or sends an empty address name.
- Reuse the same trimmed attribute-name construction for legacy shipping-address fallback data.
- Add unit coverage for payment-extension contact address mapping when transaction data contains an empty name.
- Add a changelog entry for the partner-visible fix.

## How Has This Been Tested

- `trunk check` passed.
- `xcodebuild -project Example/rokt.xcodeproj -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -skipPackagePluginValidation build CODE_SIGNING_ALLOWED=NO` passed.
- Started `xcodebuild test -scheme Rokt-Widget ...`; the run was stopped locally after stalling in unrelated networking/init tests. The new contact-name fallback test passed before the run was stopped.
- Full unit tests, periphery, and size report will run on CI.

## Notes

No visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
