### PR TITLE
test(pact): scaffold consumer-driven contracts against transactions-api v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Package.resolved
 vendor/
 Tests/Rokt_WidgetTests/**/*.swift.plist
 Tests/SizeReport/build/
+
+# Pact JSON artifacts (generated locally by ContractTests, published to broker
+# by CI, never committed — see rokt-pact-mobile-runner for the publish path).
+pacts/

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
         .testTarget(
             name: "ContractTests",
             dependencies: [
+                "Rokt_Widget",
                 .product(name: "PactSwift", package: "PactSwift")
             ],
             path: "Tests/ContractTests"

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", .upToNextMajor(from: "0.10.10")),
-        .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0"))
+        .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0")),
+        .package(url: "https://github.com/surpher/PactSwift.git", .upToNextMajor(from: "1.2.0"))
     ],
     targets: [
         .target(
@@ -43,6 +44,13 @@ let package = Package(
             resources: [
                 .process("Resource")
             ]
+        ),
+        .testTarget(
+            name: "ContractTests",
+            dependencies: [
+                .product(name: "PactSwift", package: "PactSwift")
+            ],
+            path: "Tests/ContractTests"
         )
     ]
 )

--- a/Sources/Rokt_Widget/Networking/V2OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2OffersClient.swift
@@ -1,3 +1,7 @@
+// periphery:ignore:all - referenced from Tests/ContractTests/V2OffersClientPactSpec.swift,
+// which isn't part of the rokt-Example scheme that Periphery scans. See the V2OffersClient
+// doc comment below for why this client lives in Sources/ rather than Tests/.
+
 import Foundation
 
 /// Client for the v2 sessions offers endpoint on transactions-api.

--- a/Sources/Rokt_Widget/Networking/V2OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2OffersClient.swift
@@ -1,18 +1,23 @@
 import Foundation
 
-/// Test-only client for the v2 sessions offers endpoint on transactions-api.
+/// Client for the v2 sessions offers endpoint on transactions-api.
 ///
-/// Mobile is not yet a consumer of this surface — production code still calls
-/// `/rokt-mobile/v1/*`. This client describes the v2 contract that mobile will
-/// satisfy at v1→v2 migration. Lift / replace at cutover.
+/// Not yet called from any production code path — the SDK still uses
+/// `/rokt-mobile/v1/*` via `RoktNetWorkAPI`. This client describes the
+/// v2 wire contract that mobile will satisfy when v1→v2 migration lands;
+/// at that point the existing networking code switches over to call this.
 ///
