### PR TITLE
feat(payment): send paymentMethod and paymentProvider in cart initialize-purchase

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -9,9 +9,12 @@ struct InitializePurchaseRequest {
     let returnURL: String?
     /// Optional cancel URL for the cart initialize-purchase API.
     let cancelURL: String?
-    /// Cart API payment method discriminator (e.g. built-in PayPal: `"PAYPAL"`).
+    /// Cart API `paymentMethod` discriminator (lowercase, e.g. `"card"`, `"apple_pay"`,
+    /// `"paypal"`, `"afterpay"`). Maps to the protobuf `PaymentMethodType` enum on the backend.
     let paymentMethod: String?
-    /// Cart API payment provider discriminator (e.g. built-in PayPal: `"PAYPAL"`).
+    /// Cart API `paymentProvider` discriminator (lowercase, e.g. `"stripe"`, `"paypal"`,
+    /// `"card"`, `"afterpay"`). Pass-through of the upstream DCUI provider so the backend can
+    /// disambiguate routing (e.g. stripe-routed apple_pay vs built-in apple_pay).
     let paymentProvider: String?
 
     func toDictionary() -> [String: Any] {

--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -9,12 +9,14 @@ struct InitializePurchaseRequest {
     let returnURL: String?
     /// Optional cancel URL for the cart initialize-purchase API.
     let cancelURL: String?
-    /// Cart API `paymentMethod` discriminator (lowercase, e.g. `"card"`, `"apple_pay"`,
-    /// `"paypal"`, `"afterpay"`). Maps to the protobuf `PaymentMethodType` enum on the backend.
+    /// Cart API `paymentMethod` discriminator (UPPERCASE, e.g. `"CARD"`, `"APPLE_PAY"`,
+    /// `"PAYPAL"`, `"AFTERPAY"`). Matches the `LayoutPaymentMethodType` enum (web SDK) and
+    /// the `PaymentMethod.MethodType` rawValues decoded from backend `transactionData`.
     let paymentMethod: String?
-    /// Cart API `paymentProvider` discriminator (lowercase, e.g. `"stripe"`, `"paypal"`,
-    /// `"card"`, `"afterpay"`). Pass-through of the upstream DCUI provider so the backend can
-    /// disambiguate routing (e.g. stripe-routed apple_pay vs built-in apple_pay).
+    /// Cart API `paymentProvider` discriminator (PascalCase, e.g. `"Stripe"`, `"PayPal"`,
+    /// `"Card"`, `"Afterpay"`, `"ApplePay"`). Pass-through of the DcuiSchema `PaymentProvider`
+    /// enum so the backend can disambiguate routing (e.g. Stripe-routed ApplePay vs built-in
+    /// ApplePay).
     let paymentProvider: String?
 
     func toDictionary() -> [String: Any] {

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -27,16 +27,31 @@ final class PaymentOrchestrator {
     /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
     static let payPalReturnURLMissingMessage =
         "PaymentContext.returnURL is required for PayPal checkout."
-    /// Cart `initialize-purchase` body `paymentMethod` wire value. Lowercase tokens that map to
-    /// the protobuf `PaymentMethodType` enum (see ROKT/protobufs trolley-api/trolley.proto).
+    /// Cart `initialize-purchase` body `paymentMethod` wire value. UPPERCASE tokens that match
+    /// the `LayoutPaymentMethodType` enum (see ROKT/rokt-web-plugin-dcui PR #966) and the
+    /// `PaymentMethod.MethodType` rawValues decoded from backend `transactionData`.
     /// Distinct from ``PaymentMethodType/wireValue`` (which is for extension matching and uses
     /// `"afterpay_clearpay"` for `.afterpay`).
-    static func cartWireValue(for method: PaymentMethodType) -> String {
+    static func cartPaymentMethodWireValue(for method: PaymentMethodType) -> String {
         switch method {
-        case .applePay: return "apple_pay"
-        case .card: return "card"
-        case .afterpay: return "afterpay"
-        case .paypal: return "paypal"
+        case .applePay: return "APPLE_PAY"
+        case .card: return "CARD"
+        case .afterpay: return "AFTERPAY"
+        case .paypal: return "PAYPAL"
+        }
+    }
+
+    /// Cart `initialize-purchase` body `paymentProvider` wire value for built-in flows.
+    /// PascalCase pass-through of the `DcuiSchema.PaymentProvider` enum — matches the web
+    /// SDK payload (`paymentProvider: PaymentProvider`) on `INITIATE_DEVICE_PAY_EVENT`.
+    /// Used only for built-in flows that hardcode their own provider (PayPal, Card);
+    /// extension-routed flows forward the caller-supplied PascalCase value verbatim.
+    static func cartPaymentProviderWireValue(for method: PaymentMethodType) -> String {
+        switch method {
+        case .applePay: return "ApplePay"
+        case .card: return "Card"
+        case .afterpay: return "Afterpay"
+        case .paypal: return "PayPal"
         }
     }
 
@@ -154,12 +169,13 @@ final class PaymentOrchestrator {
     ///
     /// - Parameters:
     ///   - method: The payment method to use (e.g. `.applePay`). Forwarded to the cart
-    ///     `initialize-purchase` body as a lowercase token (e.g. `"apple_pay"`) via
-    ///     ``cartWireValue(for:)``.
-    ///   - paymentProvider: Lowercase cart wire value for the upstream processor (e.g. `"stripe"`,
-    ///     `"afterpay"`). Forwarded as `paymentProvider` on the cart `initialize-purchase` body
+    ///     `initialize-purchase` body as an UPPERCASE token (e.g. `"APPLE_PAY"`) via
+    ///     ``cartPaymentMethodWireValue(for:)``.
+    ///   - paymentProvider: PascalCase cart wire value for the upstream processor (e.g. `"Stripe"`,
+    ///     `"Afterpay"`). Forwarded as `paymentProvider` on the cart `initialize-purchase` body
     ///     for extension-routed flows. Ignored for built-in PayPal and built-in card forwarding,
-    ///     which hardcode their own `paymentMethod` / `paymentProvider` (`"paypal"` / `"card"`).
+    ///     which hardcode their own `paymentMethod` / `paymentProvider` (`"PAYPAL"` / `"PayPal"`,
+    ///     `"CARD"` / `"Card"`).
     ///   - item: The item being purchased (from RoktContracts)
     ///   - cartItemId: The backend cart item ID (format `"v1:uuid:canal"`)
     ///   - viewController: The view controller to present the payment sheet from
@@ -181,7 +197,7 @@ final class PaymentOrchestrator {
             Self.warnIfCallerSuppliedProviderIgnored(
                 method: method,
                 callerProvider: paymentProvider,
-                hardcodedProvider: Self.cartWireValue(for: .paypal)
+                hardcodedProvider: Self.cartPaymentProviderWireValue(for: .paypal)
             )
             processBuiltInPayPalPayment(
                 item: item,
@@ -198,7 +214,7 @@ final class PaymentOrchestrator {
             Self.warnIfCallerSuppliedProviderIgnored(
                 method: method,
                 callerProvider: paymentProvider,
-                hardcodedProvider: Self.cartWireValue(for: .card)
+                hardcodedProvider: Self.cartPaymentProviderWireValue(for: .card)
             )
             processBuiltInCardPayment(
                 item: item,
@@ -227,9 +243,9 @@ final class PaymentOrchestrator {
                 contactAddress: contactAddress,
                 returnURL: nil,
                 cancelURL: nil,
-                // `cartWireValue` is total and guaranteed non-empty; only the
+                // `cartPaymentMethodWireValue` is total and guaranteed non-empty; only the
                 // caller-supplied provider needs whitespace/empty normalization.
-                paymentMethod: Self.cartWireValue(for: method),
+                paymentMethod: Self.cartPaymentMethodWireValue(for: method),
                 paymentProvider: Self.nonEmptyTrimmed(paymentProvider)
             ) { result in
                 switch result {
@@ -270,7 +286,7 @@ final class PaymentOrchestrator {
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
-    /// and `paymentMethod` / `paymentProvider` as `paypal` for the cart API.
+    /// and `paymentMethod` / `paymentProvider` as `PAYPAL` / `PayPal` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInTwoStepDevicePaySession``) and defers the hosted
     /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.
@@ -289,8 +305,8 @@ final class PaymentOrchestrator {
             contactAddress: contactAddress,
             returnURL: context.returnURL,
             cancelURL: context.cancelURL,
-            paymentMethod: Self.cartWireValue(for: .paypal),
-            paymentProvider: Self.cartWireValue(for: .paypal)
+            paymentMethod: Self.cartPaymentMethodWireValue(for: .paypal),
+            paymentProvider: Self.cartPaymentProviderWireValue(for: .paypal)
         ) { result in
             switch result {
             case .success(let preparation):
@@ -429,10 +445,10 @@ final class PaymentOrchestrator {
     /// Entry point for Card device-pay (Step-1 of the two-step Card forward-payment flow).
     ///
     /// Runs the same cart ``initializePurchase`` preparation as PayPal but without return/cancel URLs
-    /// (no hosted approval step). Passes `paymentMethod` / `paymentProvider` as `card`. After cart
-    /// prepare, triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions to the Step-2
-    /// confirm button, and caches `completion` so it can fire alongside ``forwardPaymentFinalized``
-    /// once ``handleForwardPayment`` posts to `/v1/cart/purchase`.
+    /// (no hosted approval step). Passes `paymentMethod` / `paymentProvider` as `CARD` / `Card`.
+    /// After cart prepare, triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions
+    /// to the Step-2 confirm button, and caches `completion` so it can fire alongside
+    /// ``forwardPaymentFinalized`` once ``handleForwardPayment`` posts to `/v1/cart/purchase`.
     private func processBuiltInCardPayment(
         item: PaymentItem,
         context: PaymentContext,
@@ -447,8 +463,8 @@ final class PaymentOrchestrator {
             contactAddress: contactAddress,
             returnURL: nil,
             cancelURL: nil,
-            paymentMethod: Self.cartWireValue(for: .card),
-            paymentProvider: Self.cartWireValue(for: .card)
+            paymentMethod: Self.cartPaymentMethodWireValue(for: .card),
+            paymentProvider: Self.cartPaymentProviderWireValue(for: .card)
         ) { result in
             switch result {
             case .success(let preparation):
@@ -535,7 +551,7 @@ final class PaymentOrchestrator {
 
     /// Logs when a built-in flow ignored a caller-supplied `paymentProvider` that
     /// disagrees with the hardcoded override. Helps the next person catch a wiring
-    /// bug (e.g. plumbing `"stripe"` into a built-in PayPal flow) without changing
+    /// bug (e.g. plumbing `"Stripe"` into a built-in PayPal flow) without changing
     /// the cart payload semantics.
     private static func warnIfCallerSuppliedProviderIgnored(
         method: PaymentMethodType,

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -178,6 +178,11 @@ final class PaymentOrchestrator {
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         if method == .paypal {
+            Self.warnIfCallerSuppliedProviderIgnored(
+                method: method,
+                callerProvider: paymentProvider,
+                hardcodedProvider: Self.cartWireValue(for: .paypal)
+            )
             processBuiltInPayPalPayment(
                 item: item,
                 context: context,
@@ -190,6 +195,11 @@ final class PaymentOrchestrator {
         }
 
         if method == .card, let cardSession = builtInCardDevicePaySession {
+            Self.warnIfCallerSuppliedProviderIgnored(
+                method: method,
+                callerProvider: paymentProvider,
+                hardcodedProvider: Self.cartWireValue(for: .card)
+            )
             processBuiltInCardPayment(
                 item: item,
                 context: context,
@@ -217,6 +227,8 @@ final class PaymentOrchestrator {
                 contactAddress: contactAddress,
                 returnURL: nil,
                 cancelURL: nil,
+                // `cartWireValue` is total and guaranteed non-empty; only the
+                // caller-supplied provider needs whitespace/empty normalization.
                 paymentMethod: Self.cartWireValue(for: method),
                 paymentProvider: Self.nonEmptyTrimmed(paymentProvider)
             ) { result in
@@ -519,6 +531,24 @@ final class PaymentOrchestrator {
         guard let string else { return nil }
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Logs when a built-in flow ignored a caller-supplied `paymentProvider` that
+    /// disagrees with the hardcoded override. Helps the next person catch a wiring
+    /// bug (e.g. plumbing `"stripe"` into a built-in PayPal flow) without changing
+    /// the cart payload semantics.
+    private static func warnIfCallerSuppliedProviderIgnored(
+        method: PaymentMethodType,
+        callerProvider: String?,
+        hardcodedProvider: String
+    ) {
+        guard let provided = nonEmptyTrimmed(callerProvider),
+              provided != hardcodedProvider
+        else { return }
+        RoktLogger.shared.warning(
+            "Built-in \(method.wireValue) flow ignoring caller-supplied " +
+                "paymentProvider=\(provided); using \(hardcodedProvider)."
+        )
     }
 
     private func sendPaymentFailureDiagnostics(

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -27,9 +27,18 @@ final class PaymentOrchestrator {
     /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
     static let payPalReturnURLMissingMessage =
         "PaymentContext.returnURL is required for PayPal checkout."
-    /// Cart `initialize-purchase` body `paymentMethod` / `paymentProvider` for built-in PayPal.
-    private static let builtInPayPalInitializePurchaseMethod = "PAYPAL"
-    private static let builtInPayPalInitializePurchaseProvider = "PAYPAL"
+    /// Cart `initialize-purchase` body `paymentMethod` wire value. Lowercase tokens that map to
+    /// the protobuf `PaymentMethodType` enum (see ROKT/protobufs trolley-api/trolley.proto).
+    /// Distinct from ``PaymentMethodType/wireValue`` (which is for extension matching and uses
+    /// `"afterpay_clearpay"` for `.afterpay`).
+    static func cartWireValue(for method: PaymentMethodType) -> String {
+        switch method {
+        case .applePay: return "apple_pay"
+        case .card: return "card"
+        case .afterpay: return "afterpay"
+        case .paypal: return "paypal"
+        }
+    }
 
     private static let pendingBuiltInTwoStepLock = NSLock()
 
@@ -144,7 +153,13 @@ final class PaymentOrchestrator {
     /// Process a payment using the first registered extension that supports the given method.
     ///
     /// - Parameters:
-    ///   - method: The payment method to use (e.g. `.applePay`)
+    ///   - method: The payment method to use (e.g. `.applePay`). Forwarded to the cart
+    ///     `initialize-purchase` body as a lowercase token (e.g. `"apple_pay"`) via
+    ///     ``cartWireValue(for:)``.
+    ///   - paymentProvider: Lowercase cart wire value for the upstream processor (e.g. `"stripe"`,
+    ///     `"afterpay"`). Forwarded as `paymentProvider` on the cart `initialize-purchase` body
+    ///     for extension-routed flows. Ignored for built-in PayPal and built-in card forwarding,
+    ///     which hardcode their own `paymentMethod` / `paymentProvider` (`"paypal"` / `"card"`).
     ///   - item: The item being purchased (from RoktContracts)
     ///   - cartItemId: The backend cart item ID (format `"v1:uuid:canal"`)
     ///   - viewController: The view controller to present the payment sheet from
@@ -153,6 +168,7 @@ final class PaymentOrchestrator {
     ///   - completion: Called with the payment result
     func processPayment(
         method: PaymentMethodType,
+        paymentProvider: String? = nil,
         item: PaymentItem,
         context: PaymentContext,
         cartItemId: String,
@@ -200,7 +216,9 @@ final class PaymentOrchestrator {
                 cartItemId: cartItemId,
                 contactAddress: contactAddress,
                 returnURL: nil,
-                cancelURL: nil
+                cancelURL: nil,
+                paymentMethod: Self.cartWireValue(for: method),
+                paymentProvider: Self.nonEmptyTrimmed(paymentProvider)
             ) { result in
                 switch result {
                 case .success(let preparation):
@@ -240,7 +258,7 @@ final class PaymentOrchestrator {
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
-    /// and `paymentMethod` / `paymentProvider` as `PAYPAL` for the cart API.
+    /// and `paymentMethod` / `paymentProvider` as `paypal` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInTwoStepDevicePaySession``) and defers the hosted
     /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.
@@ -259,8 +277,8 @@ final class PaymentOrchestrator {
             contactAddress: contactAddress,
             returnURL: context.returnURL,
             cancelURL: context.cancelURL,
-            paymentMethod: Self.builtInPayPalInitializePurchaseMethod,
-            paymentProvider: Self.builtInPayPalInitializePurchaseProvider
+            paymentMethod: Self.cartWireValue(for: .paypal),
+            paymentProvider: Self.cartWireValue(for: .paypal)
         ) { result in
             switch result {
             case .success(let preparation):
@@ -398,11 +416,11 @@ final class PaymentOrchestrator {
 
     /// Entry point for Card device-pay (Step-1 of the two-step Card forward-payment flow).
     ///
-    /// Runs the same cart ``initializePurchase`` preparation as PayPal but without `paymentMethod` /
-    /// `paymentProvider` overrides or return/cancel URLs (no hosted approval step). After cart prepare,
-    /// triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions to the Step-2 confirm
-    /// button, and caches `completion` so it can fire alongside ``forwardPaymentFinalized`` once
-    /// ``handleForwardPayment`` posts to `/v1/cart/purchase`.
+    /// Runs the same cart ``initializePurchase`` preparation as PayPal but without return/cancel URLs
+    /// (no hosted approval step). Passes `paymentMethod` / `paymentProvider` as `card`. After cart
+    /// prepare, triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions to the Step-2
+    /// confirm button, and caches `completion` so it can fire alongside ``forwardPaymentFinalized``
+    /// once ``handleForwardPayment`` posts to `/v1/cart/purchase`.
     private func processBuiltInCardPayment(
         item: PaymentItem,
         context: PaymentContext,
@@ -416,7 +434,9 @@ final class PaymentOrchestrator {
             cartItemId: cartItemId,
             contactAddress: contactAddress,
             returnURL: nil,
-            cancelURL: nil
+            cancelURL: nil,
+            paymentMethod: Self.cartWireValue(for: .card),
+            paymentProvider: Self.cartWireValue(for: .card)
         ) { result in
             switch result {
             case .success(let preparation):

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -221,8 +221,10 @@ internal class RoktAPIHelper {
     ///   - shippingAttributes: Shipping address
     ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
     ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
-    ///   - paymentMethod: Optional cart body `paymentMethod` (e.g. `"PAYPAL"` for built-in PayPal)
-    ///   - paymentProvider: Optional cart body `paymentProvider` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentMethod: Optional cart body `paymentMethod` (lowercase, e.g. `"card"`,
+    ///     `"apple_pay"`, `"paypal"`, `"afterpay"`).
+    ///   - paymentProvider: Optional cart body `paymentProvider` (lowercase, e.g. `"stripe"`,
+    ///     `"paypal"`, `"card"`, `"afterpay"`).
     ///   - success: Callback with the initialize-purchase response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -221,10 +221,10 @@ internal class RoktAPIHelper {
     ///   - shippingAttributes: Shipping address
     ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
     ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
-    ///   - paymentMethod: Optional cart body `paymentMethod` (lowercase, e.g. `"card"`,
-    ///     `"apple_pay"`, `"paypal"`, `"afterpay"`).
-    ///   - paymentProvider: Optional cart body `paymentProvider` (lowercase, e.g. `"stripe"`,
-    ///     `"paypal"`, `"card"`, `"afterpay"`).
+    ///   - paymentMethod: Optional cart body `paymentMethod` (UPPERCASE, e.g. `"CARD"`,
+    ///     `"APPLE_PAY"`, `"PAYPAL"`, `"AFTERPAY"`).
+    ///   - paymentProvider: Optional cart body `paymentProvider` (PascalCase, e.g. `"Stripe"`,
+    ///     `"PayPal"`, `"Card"`, `"Afterpay"`, `"ApplePay"`).
     ///   - success: Callback with the initialize-purchase response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -392,10 +392,10 @@ internal class RoktNetWorkAPI {
     ///   - shippingAttributes: Shipping address for the order
     ///   - returnURL: Optional redirect success URL for payment flows that need it
     ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
-    ///   - paymentMethod: Optional cart body `paymentMethod` (lowercase, e.g. `"card"`,
-    ///     `"apple_pay"`, `"paypal"`, `"afterpay"`).
-    ///   - paymentProvider: Optional cart body `paymentProvider` (lowercase, e.g. `"stripe"`,
-    ///     `"paypal"`, `"card"`, `"afterpay"`).
+    ///   - paymentMethod: Optional cart body `paymentMethod` (UPPERCASE, e.g. `"CARD"`,
+    ///     `"APPLE_PAY"`, `"PAYPAL"`, `"AFTERPAY"`).
+    ///   - paymentProvider: Optional cart body `paymentProvider` (PascalCase, e.g. `"Stripe"`,
+    ///     `"PayPal"`, `"Card"`, `"Afterpay"`, `"ApplePay"`).
     ///   - success: Callback with the parsed response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -392,8 +392,10 @@ internal class RoktNetWorkAPI {
     ///   - shippingAttributes: Shipping address for the order
     ///   - returnURL: Optional redirect success URL for payment flows that need it
     ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
-    ///   - paymentMethod: Optional cart body `paymentMethod` (e.g. `"PAYPAL"` for built-in PayPal)
-    ///   - paymentProvider: Optional cart body `paymentProvider` (e.g. `"PAYPAL"` for built-in PayPal)
+    ///   - paymentMethod: Optional cart body `paymentMethod` (lowercase, e.g. `"card"`,
+    ///     `"apple_pay"`, `"paypal"`, `"afterpay"`).
+    ///   - paymentProvider: Optional cart body `paymentProvider` (lowercase, e.g. `"stripe"`,
+    ///     `"paypal"`, `"card"`, `"afterpay"`).
     ///   - success: Callback with the parsed response
     ///   - failure: Callback with error details
     class func initializePurchase(upsellItems: [UpsellItem],

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -434,9 +434,10 @@ class RoktInternalImplementation {
             // rawValue) makes a future schema rename a compile-time error rather than a
             // silent .default; @unknown default covers cases added in newer DcuiSchema versions.
             let paymentMethod: PaymentMethodType
-            // Lowercase wire token for the cart `initialize-purchase` body's `paymentProvider`
-            // field — pass-through of the upstream DCUI provider so backend can disambiguate
-            // routing (e.g. stripe-routed apple_pay vs built-in apple_pay).
+            // PascalCase wire token for the cart `initialize-purchase` body's `paymentProvider`
+            // field — pass-through of the upstream DcuiSchema `PaymentProvider` enum so backend
+            // can disambiguate routing (e.g. Stripe-routed ApplePay vs built-in ApplePay).
+            // Matches the web SDK payload on `INITIATE_DEVICE_PAY_EVENT`.
             let paymentProviderWireValue: String
             // Card schema and Stripe schema both map to PaymentMethodType.card today;
             // routes diverge in processPayment via builtInCardDevicePaySession (set only for `.card`).
@@ -444,19 +445,19 @@ class RoktInternalImplementation {
             switch event.paymentProvider {
             case .applePay:
                 paymentMethod = .applePay
-                paymentProviderWireValue = "apple_pay"
+                paymentProviderWireValue = "ApplePay"
             case .stripe:
                 paymentMethod = .card
-                paymentProviderWireValue = "stripe"
+                paymentProviderWireValue = "Stripe"
             case .afterpay:
                 paymentMethod = .afterpay
-                paymentProviderWireValue = "afterpay"
+                paymentProviderWireValue = "Afterpay"
             case .paypal:
                 paymentMethod = .paypal
-                paymentProviderWireValue = "paypal"
+                paymentProviderWireValue = "PayPal"
             case .card:
                 paymentMethod = .card
-                paymentProviderWireValue = "card"
+                paymentProviderWireValue = "Card"
             case .googlePay:
                 RoktLogger.shared.error("GooglePay device-pay not supported on iOS")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -434,20 +434,29 @@ class RoktInternalImplementation {
             // rawValue) makes a future schema rename a compile-time error rather than a
             // silent .default; @unknown default covers cases added in newer DcuiSchema versions.
             let paymentMethod: PaymentMethodType
+            // Lowercase wire token for the cart `initialize-purchase` body's `paymentProvider`
+            // field — pass-through of the upstream DCUI provider so backend can disambiguate
+            // routing (e.g. stripe-routed apple_pay vs built-in apple_pay).
+            let paymentProviderWireValue: String
             // Card schema and Stripe schema both map to PaymentMethodType.card today;
             // routes diverge in processPayment via builtInCardDevicePaySession (set only for `.card`).
             let isBuiltInCardForwarding = (event.paymentProvider == .card)
             switch event.paymentProvider {
             case .applePay:
                 paymentMethod = .applePay
+                paymentProviderWireValue = "apple_pay"
             case .stripe:
                 paymentMethod = .card
+                paymentProviderWireValue = "stripe"
             case .afterpay:
                 paymentMethod = .afterpay
+                paymentProviderWireValue = "afterpay"
             case .paypal:
                 paymentMethod = .paypal
+                paymentProviderWireValue = "paypal"
             case .card:
                 paymentMethod = .card
+                paymentProviderWireValue = "card"
             case .googlePay:
                 RoktLogger.shared.error("GooglePay device-pay not supported on iOS")
                 devicePayFinalized(executeId: executeId, layoutId: event.layoutId,
@@ -552,6 +561,7 @@ class RoktInternalImplementation {
             // Process the payment via the registered extension or built-in two-step flow
             paymentOrchestrator.processPayment(
                 method: paymentMethod,
+                paymentProvider: paymentProviderWireValue,
                 item: item,
                 context: context,
                 cartItemId: event.cartItemId,

--- a/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
@@ -27,4 +27,30 @@ final class InitializePurchaseRequestTests: XCTestCase {
         XCTAssertNil(dict["paymentMethod"] as? String)
         XCTAssertNil(dict["paymentProvider"] as? String)
     }
+
+    func test_toDictionary_includesPaymentMethodAndProviderWhenSet() {
+        let upsell = UpsellItem(
+            cartItemId: "c1",
+            catalogItemId: "cat1",
+            quantity: 1,
+            unitPrice: 10,
+            totalPrice: 10,
+            currency: "USD"
+        )
+        let request = InitializePurchaseRequest(
+            totalUpsellPrice: 10,
+            currency: "USD",
+            upsellItems: [upsell],
+            fulfillmentDetails: nil,
+            returnURL: nil,
+            cancelURL: nil,
+            paymentMethod: "apple_pay",
+            paymentProvider: "stripe"
+        )
+
+        let dict = request.toDictionary()
+
+        XCTAssertEqual(dict["paymentMethod"] as? String, "apple_pay")
+        XCTAssertEqual(dict["paymentProvider"] as? String, "stripe")
+    }
 }

--- a/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
@@ -44,13 +44,13 @@ final class InitializePurchaseRequestTests: XCTestCase {
             fulfillmentDetails: nil,
             returnURL: nil,
             cancelURL: nil,
-            paymentMethod: "apple_pay",
-            paymentProvider: "stripe"
+            paymentMethod: "APPLE_PAY",
+            paymentProvider: "Stripe"
         )
 
         let dict = request.toDictionary()
 
-        XCTAssertEqual(dict["paymentMethod"] as? String, "apple_pay")
-        XCTAssertEqual(dict["paymentProvider"] as? String, "stripe")
+        XCTAssertEqual(dict["paymentMethod"] as? String, "APPLE_PAY")
+        XCTAssertEqual(dict["paymentProvider"] as? String, "Stripe")
     }
 }

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -450,7 +450,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -555,7 +555,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -607,11 +607,11 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
-        // Tripwire against re-introducing the legacy uppercase token.
-        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
-        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
+        // Tripwire against re-introducing the legacy lowercase tokens.
+        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
         XCTAssertEqual(payPalPresenter.presentCallCount, 1)
         XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
     }
@@ -648,8 +648,8 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
     }
 
     func test_processPayment_payPal_ignoresRegisteredExtensionSupportingPayPal() {
@@ -682,8 +682,8 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
         wait(for: [paypalExpectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
         XCTAssertEqual(ext.presentPaymentSheetCallCount, 0, "PayPal must not use PaymentExtension.presentPaymentSheet")
 
         let appleExpectation = expectation(description: "Apple Pay still uses extension")
@@ -777,7 +777,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -813,9 +813,9 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [confirmationExpectation], timeout: 1.0)
 
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
-        // Built-in card forwarding passes `card` / `card` as the cart wire values.
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "card")
+        // Built-in card forwarding passes `CARD` / `Card` as the cart wire values.
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Card")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL)
         XCTAssertNotNil(confirmationData)
@@ -1052,16 +1052,27 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(payPalPresenter.presentCallCount, 0)
     }
 
-    // MARK: - cartWireValue helper
+    // MARK: - cart wire-value helpers
 
-    func test_cartWireValue_returnsLowercaseTokensForAllMethods() {
-        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .applePay), "apple_pay")
-        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .card), "card")
-        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .paypal), "paypal")
-        // Cart wire (`afterpay`) intentionally diverges from `PaymentMethodType.wireValue`
+    func test_cartPaymentMethodWireValue_returnsUppercaseTokensForAllMethods() {
+        // Matches LayoutPaymentMethodType (web SDK) and PaymentMethod.MethodType rawValues
+        // decoded from backend transactionData.
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .applePay), "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .card), "CARD")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .paypal), "PAYPAL")
+        // Cart wire (`AFTERPAY`) intentionally diverges from `PaymentMethodType.wireValue`
         // (`afterpay_clearpay`, used for extension matching).
-        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .afterpay), "afterpay")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .afterpay), "AFTERPAY")
         XCTAssertEqual(PaymentMethodType.afterpay.wireValue, "afterpay_clearpay")
+    }
+
+    func test_cartPaymentProviderWireValue_returnsPascalCaseTokensForAllMethods() {
+        // PascalCase pass-through of the DcuiSchema PaymentProvider enum — matches the web
+        // SDK payload on INITIATE_DEVICE_PAY_EVENT.
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentProviderWireValue(for: .applePay), "ApplePay")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentProviderWireValue(for: .card), "Card")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentProviderWireValue(for: .paypal), "PayPal")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentProviderWireValue(for: .afterpay), "Afterpay")
     }
 
     // MARK: - paymentMethod / paymentProvider plumbing for extension flows
@@ -1077,7 +1088,7 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
         sut.processPayment(
             method: .applePay,
-            paymentProvider: "stripe",
+            paymentProvider: "Stripe",
             item: item,
             context: PaymentContext(),
             cartItemId: "v1:cart-stripe:canal",
@@ -1096,8 +1107,8 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "stripe")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Stripe")
     }
 
     func test_processPayment_extensionFlow_cardMethod_passesCardWireValueAsPaymentMethod() {
@@ -1112,7 +1123,7 @@ class TestPaymentOrchestrator: XCTestCase {
         // No builtInCardDevicePaySession -> routes via the registered extension, not built-in card.
         sut.processPayment(
             method: .card,
-            paymentProvider: "stripe",
+            paymentProvider: "Stripe",
             item: item,
             context: PaymentContext(),
             cartItemId: "v1:cart-stripe-card:canal",
@@ -1131,8 +1142,8 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "stripe")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Stripe")
     }
 
     func test_processPayment_extensionFlow_afterpay_passesAfterpayWireValueNotClearpay() {
@@ -1146,7 +1157,7 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
         sut.processPayment(
             method: .afterpay,
-            paymentProvider: "afterpay",
+            paymentProvider: "Afterpay",
             item: item,
             context: PaymentContext(),
             cartItemId: "v1:cart-afterpay:canal",
@@ -1165,9 +1176,9 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        // Cart wire is "afterpay", not the extension-matching "afterpay_clearpay".
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "afterpay")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "afterpay")
+        // Cart wire is "AFTERPAY", not the extension-matching "afterpay_clearpay".
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "AFTERPAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Afterpay")
     }
 
     func test_processPayment_extensionFlow_emptyPaymentProvider_passesNilToInitializePurchase() {
@@ -1200,7 +1211,7 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -1216,7 +1227,7 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item-paypal", name: "Widget", amount: 9.99, currency: "USD")
         sut.processPayment(
             method: .paypal,
-            paymentProvider: "stripe", // garbage value — built-in PayPal must override.
+            paymentProvider: "Stripe", // garbage value — built-in PayPal must override.
             item: item,
             context: context,
             cartItemId: "v1:cart-paypal-override:canal",
@@ -1224,8 +1235,8 @@ class TestPaymentOrchestrator: XCTestCase {
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { _ in }
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
     }
 
     func test_processPayment_builtInCard_ignoresCallerSuppliedPaymentProvider() {
@@ -1243,7 +1254,7 @@ class TestPaymentOrchestrator: XCTestCase {
         let item = PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD")
         sut.processPayment(
             method: .card,
-            paymentProvider: "stripe", // garbage value — built-in card must override.
+            paymentProvider: "Stripe", // garbage value — built-in card must override.
             item: item,
             context: PaymentContext(),
             cartItemId: "v1:cart-card-override:canal",
@@ -1255,8 +1266,8 @@ class TestPaymentOrchestrator: XCTestCase {
 
         wait(for: [confirmationExpectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "card")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Card")
     }
 }
 

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -609,6 +609,9 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
+        // Tripwire against re-introducing the legacy uppercase token.
+        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
         XCTAssertEqual(payPalPresenter.presentCallCount, 1)
         XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
     }

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -450,7 +450,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -555,7 +555,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -607,8 +607,8 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
         XCTAssertEqual(payPalPresenter.presentCallCount, 1)
         XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
     }
@@ -645,8 +645,8 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
     }
 
     func test_processPayment_payPal_ignoresRegisteredExtensionSupportingPayPal() {
@@ -679,8 +679,8 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
         wait(for: [paypalExpectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
         XCTAssertEqual(ext.presentPaymentSheetCallCount, 0, "PayPal must not use PaymentExtension.presentPaymentSheet")
 
         let appleExpectation = expectation(description: "Apple Pay still uses extension")
@@ -774,7 +774,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -810,9 +810,9 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [confirmationExpectation], timeout: 1.0)
 
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
-        // Card flow does NOT pass paymentMethod/paymentProvider overrides — those are PayPal-specific.
-        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod)
-        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
+        // Built-in card forwarding passes `card` / `card` as the cart wire values.
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "card")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL)
         XCTAssertNotNil(confirmationData)
@@ -1047,6 +1047,213 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(payPalPresenter.presentCallCount, 0)
+    }
+
+    // MARK: - cartWireValue helper
+
+    func test_cartWireValue_returnsLowercaseTokensForAllMethods() {
+        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .applePay), "apple_pay")
+        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .card), "card")
+        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .paypal), "paypal")
+        // Cart wire (`afterpay`) intentionally diverges from `PaymentMethodType.wireValue`
+        // (`afterpay_clearpay`, used for extension matching).
+        XCTAssertEqual(PaymentOrchestrator.cartWireValue(for: .afterpay), "afterpay")
+        XCTAssertEqual(PaymentMethodType.afterpay.wireValue, "afterpay_clearpay")
+    }
+
+    // MARK: - paymentMethod / paymentProvider plumbing for extension flows
+
+    func test_processPayment_extensionFlow_forwardsPaymentProviderToInitializePurchase() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.applePay])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
+        sut.processPayment(
+            method: .applePay,
+            paymentProvider: "stripe",
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-stripe:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment completes")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { _, _ in expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "stripe")
+    }
+
+    func test_processPayment_extensionFlow_cardMethod_passesCardWireValueAsPaymentMethod() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.card])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
+        // No builtInCardDevicePaySession -> routes via the registered extension, not built-in card.
+        sut.processPayment(
+            method: .card,
+            paymentProvider: "stripe",
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-stripe-card:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment completes")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { _, _ in expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "stripe")
+    }
+
+    func test_processPayment_extensionFlow_afterpay_passesAfterpayWireValueNotClearpay() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.afterpay])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
+        sut.processPayment(
+            method: .afterpay,
+            paymentProvider: "afterpay",
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-afterpay:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment completes")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { _, _ in expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Cart wire is "afterpay", not the extension-matching "afterpay_clearpay".
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "afterpay")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "afterpay")
+    }
+
+    func test_processPayment_extensionFlow_emptyPaymentProvider_passesNilToInitializePurchase() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+
+        let ext = MockPaymentExtension(id: "ext1", supportedMethods: [.applePay])
+        ext.shouldAutomaticallyCompletePayment = false
+        sut.register(ext, config: [:])
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let item = PaymentItem(id: "item1", name: "Widget", amount: 10, currency: "USD")
+        sut.processPayment(
+            method: .applePay,
+            paymentProvider: "   ",
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-empty-provider:canal",
+            from: UIViewController()
+        ) { _ in
+            XCTFail("Completion should not be called in this test")
+        }
+
+        guard let preparePayment = ext.capturedPreparePayment else {
+            XCTFail("Expected preparePayment callback to be captured")
+            return
+        }
+
+        let expectation = expectation(description: "preparePayment completes")
+        let address = ContactAddress(name: "Jane Doe", email: "jane@example.com")
+        preparePayment(address) { _, _ in expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "apple_pay")
+        XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
+    }
+
+    func test_processPayment_builtInPayPal_ignoresCallerSuppliedPaymentProvider() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        let context = PaymentContext(returnURL: "myapp://paypal/success", cancelURL: "myapp://paypal/cancel")
+        let item = PaymentItem(id: "item-paypal", name: "Widget", amount: 9.99, currency: "USD")
+        sut.processPayment(
+            method: .paypal,
+            paymentProvider: "stripe", // garbage value — built-in PayPal must override.
+            item: item,
+            context: context,
+            cartItemId: "v1:cart-paypal-override:canal",
+            from: UIViewController(),
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
+        ) { _ in }
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
+    }
+
+    func test_processPayment_builtInCard_ignoresCallerSuppliedPaymentProvider() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let confirmationExpectation = expectation(description: "Card showConfirmation fires")
+        let cardSession = BuiltInTwoStepDevicePaySession(
+            layoutId: "test_layout",
+            catalogItemId: "test_catalog"
+        ) { _, _, _ in
+            confirmationExpectation.fulfill()
+        }
+
+        let item = PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD")
+        sut.processPayment(
+            method: .card,
+            paymentProvider: "stripe", // garbage value — built-in card must override.
+            item: item,
+            context: PaymentContext(),
+            cartItemId: "v1:cart-card-override:canal",
+            from: UIViewController(),
+            builtInCardDevicePaySession: cardSession
+        ) { _ in
+            XCTFail("Step-1 completion fired before Step-2 popped it")
+        }
+
+        wait(for: [confirmationExpectation], timeout: 1.0)
+
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "card")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "card")
     }
 }
 


### PR DESCRIPTION
## Background

Today the iOS SDK only populates `paymentMethod` / `paymentProvider` on the cart `initialize-purchase` request for built-in PayPal, and even then it sends the legacy uppercase `"PAYPAL"` token. Every other device-pay flow (Stripe-routed Apple Pay, Stripe-routed Card, built-in Card forwarding, Afterpay) sends neither field, leaving the backend to infer the flow from context.

This change makes every flow self-describing on the wire so the backend can route deterministically.

## What Has Changed

- `PaymentOrchestrator.processPayment` accepts a `paymentProvider: String?` and a new `cartWireValue(for:)` helper produces a lowercase `paymentMethod` token from `PaymentMethodType`.
- `RoktInternalImplementation` maps the upstream DCUI `event.paymentProvider` to a lowercase wire string and plumbs it through.
- Built-in PayPal moves from `"PAYPAL"` (uppercase) to `"paypal"` (lowercase). Built-in PayPal and built-in card forwarding hardcode their own `paymentMethod` / `paymentProvider`; if a caller supplies a mismatching provider, a warning is logged so wiring bugs surface at runtime.
- `cartWireValue` is intentionally distinct from `PaymentMethodType.wireValue` for `.afterpay` — cart API sends `"afterpay"`, extension matching stays `"afterpay_clearpay"`. A unit test asserts both values to keep the divergence honest.

### Provider / method combos on the cart `initialize-purchase` wire

`paymentMethod` is UPPERCASE (matches the web SDK's `LayoutPaymentMethodType` enum and the `PaymentMethod.MethodType` rawValues decoded from backend `transactionData`). `paymentProvider` is PascalCase pass-through of the `DcuiSchema.PaymentProvider` enum (matches the web SDK payload on `INITIATE_DEVICE_PAY_EVENT`).

| DCUI `event.paymentProvider` | `PaymentMethodType` | Cart `paymentMethod` | Cart `paymentProvider` | Flow |
|---|---|---|---|---|
| `.applePay` | `.applePay` | `APPLE_PAY` | `ApplePay` | Extension (e.g. Stripe Apple Pay) |
| `.stripe` | `.card` | `CARD` | `Stripe` | Extension (Stripe-routed card) |
| `.afterpay` | `.afterpay` | `AFTERPAY` | `Afterpay` | Extension |
| `.paypal` | `.paypal` | `PAYPAL` | `PayPal` | Built-in PayPal (hardcoded override) |
| `.card` | `.card` | `CARD` | `Card` | Built-in card forwarding (hardcoded override) |

Notes:
- `paymentMethod` divergence from `PaymentMethodType.wireValue`: cart sends `AFTERPAY`, extension matching stays `afterpay_clearpay`.
- Built-in PayPal and built-in card forwarding ignore any caller-supplied `paymentProvider` and log a warning when it disagrees with the hardcoded value — surfaces wiring bugs (e.g. plumbing `"Stripe"` into the built-in PayPal flow) at runtime.

## How Has This Been Tested

- Full `Rokt_WidgetTests` suite passes locally (with `-retry-tests-on-failure` matching the CI workflow; an unrelated `RealTimeEventStoreFileTest` is timing-flaky).
- `trunk check` clean on all changed files.
- Added unit tests cover: the wire-value mapping helper, the new orchestrator parameter for extension flows (Stripe Apple Pay, Stripe Card, Afterpay), empty/whitespace normalization, and the built-in PayPal / Card override behavior (including a tripwire against re-introducing the legacy uppercase `"PAYPAL"`).

<img width="591" alt="Screenshot 2026-05-21 at 2 00 35 PM" src="https://github.com/user-attachments/assets/d76b76df-c009-4b99-81fd-15f746f34693" />

## Notes

iOS leads this contract — web SDK does not yet send `paymentMethod` / `paymentProvider` in `initialize-purchase`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
