### PR TITLE
fix: report payment extension failures in diagnostics

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -189,6 +189,8 @@ final class PaymentOrchestrator {
             return
         }
 
+        var lastPreparePaymentFailureMessage: String?
+
         // The preparePayment callback bridges the completion-handler pattern
         // to the SDK's backend API call (initializePurchase)
         let preparePayment: (ContactAddress, @escaping (PaymentPreparation?, Error?) -> Void)
@@ -202,8 +204,10 @@ final class PaymentOrchestrator {
             ) { result in
                 switch result {
                 case .success(let preparation):
+                    lastPreparePaymentFailureMessage = nil
                     prepareCompletion(preparation, nil)
                 case .failure(let error):
+                    lastPreparePaymentFailureMessage = error.localizedDescription
                     prepareCompletion(nil, error)
                 }
             }
@@ -215,7 +219,18 @@ final class PaymentOrchestrator {
             context: context,
             from: viewController,
             preparePayment: preparePayment,
-            completion: completion
+            completion: { [weak self] result in
+                if result.outcome == .failed,
+                   result.errorMessage != lastPreparePaymentFailureMessage {
+                    self?.sendPaymentFailureDiagnostics(
+                        method: method,
+                        item: item,
+                        cartItemId: cartItemId,
+                        result: result
+                    )
+                }
+                completion(result)
+            }
         )
     }
 
@@ -484,6 +499,28 @@ final class PaymentOrchestrator {
         guard let string else { return nil }
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func sendPaymentFailureDiagnostics(
+        method: PaymentMethodType,
+        item: PaymentItem,
+        cartItemId: String,
+        result: PaymentSheetResult
+    ) {
+        let errorMessage = result.errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let callStack = errorMessage?.isEmpty == false
+            ? errorMessage ?? ""
+            : "Payment extension failed without an error message"
+        apiHelper.sendDiagnostics(
+            message: Self.devicePayErrorCode,
+            callStack: callStack,
+            severity: .warning,
+            additionalInfo: [
+                "paymentMethod": method.wireValue,
+                "cartItemId": cartItemId,
+                "catalogItemId": item.id
+            ]
+        )
     }
 
     /// Prefer shipping, then billing, for cart shipping attributes; otherwise a minimal placeholder.

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -349,6 +349,51 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func test_processPayment_extensionFailure_sendsDiagnostics() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.afterpay])
+        ext.paymentResultToReturn = .failed(
+            error: "The PaymentMethod provided is not allowed (Stripe paymentIntentId: pi_test123)"
+        )
+        sut.register(ext, config: [:])
+
+        let expectation = expectation(description: "Payment completes with failure")
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 9.99, currency: "USD")
+
+        sut.processPayment(
+            method: .afterpay,
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-456:canal",
+            from: UIViewController()
+        ) { result in
+            XCTAssertEqual(result.outcome, .failed)
+            XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.sendDiagnosticsCallCount, 1)
+            XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastDiagnosticsMessage, PaymentOrchestrator.devicePayErrorCode)
+            XCTAssertEqual(
+                PaymentOrchestratorAPIHelperSpy.lastDiagnosticsCallStack,
+                "The PaymentMethod provided is not allowed (Stripe paymentIntentId: pi_test123)"
+            )
+            XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastDiagnosticsSeverity, .warning)
+            XCTAssertEqual(
+                PaymentOrchestratorAPIHelperSpy.lastDiagnosticsAdditionalInfo?["paymentMethod"] as? String,
+                PaymentMethodType.afterpay.wireValue
+            )
+            XCTAssertEqual(
+                PaymentOrchestratorAPIHelperSpy.lastDiagnosticsAdditionalInfo?["cartItemId"] as? String,
+                "v1:cart-456:canal"
+            )
+            XCTAssertEqual(
+                PaymentOrchestratorAPIHelperSpy.lastDiagnosticsAdditionalInfo?["catalogItemId"] as? String,
+                "item1"
+            )
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func test_processPayment_preparePayment_plumbsTotalAmountTaxAndShipping() {
         sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
 
@@ -966,6 +1011,8 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
     static var sendDiagnosticsCallCount = 0
     static var lastDiagnosticsMessage: String?
     static var lastDiagnosticsCallStack: String?
+    static var lastDiagnosticsSeverity: Severity?
+    static var lastDiagnosticsAdditionalInfo: [String: Any]?
 
     static func reset() {
         initializePurchaseResponse = nil
@@ -977,6 +1024,8 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         sendDiagnosticsCallCount = 0
         lastDiagnosticsMessage = nil
         lastDiagnosticsCallStack = nil
+        lastDiagnosticsSeverity = nil
+        lastDiagnosticsAdditionalInfo = nil
     }
 
     override class func initializePurchase(
@@ -1019,6 +1068,8 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         sendDiagnosticsCallCount += 1
         lastDiagnosticsMessage = message
         lastDiagnosticsCallStack = callStack
+        lastDiagnosticsSeverity = severity
+        lastDiagnosticsAdditionalInfo = additionalInfo
         success?()
     }
 }


### PR DESCRIPTION
## Background

Payment extension checkout failures that happen after the sheet is presented were not always emitting the existing device-pay diagnostic event. That left extension-side checkout failures harder to trace from SDK telemetry and made it harder to distinguish them from initialize-purchase failures.

## What Has Changed

- Track the last `preparePayment` failure message so initialize-purchase failures are not reported twice.
- Send the existing device-pay warning diagnostic when a payment extension returns a failed sheet result, including the payment method, cart item ID, and catalog item ID.
- Add a regression test that verifies the diagnostic payload for a failed payment-extension checkout.

## How Has This Been Tested

- `trunk check --ci`
- `xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -skipPackagePluginValidation build CODE_SIGNING_ALLOWED=NO ENABLE_BITCODE=NO`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure`
- `xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED=NO ENABLE_BITCODE=NO DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=YES INDEX_ENABLE_DATA_STORE=YES`
- `periphery scan --format github-actions`
- `Tests/SizeReport/measure_size.sh --json`

## Notes

Attached screenshot:

![Payment extension failure screenshot](https://gist.githubusercontent.com/thomson-t/5a89fa6c75bcd9bf9012f7255f66d4a0/raw/6c922a13ad924e85dac1690340c8e3ded0ed47a8/payment-extension-failure.png)

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
