### PR TITLE
chore(deps): update Rokt payment package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 ### Changed
 
 - **RoktContracts** SwiftPM dependency: require [2.0.1](https://github.com/ROKT/rokt-contracts-apple/releases/tag/2.0.1)+ (replaces branch pin). CocoaPods spec now requires RoktContracts `>= 2.0.1`, `< 3.0`.
-- **RoktUXHelper** SwiftPM: require [0.10.7](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.7)+ (includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.7`, `< 0.11`.
+- **RoktUXHelper** SwiftPM: require [0.10.8](https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.8)+ (includes card payment provider support from [#267](https://github.com/ROKT/rokt-ux-helper-ios/pull/267) alongside the PayPal confirmation / `devicePayShowConfirmation` changes from [#265](https://github.com/ROKT/rokt-ux-helper-ios/pull/265)). CocoaPods spec now requires RoktUXHelper `>= 0.10.8`, `< 0.11`.
 - Built-in PayPal device pay no longer reads return/cancel URLs from placement **`TransactionData`** metadata or execute **attributes**; the scheme-based URLs above are the only source.
 - Cart **`/v1/cart/initialize-purchase`** for built-in PayPal now sends `paymentMethod` and `paymentProvider` as `PAYPAL` in the JSON body (extension-based Shoppable Ads prepare calls omit these keys).
 

--- a/Example/rokt.xcodeproj/project.pbxproj
+++ b/Example/rokt.xcodeproj/project.pbxproj
@@ -2070,7 +2070,7 @@
 			repositoryURL = "https://github.com/ROKT/rokt-payment-extension-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.1;
+				minimumVersion = 2.0.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.1")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.7")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.8")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.1', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.10.7', '< 0.11'
+  s.dependency 'RoktUXHelper', '>= 0.10.8', '< 0.11'
 end


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

RoktUXHelper 0.10.8 and Rokt Payment Extension 2.0.2 have been released. This updates the SDK dependency floors so SwiftPM, CocoaPods, and the sample app resolve the newer released package versions.

## What Has Changed

- Updated the SwiftPM RoktUXHelper minimum version to 0.10.8.
- Updated the CocoaPods RoktUXHelper dependency floor to 0.10.8.
- Updated the sample app Rokt Payment Extension package minimum version to 2.0.2.
- Updated the Unreleased changelog entry to reflect the new RoktUXHelper dependency floor.

## How Has This Been Tested

- Verified the upstream `rokt-ux-helper-ios` 0.10.8 and `rokt-payment-extension-ios` 2.0.2 tags exist.
- Ran `git diff --check`.
- Full local validation was not run per request.

## Notes

No visual changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
