### PR TITLE
build(deps): update Rokt payment dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 ### Changed
 
 - Require `RoktContracts` 2.0.2 or later.
+- Require `RoktUXHelper` 0.10.10 or later.
+- Update the Shoppable Ads example payment extension to `RoktPaymentExtension` 2.0.3.
 
 ## [5.2.1] - 2026-05-12
 

--- a/Example/rokt.xcodeproj/project.pbxproj
+++ b/Example/rokt.xcodeproj/project.pbxproj
@@ -2070,7 +2070,7 @@
 			repositoryURL = "https://github.com/ROKT/rokt-payment-extension-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.2;
+				minimumVersion = 2.0.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.8")),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.10")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.2', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.10.8', '< 0.11'
+  s.dependency 'RoktUXHelper', '>= 0.10.10', '< 0.11'
 end


### PR DESCRIPTION
## Background

RoktUXHelper 0.10.10 and RoktPaymentExtension 2.0.3 have been released. This PR updates the SDK dependency minimums and example app package reference so Shoppable Ads integrations use the latest helper and payment extension fixes.

## What Has Changed

- Raised the Swift Package Manager `rokt-ux-helper-ios` minimum version to 0.10.10.
- Raised the CocoaPods `RoktUXHelper` lower bound to 0.10.10 while keeping the existing `< 0.11` upper bound.
- Updated the example app's `rokt-payment-extension-ios` package minimum version to 2.0.3.
- Added Unreleased changelog entries for the helper dependency and example payment extension updates.

## How Has This Been Tested

- `trunk check`
- `xcodebuild build -project Example/rokt.xcodeproj -scheme rokt-Example -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme Rokt-Widget -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -enableCodeCoverage YES -skipPackagePluginValidation` — 442 tests passed
- `xcodebuild test -project Example/rokt.xcodeproj -scheme rokt-Example-MOCK -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -enableCodeCoverage YES -skipPackagePluginValidation -retry-tests-on-failure`
- `periphery scan --format github-actions`
- `Tests/SizeReport/measure_size.sh` — SDK impact 4,736 KB, executable delta 4,832,656 bytes
- Visual testing: N/A — no visual behavior changes

## Notes

- RoktUXHelper release: https://github.com/ROKT/rokt-ux-helper-ios/releases/tag/0.10.10
- RoktPaymentExtension release: https://github.com/ROKT/rokt-payment-extension-ios/releases/tag/2.0.3

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.