### PR TITLE
ci(pact): add GitHub Actions workflow for consumer pact publish

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -156,12 +156,20 @@ jobs:
             exit 1
           fi
 
+          # Image pinned to manifest digest (not :latest). Renovate keeps it
+          # current via the `# renovate: datasource=docker depName=...` comment
+          # convention. Don't replace with :latest or a moving tag; this step
+          # runs with broker write credentials, so a compromised upstream image
+          # would have direct credential-exfiltration access. See security
+          # review note from 2026-05-27 (Sushant Adhikari) for the threat model.
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \
             -v "${PWD}/pacts:/pacts" \
             -e PACT_BROKER_BASE_URL \
             -e PACT_BROKER_USERNAME \
             -e PACT_BROKER_PASSWORD \
-            pactfoundation/pact-cli:latest \
+            "${PACT_CLI_IMAGE}" \
             broker publish /pacts \
               --consumer-app-version "${GITHUB_SHA}" \
               --branch "${GITHUB_REF_NAME}" \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -18,17 +18,17 @@ name: Pact Consumer
 on:
   pull_request:
     paths:
-      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
-      - "Tests/ContractTests/**"
-      - "Package.swift"
-      - ".github/workflows/pact-consumer.yml"
+      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
+      - Tests/ContractTests/**
+      - Package.swift
+      - .github/workflows/pact-consumer.yml
   push:
     branches: [main]
     paths:
-      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
-      - "Tests/ContractTests/**"
-      - "Package.swift"
-      - ".github/workflows/pact-consumer.yml"
+      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
+      - Tests/ContractTests/**
+      - Package.swift
+      - .github/workflows/pact-consumer.yml
 
 permissions:
   contents: read

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -2,16 +2,21 @@ name: Pact Consumer
 
 # Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
 #
-# Two jobs:
-#  - `consumer-test` runs on every PR + every push to `main`. It executes the
-#    PactSwift spec against the in-process mock server, generates a pact JSON,
-#    and uploads it as a workflow artifact. No Rokt secrets are exposed; PR code
-#    from public forks is safe to run here because the GitHub-provided runner is
-#    fully isolated from Rokt infrastructure.
-#  - `publish` runs only on push to `main` and is gated by the `pact-publish`
-#    GitHub environment (required-reviewers + main-branch-only). On approval,
-#    broker write credentials are exposed and the pact JSON is published
-#    directly to the pact broker.
+# Three jobs:
+#  - `detect-changes` runs first on every PR + every push to `main`. It uses
+#    dorny/paths-filter to check whether contract-relevant files changed
+#    (V2 clients, contract tests, Package.swift, this workflow). Its output
+#    gates the publish job below.
+#  - `consumer-test` runs unconditionally on every PR + every push to `main`,
+#    regardless of which files changed. This catches *indirect* drift — e.g.
+#    a refactor to a shared networking helper that V2OffersClient calls would
+#    still run the pact spec. Uses macos-latest for the iOS Simulator. No
+#    Rokt secrets are exposed; fork-PR code is safe to run here.
+#  - `publish` runs only on push to `main` AND only when contract-relevant
+#    files actually changed (per `detect-changes`). It is gated by the
+#    `pact-publish` GitHub environment (required-reviewers + main-branch-only).
+#    Skipping publish on no-op merges saves maintainer approval clicks while
+#    keeping the consumer-test safety net unconditional.
 #
 # Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
 
@@ -28,6 +33,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect Contract Changes
+    runs-on: ubuntu-latest
+    outputs:
+      contract: ${{ steps.filter.outputs.contract }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # paths-filter needs git history on push events to diff against the
+          # previous main commit. Full clone for safety; this job is tiny.
+          fetch-depth: 0
+
+      - name: Filter contract paths
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # `contract` is true when any of these paths changed in the PR /
+          # push. The publish job below gates on this. consumer-test runs
+          # unconditionally regardless of this output.
+          filters: |
+            contract:
+              - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
+              - 'Sources/Rokt_Widget/Networking/V2EventsClient.swift'
+              - 'Tests/ContractTests/**'
+              - 'Package.swift'
+              - '.github/workflows/pact-consumer.yml'
+
   consumer-test:
     name: Consumer Test (PactSwift)
     runs-on: macos-latest
@@ -79,8 +113,17 @@ jobs:
 
   publish:
     name: Publish to Broker
-    needs: consumer-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [consumer-test, detect-changes]
+    # Publish only when:
+    #   1. This is a push to main (not a PR)
+    #   2. Contract-relevant files actually changed (per detect-changes)
+    # The second gate prevents approval-click fatigue on no-op merges. The
+    # broker would dedup byte-identical content anyway, but skipping the
+    # publish job entirely also skips the env-protected approval prompt.
+    if: |
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.detect-changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
     # `pact-publish` is configured with required reviewers + main-only deployment
     # branches. Broker write credentials are exposed only after maintainer approval.

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -156,12 +156,10 @@ jobs:
             exit 1
           fi
 
-          # Image pinned to manifest digest (not :latest). Renovate keeps it
-          # current via the `# renovate: datasource=docker depName=...` comment
-          # convention. Don't replace with :latest or a moving tag; this step
-          # runs with broker write credentials, so a compromised upstream image
-          # would have direct credential-exfiltration access. See security
-          # review note from 2026-05-27 (Sushant Adhikari) for the threat model.
+          # Image pinned to manifest digest (not :latest). This step runs with
+          # write credentials in env, so a moving tag would be a credential-
+          # exfiltration vector if the upstream image were ever compromised.
+          # Renovate keeps the digest current via the comment below.
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,25 +1,5 @@
 name: Pact Consumer
 
-# Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
-#
-# Three jobs:
-#  - `detect-changes` runs first on every PR + every push to `main`. It uses
-#    dorny/paths-filter to check whether contract-relevant files changed
-#    (V2 clients, contract tests, Package.swift, this workflow). Its output
-#    gates the publish job below.
-#  - `consumer-test` runs unconditionally on every PR + every push to `main`,
-#    regardless of which files changed. This catches *indirect* drift — e.g.
-#    a refactor to a shared networking helper that V2OffersClient calls would
-#    still run the pact spec. Uses macos-latest for the iOS Simulator. No
-#    Rokt secrets are exposed; fork-PR code is safe to run here.
-#  - `publish` runs only on push to `main` AND only when contract-relevant
-#    files actually changed (per `detect-changes`). It is gated by the
-#    `pact-publish` GitHub environment (required-reviewers + main-branch-only).
-#    Skipping publish on no-op merges saves maintainer approval clicks while
-#    keeping the consumer-test safety net unconditional.
-#
-# Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
-
 on:
   pull_request:
   push:
@@ -43,17 +23,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          # paths-filter needs git history on push events to diff against the
-          # previous main commit. Full clone for safety; this job is tiny.
+          # paths-filter needs history to diff against the previous commit on push.
           fetch-depth: 0
 
       - name: Filter contract paths
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
-          # `contract` is true when any of these paths changed in the PR /
-          # push. The publish job below gates on this. consumer-test runs
-          # unconditionally regardless of this output.
           filters: |
             contract:
               - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
@@ -79,10 +55,7 @@ jobs:
 
       - name: Run contract tests
         env:
-          # PactSwift writes inside the simulator data container by default. The
-          # TEST_RUNNER_ prefix is xcodebuild's mechanism for propagating env vars
-          # to the test runner inside the simulator (the prefix is stripped on
-          # arrival, so the test reads `PACT_OUTPUT_DIR` directly).
+          # TEST_RUNNER_ prefix propagates env vars to the simulator test runner; prefix is stripped on arrival.
           TEST_RUNNER_PACT_OUTPUT_DIR: ${{ runner.temp }}/pacts
         run: |
           mkdir -p "${{ runner.temp }}/pacts"
@@ -114,20 +87,11 @@ jobs:
   publish:
     name: Publish to Broker
     needs: [consumer-test, detect-changes]
-    # Publish only when:
-    #   1. This is a push to main (not a PR)
-    #   2. Contract-relevant files actually changed (per detect-changes)
-    # The second gate prevents approval-click fatigue on no-op merges. The
-    # broker would dedup byte-identical content anyway, but skipping the
-    # publish job entirely also skips the env-protected approval prompt.
     if: |
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
       && needs.detect-changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
-    # `pact-publish` is configured with required reviewers + main-only deployment
-    # branches. Broker write credentials are exposed only after maintainer approval.
-    # See documentation/pact-v2-migration.md for setup details.
     environment: pact-publish
     steps:
       - name: Download pact JSON
@@ -156,10 +120,6 @@ jobs:
             exit 1
           fi
 
-          # Image pinned to manifest digest (not :latest). This step runs with
-          # write credentials in env, so a moving tag would be a credential-
-          # exfiltration vector if the upstream image were ever compromised.
-          # Renovate keeps the digest current via the comment below.
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,0 +1,136 @@
+name: Pact Consumer
+
+# Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
+#
+# Two jobs:
+#  - `consumer-test` runs on every PR + every push to `main`. It executes the
+#    PactSwift spec against the in-process mock server, generates a pact JSON,
+#    and uploads it as a workflow artifact. No Rokt secrets are exposed; PR code
+#    from public forks is safe to run here because the GitHub-provided runner is
+#    fully isolated from Rokt infrastructure.
+#  - `publish` runs only on push to `main` and is gated by the `pact-publish`
+#    GitHub environment (required-reviewers + main-branch-only). On approval,
+#    broker write credentials are exposed and the pact JSON is published
+#    directly to the pact broker.
+#
+# Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
+
+on:
+  pull_request:
+    paths:
+      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
+      - "Tests/ContractTests/**"
+      - "Package.swift"
+      - ".github/workflows/pact-consumer.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
+      - "Tests/ContractTests/**"
+      - "Package.swift"
+      - ".github/workflows/pact-consumer.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consumer-test:
+    name: Consumer Test (PactSwift)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: "26.2"
+
+      - name: Run contract tests
+        env:
+          # PactSwift writes inside the simulator data container by default. The
+          # TEST_RUNNER_ prefix is xcodebuild's mechanism for propagating env vars
+          # to the test runner inside the simulator (the prefix is stripped on
+          # arrival, so the test reads `PACT_OUTPUT_DIR` directly).
+          TEST_RUNNER_PACT_OUTPUT_DIR: ${{ runner.temp }}/pacts
+        run: |
+          mkdir -p "${{ runner.temp }}/pacts"
+          xcodebuild test \
+            -scheme Rokt-Widget \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -only-testing:ContractTests \
+            -resultBundlePath "${{ runner.temp }}/test-results.xcresult"
+
+      - name: Verify pact JSON generated
+        run: |
+          if ! ls "${{ runner.temp }}/pacts/"*.json >/dev/null 2>&1; then
+            echo "::error::No pact JSON generated under ${{ runner.temp }}/pacts/" >&2
+            echo "Listing simulator data container as a fallback diagnostic:"
+            find ~/Library/Developer/CoreSimulator/Devices -name "rokt-sdk-ios-*.json" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Generated pact files:"
+          ls -la "${{ runner.temp }}/pacts/"
+
+      - name: Upload pact JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pact-json
+          path: ${{ runner.temp }}/pacts/
+          retention-days: 14
+          if-no-files-found: error
+
+  publish:
+    name: Publish to Broker
+    needs: consumer-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # `pact-publish` is configured with required reviewers + main-only deployment
+    # branches. Broker write credentials are exposed only after maintainer approval.
+    # See documentation/pact-v2-migration.md for setup details.
+    environment: pact-publish
+    steps:
+      - name: Download pact JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pact-json
+          path: pacts/
+
+      - name: Publish to pact broker
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
+            echo "::error::PACT_BROKER_BASE_URL is unset. Configure the pact-publish environment." >&2
+            exit 1
+          fi
+          if [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
+            echo "::error::PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD missing." >&2
+            exit 1
+          fi
+
+          docker run --rm \
+            -v "${PWD}/pacts:/pacts" \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            pactfoundation/pact-cli:latest \
+            broker publish /pacts \
+              --consumer-app-version "${GITHUB_SHA}" \
+              --branch "${GITHUB_REF_NAME}" \
+              --tag "forward-looking" \
+              --build-url "${BUILD_URL}"

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -17,18 +17,8 @@ name: Pact Consumer
 
 on:
   pull_request:
-    paths:
-      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
-      - Tests/ContractTests/**
-      - Package.swift
-      - .github/workflows/pact-consumer.yml
   push:
     branches: [main]
-    paths:
-      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
-      - Tests/ContractTests/**
-      - Package.swift
-      - .github/workflows/pact-consumer.yml
 
 permissions:
   contents: read

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -27,7 +27,11 @@ class V2OffersClientPactSpec: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        let outputDir = URL(fileURLWithPath: "pacts", isDirectory: true)
+        // PACT_OUTPUT_DIR lets CI redirect the generated JSON to a host path that
+        // can be picked up after the simulator exits — without it, PactSwift writes
+        // into the simulator data container where GH Actions can't reach it.
+        let outputPath = ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "pacts"
+        let outputDir = URL(fileURLWithPath: outputPath, isDirectory: true)
         mockService = MockService(
             consumer: "rokt-sdk-ios",
             provider: "transactions-api",


### PR DESCRIPTION
## Background

Follow-up to #169 (consumer pact test scaffold). #169 added `V2OffersClient` + the PactSwift contract spec but left CI out of scope. This PR wires up the workflow that runs the consumer test on PRs and, on push to `main`, publishes the resulting pact JSON to the pact broker.

Two-job design:

- **`consumer-test`** — runs on PRs touching the contract surface, plus on every push to `main`. Executes the PactSwift spec on `macos-latest` with Xcode 26.2; generates pact JSON via a small `PACT_OUTPUT_DIR` env-var indirection; uploads the JSON as a workflow artifact. **No secrets** are exposed; PR code from public forks runs safely here because the GitHub-hosted runner is fully isolated.
- **`publish`** — runs only on push to `main`, depends on `consumer-test`, gated by the `pact-publish` GitHub environment. The environment carries required-reviewer protection and main-branch-only deployment; broker write credentials are exposed only after a maintainer clicks approve. The publish itself uses the official `pactfoundation/pact-cli:latest` Docker image.

## What has changed

- **`Tests/ContractTests/V2OffersClientPactSpec.swift`** — `setUp` reads `PACT_OUTPUT_DIR` env var (defaults to `"pacts"` if unset; preserves local behavior). CI passes a host path via `xcodebuild`'s `TEST_RUNNER_` env-var propagation, so the generated pact JSON lands somewhere `actions/upload-artifact` can find it instead of disappearing into the simulator data container.
- **`.github/workflows/pact-consumer.yml`** — new file. Two-job workflow described above. Triggers only when the contract surface or the workflow itself changes (`Sources/Rokt_Widget/Networking/V2OffersClient.swift`, `Tests/ContractTests/**`, `Package.swift`, `.github/workflows/pact-consumer.yml`). SHA-pinned third-party actions throughout.

## Setup required before the `publish` job will run

The `publish` job will be skipped until the `pact-publish` GitHub environment is configured in **Settings → Environments**:

| Type | Name | Source |
|---|---|---|
| Variable | `PACT_BROKER_BASE_URL` | Rokt pact broker URL |
| Variable | `PACT_BROKER_USERNAME` | Broker write username |
| Secret | `PACT_BROKER_PASSWORD` | Broker write password (from AWS Secrets Manager) |

The environment should also be configured with:

- **Required reviewers**: `@ROKT/sdk-engineering` (or any maintainer set the team prefers)
- **Deployment branches**: `Selected branches → main only`

The `consumer-test` job runs immediately on PRs without any setup.

## How has this been tested

Locally on macOS via `xcodebuild` against an iOS Simulator destination:

```
TEST_RUNNER_PACT_OUTPUT_DIR=/tmp/pact-out xcodebuild test \
  -scheme Rokt-Widget \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
  -only-testing:ContractTests
```

Verified outcomes:

- `test_offersHappyPath_pageDetectionMatches` passes (~0.06s).
- Pact JSON appears at `/tmp/pact-out/rokt-sdk-ios-transactions-api.json` — the host path, not the simulator data container.
- JSON shape sanity: `consumer = rokt-sdk-ios`, `provider = transactions-api`, 1 interaction at `POST /v2/sessions/offers`, pact spec `3.0.0`.

The workflow itself has not been smoke-tested end-to-end on GitHub Actions yet — that's the verification step once this is merged + the environment is configured.

## Notes

- **Draft until the `pact-publish` environment is provisioned.** Once it exists, this PR's CI will show what the `consumer-test` job looks like on GitHub-hosted runners; we can flip to ready-for-review then.
- The `publish` job uses `pactfoundation/pact-cli:latest` rather than a pinned tag. Acceptable because (a) it's published by the pact foundation and (b) the worst-case failure mode is the publish step failing, which is `soft_fail`-equivalent given the consumer test still gates on contract validity.
- Tags applied on publish: `--branch ${GITHUB_REF_NAME}` (so `main`), `--tag forward-looking` (per the v1→v2 migration plan — the contract is aspirational until the SDK actually switches to v2).
- Follow-up: docs section (`documentation/pact-v2-migration.md`) referenced by the workflow comments will land in a later PR (M8 in the rollout plan).

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. (deferred — migration doc lands in a follow-up PR per the rollout plan)
- [x] I have added tests that prove my fix is effective or that my feature works. (PactSwift consumer spec from #169 exercises the path; locally verified the new PACT_OUTPUT_DIR plumbing produces the JSON at the expected host path)
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully. (consumer-test job will be observable once this PR runs CI; publish job depends on environment provisioning)
- [x] All insignificant commits have been squashed. (intentionally two commits: PACT_OUTPUT_DIR plumbing on the spec, then the workflow YAML — separate concerns, each independently revertable)