-/// Design intentionally mirrors sdk-web's consumer-pact pattern (see
-/// `build-pact-services.ts` in that repo): the client owns wire-shape
-/// construction — header and body assembly — based on domain inputs. The
-/// pact spec describes the expected wire shape via matchers, and any drift
-/// in this client's outgoing request will be caught by the pact mock. The
-/// test never constructs the headers or body directly.
-struct V2OffersClient {
+/// Lives in Sources/ rather than Tests/ so the consumer pact spec in
+/// `Tests/ContractTests/V2OffersClientPactSpec.swift` constrains the
+/// actual shipping SDK code. A pact contract describing test-only code
+/// can silently diverge from production at migration time; describing
+/// real SDK code closes that gap.
+///
+/// The client owns wire-shape construction — header and body assembly —
+/// based on domain inputs. The pact spec describes the expected wire
+/// shape via matchers, and any drift here will be caught by the pact
+/// mock service. See [[pact-consumer-conventions]] §10a for the rule.
+internal struct V2OffersClient {
     let baseURL: URL
     let accountId: String
     let authToken: String
@@ -82,8 +87,8 @@ struct V2OffersClient {
 /// Holds only the values that vary per-request from a caller's perspective.
 /// Session-shaped values (account id, session token, mp ids, etc.) are
 /// injected at client construction time, mirroring how a production iOS
-/// service would resolve them from session / config services.
-struct V2OffersInput {
+/// service resolves them from session / config services.
+internal struct V2OffersInput {
     let requestId: String
     let pageIdentifier: String
     let pageURL: String
@@ -91,7 +96,7 @@ struct V2OffersInput {
     let attributes: [String: String]
 }
 
-struct V2OffersRequest: Encodable {
+internal struct V2OffersRequest: Encodable {
     let sessionId: String
     let mpSessionId: String
     let mpid: String
@@ -113,7 +118,7 @@ struct V2OffersRequest: Encodable {
     }
 }
 
-struct V2OffersPage: Encodable {
+internal struct V2OffersPage: Encodable {
     let pageIdentifier: String
     let url: String
 
@@ -123,7 +128,7 @@ struct V2OffersPage: Encodable {
     }
 }
 
-struct V2OffersPrivacy: Encodable {
+internal struct V2OffersPrivacy: Encodable {
     let doNotTrack: Bool
     let gpcEnabled: Bool
     let doNotShareOrSell: Bool
@@ -135,7 +140,7 @@ struct V2OffersPrivacy: Encodable {
     }
 }
 
-struct V2OffersChannel: Encodable {
+internal struct V2OffersChannel: Encodable {
     let type: String
     let sdkVersion: String
 
@@ -145,6 +150,6 @@ struct V2OffersChannel: Encodable {
     }
 }
 
-struct V2OffersCustomer: Encodable {
+internal struct V2OffersCustomer: Encodable {
     let email: String
 }

--- a/Tests/ContractTests/V2OffersClient.swift
+++ b/Tests/ContractTests/V2OffersClient.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Test-only client for the v2 sessions offers endpoint on transactions-api.
+///
+/// Mobile is not yet a consumer of this surface — production code still calls
+/// `/rokt-mobile/v1/*`. This client exists so the consumer-driven pact spec can
+/// describe the v2 contract that mobile will satisfy at v1→v2 migration. Lift
+/// into `Sources/Rokt_Widget/Networking/` at cutover. See architecture plan in
+/// rokt-pact-mobile-runner.
+struct V2OffersClient {
+    let baseURL: URL
+    let urlSession: URLSession
+
+    init(baseURL: URL, urlSession: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.urlSession = urlSession
+    }
+
+    struct Headers {
+        let accountId: String
+        let authorization: String
+        let platformType: String
+        let integrationType: String
+        let requestId: String
+        let pageInstanceGuid: String
+
+        static func iOSDefaults(
+            accountId: String,
+            authorization: String,
+            requestId: String,
+            pageInstanceGuid: String
+        ) -> Headers {
+            Headers(
+                accountId: accountId,
+                authorization: authorization,
+                platformType: "iOS",
+                integrationType: "msdk-ios",
+                requestId: requestId,
+                pageInstanceGuid: pageInstanceGuid
+            )
+        }
+    }
+
+    struct Request: Encodable {
+        let sessionId: String
+        let mpSessionId: String
+        let mpid: String
+        let page: Page
+        let privacy: Privacy
+        let channel: Channel
+        let customer: Customer
+        let attributes: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case sessionId = "session_id"
+            case mpSessionId = "mp_session_id"
+            case mpid
+            case page
+            case privacy
+            case channel
+            case customer
+            case attributes
+        }
+
+        struct Page: Encodable {
+            let pageIdentifier: String
+            let url: String
+
+            enum CodingKeys: String, CodingKey {
+                case pageIdentifier = "page_identifier"
+                case url
+            }
+        }
+
+        struct Privacy: Encodable {
+            let doNotTrack: Bool
+            let gpcEnabled: Bool
+            let doNotShareOrSell: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case doNotTrack = "do_not_track"
+                case gpcEnabled = "gpc_enabled"
+                case doNotShareOrSell = "do_not_share_or_sell"
+            }
+        }
+
+        struct Channel: Encodable {
+            let type: String
+            let sdkVersion: String
+
+            enum CodingKeys: String, CodingKey {
+                case type
+                case sdkVersion = "sdk_version"
+            }
+        }
+
+        struct Customer: Encodable {
+            let email: String
+        }
+    }
+
+    func sendOffers(headers: Headers, body: Request) async throws -> (Data, URLResponse) {
+        let url = baseURL
+            .appendingPathComponent("v2")
+            .appendingPathComponent("sessions")
+            .appendingPathComponent("offers")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(headers.accountId, forHTTPHeaderField: "rokt-account-id")
+        request.setValue(headers.authorization, forHTTPHeaderField: "Authorization")
+        request.setValue(headers.platformType, forHTTPHeaderField: "rokt-platform-type")
+        request.setValue(headers.integrationType, forHTTPHeaderField: "rokt-integration-type")
+        request.setValue(headers.requestId, forHTTPHeaderField: "x-request-id")
+        request.setValue(headers.pageInstanceGuid, forHTTPHeaderField: "rokt-page-instance-guid")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        request.httpBody = try JSONEncoder().encode(body)
+
+        return try await urlSession.data(for: request)
+    }
+}

--- a/Tests/ContractTests/V2OffersClient.swift
+++ b/Tests/ContractTests/V2OffersClient.swift
@@ -3,63 +3,92 @@ import Foundation
 /// Test-only client for the v2 sessions offers endpoint on transactions-api.
 ///
 /// Mobile is not yet a consumer of this surface — production code still calls
-/// `/rokt-mobile/v1/*`. This client exists so the consumer-driven pact spec can
-/// describe the v2 contract that mobile will satisfy at v1→v2 migration. Lift
-/// into `Sources/Rokt_Widget/Networking/` at cutover. See architecture plan in
-/// rokt-pact-mobile-runner.
+/// `/rokt-mobile/v1/*`. This client describes the v2 contract that mobile will
+/// satisfy at v1→v2 migration. Lift / replace at cutover.
+///
+/// Design intentionally mirrors sdk-web's consumer-pact pattern (see
+/// `build-pact-services.ts` in that repo): the client owns wire-shape
+/// construction — header and body assembly — based on domain inputs. The
+/// pact spec describes the expected wire shape via matchers, and any drift
+/// in this client's outgoing request will be caught by the pact mock. The
+/// test never constructs the headers or body directly.
 struct V2OffersClient {
     let baseURL: URL
+    let accountId: String
+    let authToken: String
+    let sessionId: String
+    let mpSessionId: String
+    let mpid: String
+    let sdkVersion: String
+    let pageInstanceGuid: String
     let urlSession: URLSession
 
-    init(baseURL: URL, urlSession: URLSession = .shared) {
+    init(
+        baseURL: URL,
+        accountId: String,
+        authToken: String,
+        sessionId: String,
+        mpSessionId: String,
+        mpid: String,
+        sdkVersion: String,
+        pageInstanceGuid: String,
+        urlSession: URLSession = .shared
+    ) {
         self.baseURL = baseURL
+        self.accountId = accountId
+        self.authToken = authToken
+        self.sessionId = sessionId
+        self.mpSessionId = mpSessionId
+        self.mpid = mpid
+        self.sdkVersion = sdkVersion
+        self.pageInstanceGuid = pageInstanceGuid
         self.urlSession = urlSession
     }
 
-    func sendOffers(headers: V2OffersHeaders, body: V2OffersRequest) async throws -> (Data, URLResponse) {
+    func fetchOffers(input: V2OffersInput) async throws -> (Data, URLResponse) {
         let url = baseURL
             .appendingPathComponent("v2")
             .appendingPathComponent("sessions")
             .appendingPathComponent("offers")
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue(headers.accountId, forHTTPHeaderField: "rokt-account-id")
-        request.setValue(headers.authorization, forHTTPHeaderField: "Authorization")
-        request.setValue(headers.platformType, forHTTPHeaderField: "rokt-platform-type")
-        request.setValue(headers.integrationType, forHTTPHeaderField: "rokt-integration-type")
-        request.setValue(headers.requestId, forHTTPHeaderField: "x-request-id")
-        request.setValue(headers.pageInstanceGuid, forHTTPHeaderField: "rokt-page-instance-guid")
+        request.setValue(accountId, forHTTPHeaderField: "rokt-account-id")
+        request.setValue(authToken, forHTTPHeaderField: "Authorization")
+        request.setValue("iOS", forHTTPHeaderField: "rokt-platform-type")
+        request.setValue("msdk-ios", forHTTPHeaderField: "rokt-integration-type")
+        request.setValue(input.requestId, forHTTPHeaderField: "x-request-id")
+        request.setValue(pageInstanceGuid, forHTTPHeaderField: "rokt-page-instance-guid")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        let body = V2OffersRequest(
+            sessionId: sessionId,
+            mpSessionId: mpSessionId,
+            mpid: mpid,
+            page: V2OffersPage(pageIdentifier: input.pageIdentifier, url: input.pageURL),
+            privacy: V2OffersPrivacy(doNotTrack: false, gpcEnabled: false, doNotShareOrSell: false),
+            channel: V2OffersChannel(type: "msdk", sdkVersion: sdkVersion),
+            customer: V2OffersCustomer(email: input.customerEmail),
+            attributes: input.attributes
+        )
         request.httpBody = try JSONEncoder().encode(body)
 
         return try await urlSession.data(for: request)
     }
 }
 
-struct V2OffersHeaders {
-    let accountId: String
-    let authorization: String
-    let platformType: String
-    let integrationType: String
+/// Per-call domain inputs for `V2OffersClient.fetchOffers`.
+///
+/// Holds only the values that vary per-request from a caller's perspective.
+/// Session-shaped values (account id, session token, mp ids, etc.) are
+/// injected at client construction time, mirroring how a production iOS
+/// service would resolve them from session / config services.
+struct V2OffersInput {
     let requestId: String
-    let pageInstanceGuid: String
-
-    static func iOSDefaults(
-        accountId: String,
-        authorization: String,
-        requestId: String,
-        pageInstanceGuid: String
-    ) -> V2OffersHeaders {
-        V2OffersHeaders(
-            accountId: accountId,
-            authorization: authorization,
-            platformType: "iOS",
-            integrationType: "msdk-ios",
-            requestId: requestId,
-            pageInstanceGuid: pageInstanceGuid
-        )
-    }
+    let pageIdentifier: String
+    let pageURL: String
+    let customerEmail: String
+    let attributes: [String: String]
 }
 
 struct V2OffersRequest: Encodable {

--- a/Tests/ContractTests/V2OffersClient.swift
+++ b/Tests/ContractTests/V2OffersClient.swift
@@ -16,90 +16,7 @@ struct V2OffersClient {
         self.urlSession = urlSession
     }
 
-    struct Headers {
-        let accountId: String
-        let authorization: String
-        let platformType: String
-        let integrationType: String
-        let requestId: String
-        let pageInstanceGuid: String
-
-        static func iOSDefaults(
-            accountId: String,
-            authorization: String,
-            requestId: String,
-            pageInstanceGuid: String
-        ) -> Headers {
-            Headers(
-                accountId: accountId,
-                authorization: authorization,
-                platformType: "iOS",
-                integrationType: "msdk-ios",
-                requestId: requestId,
-                pageInstanceGuid: pageInstanceGuid
-            )
-        }
-    }
-
-    struct Request: Encodable {
-        let sessionId: String
-        let mpSessionId: String
-        let mpid: String
-        let page: Page
-        let privacy: Privacy
-        let channel: Channel
-        let customer: Customer
-        let attributes: [String: String]
-
-        enum CodingKeys: String, CodingKey {
-            case sessionId = "session_id"
-            case mpSessionId = "mp_session_id"
-            case mpid
-            case page
-            case privacy
-            case channel
-            case customer
-            case attributes
-        }
-
-        struct Page: Encodable {
-            let pageIdentifier: String
-            let url: String
-
-            enum CodingKeys: String, CodingKey {
-                case pageIdentifier = "page_identifier"
-                case url
-            }
-        }
-
-        struct Privacy: Encodable {
-            let doNotTrack: Bool
-            let gpcEnabled: Bool
-            let doNotShareOrSell: Bool
-
-            enum CodingKeys: String, CodingKey {
-                case doNotTrack = "do_not_track"
-                case gpcEnabled = "gpc_enabled"
-                case doNotShareOrSell = "do_not_share_or_sell"
-            }
-        }
-
-        struct Channel: Encodable {
-            let type: String
-            let sdkVersion: String
-
-            enum CodingKeys: String, CodingKey {
-                case type
-                case sdkVersion = "sdk_version"
-            }
-        }
-
-        struct Customer: Encodable {
-            let email: String
-        }
-    }
-
-    func sendOffers(headers: Headers, body: Request) async throws -> (Data, URLResponse) {
+    func sendOffers(headers: V2OffersHeaders, body: V2OffersRequest) async throws -> (Data, URLResponse) {
         let url = baseURL
             .appendingPathComponent("v2")
             .appendingPathComponent("sessions")
@@ -118,4 +35,87 @@ struct V2OffersClient {
 
         return try await urlSession.data(for: request)
     }
+}
+
+struct V2OffersHeaders {
+    let accountId: String
+    let authorization: String
+    let platformType: String
+    let integrationType: String
+    let requestId: String
+    let pageInstanceGuid: String
+
+    static func iOSDefaults(
+        accountId: String,
+        authorization: String,
+        requestId: String,
+        pageInstanceGuid: String
+    ) -> V2OffersHeaders {
+        V2OffersHeaders(
+            accountId: accountId,
+            authorization: authorization,
+            platformType: "iOS",
+            integrationType: "msdk-ios",
+            requestId: requestId,
+            pageInstanceGuid: pageInstanceGuid
+        )
+    }
+}
+
+struct V2OffersRequest: Encodable {
+    let sessionId: String
+    let mpSessionId: String
+    let mpid: String
+    let page: V2OffersPage
+    let privacy: V2OffersPrivacy
+    let channel: V2OffersChannel
+    let customer: V2OffersCustomer
+    let attributes: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case mpSessionId = "mp_session_id"
+        case mpid
+        case page
+        case privacy
+        case channel
+        case customer
+        case attributes
+    }
+}
+
+struct V2OffersPage: Encodable {
+    let pageIdentifier: String
+    let url: String
+
+    enum CodingKeys: String, CodingKey {
+        case pageIdentifier = "page_identifier"
+        case url
+    }
+}
+
+struct V2OffersPrivacy: Encodable {
+    let doNotTrack: Bool
+    let gpcEnabled: Bool
+    let doNotShareOrSell: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case doNotTrack = "do_not_track"
+        case gpcEnabled = "gpc_enabled"
+        case doNotShareOrSell = "do_not_share_or_sell"
+    }
+}
+
+struct V2OffersChannel: Encodable {
+    let type: String
+    let sdkVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case sdkVersion = "sdk_version"
+    }
+}
+
+struct V2OffersCustomer: Encodable {
+    let email: String
 }

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -19,7 +19,7 @@ final class V2OffersClientPactSpec: XCTestCase {
 
         Self.mockService
             .uponReceiving("a v2 sessions offers request from rokt-sdk-ios for a configured page")
-            .given(ProviderState(description: "a valid offers request is submitted"))
+            .given(ProviderState(description: "a valid offers request is submitted", params: [:]))
             .withRequest(
                 method: .POST,
                 path: "/v2/sessions/offers",
@@ -92,7 +92,8 @@ final class V2OffersClientPactSpec: XCTestCase {
             Task {
                 defer { done() }
                 do {
-                    let client = V2OffersClient(baseURL: baseURL)
+                    let url = try XCTUnwrap(URL(string: baseURL))
+                    let client = V2OffersClient(baseURL: url)
                     let headers = V2OffersClient.Headers.iOSDefaults(
                         accountId: "account-456",
                         authorization: "Bearer session-token-abc",

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -1,7 +1,7 @@
 import XCTest
 import PactSwift
 
-final class V2OffersClientPactSpec: XCTestCase {
+class V2OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
     override class func setUp() {
@@ -30,7 +30,7 @@ final class V2OffersClientPactSpec: XCTestCase {
                     "rokt-integration-type": Matcher.SomethingLike("msdk-ios"),
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    "Content-Type": "application/json",
+                    "Content-Type": "application/json"
                 ],
                 body: [
                     "session_id": Matcher.SomethingLike("session-123"),
@@ -38,24 +38,24 @@ final class V2OffersClientPactSpec: XCTestCase {
                     "mpid": Matcher.SomethingLike("mpid-123"),
                     "page": [
                         "page_identifier": Matcher.SomethingLike("checkout-page"),
-                        "url": Matcher.SomethingLike("https://merchant.test/checkout"),
+                        "url": Matcher.SomethingLike("https://merchant.test/checkout")
                     ],
                     "privacy": [
                         "do_not_track": Matcher.SomethingLike(false),
                         "gpc_enabled": Matcher.SomethingLike(false),
-                        "do_not_share_or_sell": Matcher.SomethingLike(false),
+                        "do_not_share_or_sell": Matcher.SomethingLike(false)
                     ],
                     "channel": [
                         "type": Matcher.SomethingLike("msdk"),
-                        "sdk_version": Matcher.SomethingLike("5.2.2"),
+                        "sdk_version": Matcher.SomethingLike("5.2.2")
                     ],
                     "customer": [
-                        "email": Matcher.SomethingLike("user@example.com"),
+                        "email": Matcher.SomethingLike("user@example.com")
                     ],
                     "attributes": [
                         "standalone": Matcher.SomethingLike("notdefined"),
-                        "customer.locale": Matcher.SomethingLike("en-US"),
-                    ],
+                        "customer.locale": Matcher.SomethingLike("en-US")
+                    ]
                 ]
             )
             .willRespondWith(
@@ -65,7 +65,7 @@ final class V2OffersClientPactSpec: XCTestCase {
                     "session_id": Matcher.SomethingLike("session-123"),
                     "session_token": [
                         "token": Matcher.SomethingLike("rotated-session-token"),
-                        "expires_at": Matcher.SomethingLike(1_774_474_053_000),
+                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
                     ],
                     "page_context": [
                         "rokt_tag_id": Matcher.SomethingLike("tag-123"),
@@ -74,15 +74,15 @@ final class V2OffersClientPactSpec: XCTestCase {
                         "page_type": Matcher.RegexLike("checkout", term: validPageTypes),
                         "language": Matcher.SomethingLike("en-US"),
                         "is_page_detected": Matcher.SomethingLike(true),
-                        "page_variant_name": Matcher.SomethingLike("control"),
+                        "page_variant_name": Matcher.SomethingLike("control")
                     ],
                     "plugins": [],
                     "placements": [],
                     "event_data": [:],
                     "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123"),
                     "privacy_control": [
-                        "limited_use": Matcher.SomethingLike(false),
-                    ],
+                        "limited_use": Matcher.SomethingLike(false)
+                    ]
                 ]
             )
 
@@ -94,30 +94,30 @@ final class V2OffersClientPactSpec: XCTestCase {
                 do {
                     let url = try XCTUnwrap(URL(string: baseURL))
                     let client = V2OffersClient(baseURL: url)
-                    let headers = V2OffersClient.Headers.iOSDefaults(
+                    let headers = V2OffersHeaders.iOSDefaults(
                         accountId: "account-456",
                         authorization: "Bearer session-token-abc",
                         requestId: "request-id-123",
                         pageInstanceGuid: "page-instance-guid-123"
                     )
-                    let body = V2OffersClient.Request(
+                    let body = V2OffersRequest(
                         sessionId: "session-123",
                         mpSessionId: "mp-session-123",
                         mpid: "mpid-123",
-                        page: .init(
+                        page: V2OffersPage(
                             pageIdentifier: "checkout-page",
                             url: "https://merchant.test/checkout"
                         ),
-                        privacy: .init(
+                        privacy: V2OffersPrivacy(
                             doNotTrack: false,
                             gpcEnabled: false,
                             doNotShareOrSell: false
                         ),
-                        channel: .init(type: "msdk", sdkVersion: "5.2.2"),
-                        customer: .init(email: "user@example.com"),
+                        channel: V2OffersChannel(type: "msdk", sdkVersion: "5.2.2"),
+                        customer: V2OffersCustomer(email: "user@example.com"),
                         attributes: [
                             "standalone": "notdefined",
-                            "customer.locale": "en-US",
+                            "customer.locale": "en-US"
                         ]
                     )
                     let (_, response) = try await client.sendOffers(headers: headers, body: body)

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -1,5 +1,6 @@
 import XCTest
 import PactSwift
+@testable import Rokt_Widget
 
 /// Consumer-driven pact spec for the v2 `/v2/sessions/offers` endpoint.
 ///
@@ -13,6 +14,14 @@ import PactSwift
 /// Pattern mirrors sdk-web's consumer-pact specs (see PR ROKT/sdk-web#1372):
 /// the test never constructs request headers or body directly, only domain
 /// inputs. Wire-shape construction lives entirely in `V2OffersClient`.
+///
+/// Matcher policy: fixed-value strings hardcoded in `V2OffersClient`
+/// (`"iOS"`, `"msdk-ios"`, `"msdk"`) are pinned as exact strings rather
+/// than `SomethingLike`. `SomethingLike` only matches by type, which
+/// would let the client drift to `"ios-mobile"` without failing the
+/// consumer test. Per-runtime values (account id, auth token, request id,
+/// session ids, page identifier, etc.) stay as `SomethingLike` because
+/// they legitimately vary per call.
 class V2OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -38,8 +47,8 @@ class V2OffersClientPactSpec: XCTestCase {
                 headers: [
                     "rokt-account-id": Matcher.SomethingLike("account-456"),
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
-                    "rokt-platform-type": Matcher.SomethingLike("iOS"),
-                    "rokt-integration-type": Matcher.SomethingLike("msdk-ios"),
+                    "rokt-platform-type": "iOS",
+                    "rokt-integration-type": "msdk-ios",
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
                     "Content-Type": "application/json"
@@ -58,7 +67,7 @@ class V2OffersClientPactSpec: XCTestCase {
                         "do_not_share_or_sell": Matcher.SomethingLike(false)
                     ],
                     "channel": [
-                        "type": Matcher.SomethingLike("msdk"),
+                        "type": "msdk",
                         "sdk_version": Matcher.SomethingLike("5.2.2")
                     ],
                     "customer": [

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -1,6 +1,18 @@
 import XCTest
 import PactSwift
 
+/// Consumer-driven pact spec for the v2 `/v2/sessions/offers` endpoint.
+///
+/// Drives `V2OffersClient.fetchOffers(input:)` — a public method that takes
+/// domain inputs (page identifier, customer email, attributes, request-scoped
+/// ids) and internally builds the wire request. The pact matchers below
+/// describe the EXPECTED wire shape; if `V2OffersClient` ever drifts from
+/// those expectations (e.g., sends `rokt-platform-type: "ios-mobile"` instead
+/// of `"iOS"`), the pact mock service rejects the request and this test fails.
+///
+/// Pattern mirrors sdk-web's consumer-pact specs (see PR ROKT/sdk-web#1372):
+/// the test never constructs request headers or body directly, only domain
+/// inputs. Wire-shape construction lives entirely in `V2OffersClient`.
 class V2OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -93,34 +105,27 @@ class V2OffersClientPactSpec: XCTestCase {
                 defer { done() }
                 do {
                     let url = try XCTUnwrap(URL(string: baseURL))
-                    let client = V2OffersClient(baseURL: url)
-                    let headers = V2OffersHeaders.iOSDefaults(
+                    let client = V2OffersClient(
+                        baseURL: url,
                         accountId: "account-456",
-                        authorization: "Bearer session-token-abc",
-                        requestId: "request-id-123",
-                        pageInstanceGuid: "page-instance-guid-123"
-                    )
-                    let body = V2OffersRequest(
+                        authToken: "Bearer session-token-abc",
                         sessionId: "session-123",
                         mpSessionId: "mp-session-123",
                         mpid: "mpid-123",
-                        page: V2OffersPage(
-                            pageIdentifier: "checkout-page",
-                            url: "https://merchant.test/checkout"
-                        ),
-                        privacy: V2OffersPrivacy(
-                            doNotTrack: false,
-                            gpcEnabled: false,
-                            doNotShareOrSell: false
-                        ),
-                        channel: V2OffersChannel(type: "msdk", sdkVersion: "5.2.2"),
-                        customer: V2OffersCustomer(email: "user@example.com"),
+                        sdkVersion: "5.2.2",
+                        pageInstanceGuid: "page-instance-guid-123"
+                    )
+                    let input = V2OffersInput(
+                        requestId: "request-id-123",
+                        pageIdentifier: "checkout-page",
+                        pageURL: "https://merchant.test/checkout",
+                        customerEmail: "user@example.com",
                         attributes: [
                             "standalone": "notdefined",
                             "customer.locale": "en-US"
                         ]
                     )
-                    let (_, response) = try await client.sendOffers(headers: headers, body: body)
+                    let (_, response) = try await client.fetchOffers(input: input)
                     let httpResponse = response as? HTTPURLResponse
                     XCTAssertEqual(httpResponse?.statusCode, 200)
                 } catch {

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -1,0 +1,134 @@
+import XCTest
+import PactSwift
+
+final class V2OffersClientPactSpec: XCTestCase {
+    static var mockService: MockService!
+
+    override class func setUp() {
+        super.setUp()
+        let outputDir = URL(fileURLWithPath: "pacts", isDirectory: true)
+        mockService = MockService(
+            consumer: "rokt-sdk-ios",
+            provider: "transactions-api",
+            writePactTo: outputDir
+        )
+    }
+
+    func test_offersHappyPath_pageDetectionMatches() {
+        let validPageTypes = #"^(checkout|confirmation|post_purchase|cart|landing|product)$"#
+
+        Self.mockService
+            .uponReceiving("a v2 sessions offers request from rokt-sdk-ios for a configured page")
+            .given(ProviderState(description: "a valid offers request is submitted"))
+            .withRequest(
+                method: .POST,
+                path: "/v2/sessions/offers",
+                headers: [
+                    "rokt-account-id": Matcher.SomethingLike("account-456"),
+                    "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
+                    "rokt-platform-type": Matcher.SomethingLike("iOS"),
+                    "rokt-integration-type": Matcher.SomethingLike("msdk-ios"),
+                    "x-request-id": Matcher.SomethingLike("request-id-123"),
+                    "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
+                    "Content-Type": "application/json",
+                ],
+                body: [
+                    "session_id": Matcher.SomethingLike("session-123"),
+                    "mp_session_id": Matcher.SomethingLike("mp-session-123"),
+                    "mpid": Matcher.SomethingLike("mpid-123"),
+                    "page": [
+                        "page_identifier": Matcher.SomethingLike("checkout-page"),
+                        "url": Matcher.SomethingLike("https://merchant.test/checkout"),
+                    ],
+                    "privacy": [
+                        "do_not_track": Matcher.SomethingLike(false),
+                        "gpc_enabled": Matcher.SomethingLike(false),
+                        "do_not_share_or_sell": Matcher.SomethingLike(false),
+                    ],
+                    "channel": [
+                        "type": Matcher.SomethingLike("msdk"),
+                        "sdk_version": Matcher.SomethingLike("5.2.2"),
+                    ],
+                    "customer": [
+                        "email": Matcher.SomethingLike("user@example.com"),
+                    ],
+                    "attributes": [
+                        "standalone": Matcher.SomethingLike("notdefined"),
+                        "customer.locale": Matcher.SomethingLike("en-US"),
+                    ],
+                ]
+            )
+            .willRespondWith(
+                status: 200,
+                headers: ["Content-Type": "application/json"],
+                body: [
+                    "session_id": Matcher.SomethingLike("session-123"),
+                    "session_token": [
+                        "token": Matcher.SomethingLike("rotated-session-token"),
+                        "expires_at": Matcher.SomethingLike(1_774_474_053_000),
+                    ],
+                    "page_context": [
+                        "rokt_tag_id": Matcher.SomethingLike("tag-123"),
+                        "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123"),
+                        "page_id": Matcher.SomethingLike("checkout-page"),
+                        "page_type": Matcher.RegexLike("checkout", term: validPageTypes),
+                        "language": Matcher.SomethingLike("en-US"),
+                        "is_page_detected": Matcher.SomethingLike(true),
+                        "page_variant_name": Matcher.SomethingLike("control"),
+                    ],
+                    "plugins": [],
+                    "placements": [],
+                    "event_data": [:],
+                    "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123"),
+                    "privacy_control": [
+                        "limited_use": Matcher.SomethingLike(false),
+                    ],
+                ]
+            )
+
+        let expectation = expectation(description: "v2 offers request completes")
+
+        Self.mockService.run(timeout: 5) { baseURL, done in
+            Task {
+                defer { done() }
+                do {
+                    let client = V2OffersClient(baseURL: baseURL)
+                    let headers = V2OffersClient.Headers.iOSDefaults(
+                        accountId: "account-456",
+                        authorization: "Bearer session-token-abc",
+                        requestId: "request-id-123",
+                        pageInstanceGuid: "page-instance-guid-123"
+                    )
+                    let body = V2OffersClient.Request(
+                        sessionId: "session-123",
+                        mpSessionId: "mp-session-123",
+                        mpid: "mpid-123",
+                        page: .init(
+                            pageIdentifier: "checkout-page",
+                            url: "https://merchant.test/checkout"
+                        ),
+                        privacy: .init(
+                            doNotTrack: false,
+                            gpcEnabled: false,
+                            doNotShareOrSell: false
+                        ),
+                        channel: .init(type: "msdk", sdkVersion: "5.2.2"),
+                        customer: .init(email: "user@example.com"),
+                        attributes: [
+                            "standalone": "notdefined",
+                            "customer.locale": "en-US",
+                        ]
+                    )
+                    let (_, response) = try await client.sendOffers(headers: headers, body: body)
+                    let httpResponse = response as? HTTPURLResponse
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+                } catch {
+                    XCTFail("V2OffersClient request failed: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 6)
+    }
+}


### PR DESCRIPTION
## Background

This PR scaffolds consumer-driven [pact](https://docs.pact.io) contract testing for the iOS SDK against the unified `transactions-api` v2 surface (`/v2/sessions/offers`, `/v2/sessions/events`).

Some upfront context that will make the diff make more sense:

**Mobile isn't a consumer of `transactions-api` yet.** The SDK still calls `/rokt-mobile/v1/*`. The pact contract introduced here describes the **v2 surface** the SDK will satisfy when it migrates from v1 to v2. Until cutover, every pact gate is advisory — failures won't block merges and the contract effectively serves as a migration spec.

**`V2OffersClient` ships in the SDK from this PR, but is not called by any production code path.** It lives at `Sources/Rokt_Widget/Networking/V2OffersClient.swift` (internal visibility) alongside the existing `RoktNetWorkAPI` v1 implementation. Putting the client (and its wire model: `V2OffersRequest`, `V2OffersPage`, `V2OffersPrivacy`, `V2OffersChannel`, `V2OffersCustomer`, `V2OffersInput`) in `Sources/` rather than `Tests/` means the pact contract constrains the actual shipping SDK code, not a test-only stand-in — at v1→v2 migration there's no separate "lift" step that could silently introduce drift. The client is `internal`, accessed from the contract test via `@testable import Rokt_Widget`, so it doesn't widen the SDK's public API. At cutover, callers in the v1 networking path switch to invoking `V2OffersClient.fetchOffers(input:)`; the wire shape is already pinned by this pact contract.

**This PR is CI-neutral.** A follow-up PR will add a GitHub Actions workflow (`.github/workflows/pact-consumer.yml`) that runs the consumer test on a GitHub-provided `macos-latest` runner on PRs and, on push to `main`, publishes the pact JSON directly to the pact broker (publicly readable, auth-gated writes). The publish step is gated by a repository environment (`pact-publish`) requiring a `@ROKT/sdk-engineering` reviewer to expose `PACT_BROKER_USERNAME`/`PACT_BROKER_PASSWORD`, so untrusted PR commits cannot reach the publish path. PR-supplied code runs only on GitHub-provided runners; the only secret-bearing surface (the broker write endpoint) is gated by maintainer approval. The CI design has been reviewed with security.

**Architectural pattern aligned with the equivalent web SDK contracts.** The consumer spec is shaped to match the established pattern: the test provides domain inputs only; the client owns wire-shape construction (headers, body); the pact matchers describe the expected wire shape and act as the source of truth. Drift in the client's outgoing request will fail at the pact mock service — the test cannot silently agree with arbitrary client output.

## What has changed

- **`Sources/Rokt_Widget/Networking/V2OffersClient.swift`** — new file. `V2OffersClient` (internal struct) + wire-model structs (`V2OffersInput`, `V2OffersRequest`, `V2OffersPage`, `V2OffersPrivacy`, `V2OffersChannel`, `V2OffersCustomer`). Initializer takes the session-shaped values a production iOS service would resolve from session / config services (`accountId`, `authToken`, `sessionId`, `mpSessionId`, `mpid`, `sdkVersion`, `pageInstanceGuid`). The single public method `fetchOffers(input:)` takes a per-call `V2OffersInput` (request id, page identifier, page URL, customer email, attributes) and internally assembles every header and the full request body. Hardcoded iOS-specific values (`rokt-platform-type: "iOS"`, `rokt-integration-type: "msdk-ios"`, `Content-Type: application/json`, channel type `"msdk"`) live in the client only. Callers do not supply them.
- **`Package.swift`** — adds [PactSwift](https://github.com/surpher/PactSwift) `1.2.x` as a test-target dependency, plus a new `ContractTests` test target at `Tests/ContractTests/`. The new target is intentionally separate from `Rokt_WidgetTests` so PactSwift doesn't bloat normal unit-test runs. `ContractTests` depends on `Rokt_Widget` so it can `@testable import` `V2OffersClient`.
- **`Tests/ContractTests/V2OffersClientPactSpec.swift`** — one happy-path consumer pact interaction with provider state `a valid offers request is submitted`. Drives `V2OffersClient.fetchOffers(input:)` with realistic domain inputs. Matchers follow the conventions used for the equivalent web SDK contracts: `Matcher.SomethingLike` for runtime-variable values (account id, auth token, session ids, request id, page identifier, etc.), `Matcher.RegexLike` for the `page_type` enum, and **exact strings** for values that are hardcoded constants in `V2OffersClient` (`"iOS"`, `"msdk-ios"`, channel `"msdk"`, `Content-Type`). Exact-string matching ensures the consumer test fails if the client ever drifts (e.g., starts sending `"ios-mobile"` instead of `"iOS"`) — type-only matching wouldn't catch that.
- **`.gitignore`** — adds `pacts/`. The pact JSON artifact is generated by the contract test, picked up by the GH Actions workflow (in the follow-up PR), and published directly to the pact broker. It is never committed to this repo.

## How has this been tested

Run locally on macOS via Xcode (Cmd+U) against an iOS Simulator destination:

```
xcodebuild test \
  -scheme Rokt-Widget \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:ContractTests
```

Verified outcomes:

- `test_offersHappyPath_pageDetectionMatches` passes (~0.06s on iPhone 17 Pro / iOS 26.5).
- Pact JSON is generated by PactSwift inside the simulator sandbox.
- The JSON's `consumer.name = rokt-sdk-ios`, `provider.name = transactions-api`, one interaction at POST `/v2/sessions/offers`, all 7 expected headers and the full body shape. Variable values carry a `type` matcher; the four fixed-constant values (`rokt-platform-type: "iOS"`, `rokt-integration-type: "msdk-ios"`, `channel.type: "msdk"`, `Content-Type: "application/json"`) carry no matcher (exact-string assertion).
- `pactSpecification.version: "3.0.0"` — compatible with the existing pact broker.

The publish side lands with the follow-up PR (`.github/workflows/pact-consumer.yml` — direct broker publish, env-protected). Existing infrastructure produces the correct pact JSON locally; end-to-end validation through the broker lands once the broker's public-read change is deployed.

## Notes

- **Initial scaffolding only — one happy-path interaction.** A follow-up PR will add the events endpoint (`/v2/sessions/events`) and a minimal-payload offers variant (provider state `no page detection on offers request`), bringing the merged pact JSON to three interactions. Once both PRs land, the contract surface matches what the web SDK already publishes for the same provider.
- This PR adds shipping code (`V2OffersClient` + wire models in `Sources/`) but no production code path invokes it; existing v1 networking is unchanged. No required-checks are added.
- The follow-up GH Actions workflow publishes directly to the broker; no internal CI infrastructure executes any PR-supplied Swift code at any point.
- Provider states used here (`a valid offers request is submitted`) already exist in the provider-side fixture — no fixture changes required on the provider side.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. (deferred — a docs section explaining the v1→v2 migration path for iOS engineers lands with the follow-up PR)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully. (GH Actions checks on this repo. The Buildkite pipeline is no longer associated with this repo as of 2026-05-22 — the publish side moves to a GH-Actions-direct-publish design in the follow-up PR.)
- [ ] All insignificant commits have been squashed. (intentionally separate commits for the scaffold, PactSwift v1.2.1 API adaptation, swiftlint fixes, the architectural refactor to match the established pattern, and the response to review feedback — happy to squash on request)
