### PR TITLE
test(pact): add V2EventsClient + consumer pact for /v2/sessions/events

### DIFF
--- a/Sources/Rokt_Widget/Networking/V2EventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2EventsClient.swift
@@ -1,0 +1,103 @@
+// periphery:ignore:all - referenced from Tests/ContractTests/V2EventsClientPactSpec.swift,
+// which isn't part of the rokt-Example scheme that Periphery scans. See V2OffersClient
+// for the rationale on why this lives in Sources/ rather than Tests/.
+
+import Foundation
+
+/// Client for the v2 sessions events endpoint on transactions-api.
+///
+/// Mirrors V2OffersClient — describes the v2 wire contract that mobile will
+/// satisfy at v1→v2 migration time. Not yet wired into production: the SDK
+/// still posts events via `/rokt-mobile/v1/*`. Lives in Sources/ so the
+/// consumer pact in `Tests/ContractTests/V2EventsClientPactSpec.swift`
+/// constrains the shipping SDK code rather than a test-only shadow.
+///
+/// Endpoint semantics (see transactions:apps/api/internal/events/handler.go):
+///   - Session identity is conveyed solely via the `Authorization` JWT;
+///     there is no session_id in the body.
+///   - `events[].timestamp` is Unix epoch milliseconds (int64). RFC 3339
+///     strings are accepted but deprecated and surface a warning on the
+///     202 response.
+///   - The response always includes a refreshed `session_token` (the
+///     server may rotate it), `event_ids` for each accepted event, and
+///     `errors` / `warnings` arrays (empty on the happy path).
+internal struct V2EventsClient {
+    let baseURL: URL
+    let accountId: String
+    let authToken: String
+    let sdkVersion: String
+    let urlSession: URLSession
+
+    init(
+        baseURL: URL,
+        accountId: String,
+        authToken: String,
+        sdkVersion: String,
+        urlSession: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.accountId = accountId
+        self.authToken = authToken
+        self.sdkVersion = sdkVersion
+        self.urlSession = urlSession
+    }
+
+    func recordEvents(events: [V2Event]) async throws -> (Data, URLResponse) {
+        let url = baseURL
+            .appendingPathComponent("v2")
+            .appendingPathComponent("sessions")
+            .appendingPathComponent("events")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(accountId, forHTTPHeaderField: "rokt-account-id")
+        request.setValue(authToken, forHTTPHeaderField: "Authorization")
+        request.setValue("iOS", forHTTPHeaderField: "rokt-platform-type")
+        request.setValue("msdk-ios", forHTTPHeaderField: "rokt-integration-type")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = V2EventsRequest(
+            channel: V2EventsChannel(type: "msdk", sdkVersion: sdkVersion),
+            events: events
+        )
+        request.httpBody = try JSONEncoder().encode(body)
+
+        return try await urlSession.data(for: request)
+    }
+}
+
+internal struct V2EventsRequest: Encodable {
+    let channel: V2EventsChannel
+    let events: [V2Event]
+}
+
+internal struct V2EventsChannel: Encodable {
+    let type: String
+    let sdkVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case sdkVersion = "sdk_version"
+    }
+}
+
+/// Single event in a v2 RecordEvents batch.
+///
+/// `timestamp` is int64 Unix epoch milliseconds — the canonical wire
+/// format. `data` is intentionally `[String: String]?` for now: the
+/// server-side schema is `map[string]any`, but iOS event payloads in
+/// practice carry only string values (e.g. `source_message_id`). Lift
+/// the value type when a real consumer needs nested or numeric data.
+internal struct V2Event: Encodable {
+    let eventType: String
+    let instanceId: String?
+    let timestamp: Int64
+    let data: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case instanceId = "instance_id"
+        case timestamp
+        case data
+    }
+}

--- a/Sources/Rokt_Widget/Networking/V2EventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2EventsClient.swift
@@ -1,26 +1,7 @@
-// periphery:ignore:all - referenced from Tests/ContractTests/V2EventsClientPactSpec.swift,
-// which isn't part of the rokt-Example scheme that Periphery scans. See V2OffersClient
-// for the rationale on why this lives in Sources/ rather than Tests/.
+// periphery:ignore:all - referenced from Tests/ContractTests/V2EventsClientPactSpec.swift
 
 import Foundation
 
-/// Client for the v2 sessions events endpoint on transactions-api.
-///
-/// Mirrors V2OffersClient — describes the v2 wire contract that mobile will
-/// satisfy at v1→v2 migration time. Not yet wired into production: the SDK
-/// still posts events via `/rokt-mobile/v1/*`. Lives in Sources/ so the
-/// consumer pact in `Tests/ContractTests/V2EventsClientPactSpec.swift`
-/// constrains the shipping SDK code rather than a test-only shadow.
-///
-/// Endpoint semantics (see transactions:apps/api/internal/events/handler.go):
-///   - Session identity is conveyed solely via the `Authorization` JWT;
-///     there is no session_id in the body.
-///   - `events[].timestamp` is Unix epoch milliseconds (int64). RFC 3339
-///     strings are accepted but deprecated and surface a warning on the
-///     202 response.
-///   - The response always includes a refreshed `session_token` (the
-///     server may rotate it), `event_ids` for each accepted event, and
-///     `errors` / `warnings` arrays (empty on the happy path).
 internal struct V2EventsClient {
     let baseURL: URL
     let accountId: String
@@ -81,13 +62,6 @@ internal struct V2EventsChannel: Encodable {
     }
 }
 
-/// Single event in a v2 RecordEvents batch.
-///
-/// `timestamp` is int64 Unix epoch milliseconds — the canonical wire
-/// format. `data` is intentionally `[String: String]?` for now: the
-/// server-side schema is `map[string]any`, but iOS event payloads in
-/// practice carry only string values (e.g. `source_message_id`). Lift
-/// the value type when a real consumer needs nested or numeric data.
 internal struct V2Event: Encodable {
     let eventType: String
     let instanceId: String?

--- a/Sources/Rokt_Widget/Networking/V2EventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2EventsClient.swift
@@ -7,44 +7,69 @@ internal struct V2EventsClient {
     let accountId: String
     let authToken: String
     let sdkVersion: String
-    let urlSession: URLSession
+    let httpClient: HTTPClientAdapter
 
     init(
         baseURL: URL,
         accountId: String,
         authToken: String,
         sdkVersion: String,
-        urlSession: URLSession = .shared
+        httpClient: HTTPClientAdapter = RoktHTTPClient()
     ) {
         self.baseURL = baseURL
         self.accountId = accountId
         self.authToken = authToken
         self.sdkVersion = sdkVersion
-        self.urlSession = urlSession
+        self.httpClient = httpClient
     }
 
-    func recordEvents(events: [V2Event]) async throws -> (Data, URLResponse) {
+    func recordEvents(events: [V2Event]) async throws -> (Data?, HTTPURLResponse?) {
         let url = baseURL
             .appendingPathComponent("v2")
             .appendingPathComponent("sessions")
             .appendingPathComponent("events")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue(accountId, forHTTPHeaderField: "rokt-account-id")
-        request.setValue(authToken, forHTTPHeaderField: "Authorization")
-        request.setValue("iOS", forHTTPHeaderField: "rokt-platform-type")
-        request.setValue("msdk-ios", forHTTPHeaderField: "rokt-integration-type")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let body = V2EventsRequest(
+        let requestBody = V2EventsRequest(
             channel: V2EventsChannel(type: "msdk", sdkVersion: sdkVersion),
             events: events
         )
-        request.httpBody = try JSONEncoder().encode(body)
+        let bodyData = try JSONEncoder().encode(requestBody)
+        guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
+            throw V2EventsClientError.bodyEncodingFailed
+        }
 
-        return try await urlSession.data(for: request)
+        let headers: RoktHTTPHeaders = [
+            "rokt-account-id": accountId,
+            "Authorization": authToken,
+            "rokt-platform-type": "iOS",
+            "rokt-integration-type": "msdk-ios",
+            "Content-Type": "application/json"
+        ]
+
+        return try await withCheckedThrowingContinuation { continuation in
+            httpClient.startRequestWith(
+                urlAddress: url.absoluteString,
+                method: .post,
+                parameters: bodyParameters,
+                parameterArray: nil,
+                headers: headers,
+                onRequestStart: nil,
+                requestTimeout: nil,
+                completionQueue: .main,
+                completionHandler: { result in
+                    if let error = result.responseError {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: (result.responseData, result.httpURLResponse))
+                    }
+                }
+            )
+        }
     }
+}
+
+internal enum V2EventsClientError: Error {
+    case bodyEncodingFailed
 }
 
 internal struct V2EventsRequest: Encodable {

--- a/Sources/Rokt_Widget/Networking/V2OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2OffersClient.swift
@@ -1,26 +1,7 @@
-// periphery:ignore:all - referenced from Tests/ContractTests/V2OffersClientPactSpec.swift,
-// which isn't part of the rokt-Example scheme that Periphery scans. See the V2OffersClient
-// doc comment below for why this client lives in Sources/ rather than Tests/.
+// periphery:ignore:all - referenced from Tests/ContractTests/V2OffersClientPactSpec.swift
 
 import Foundation
 
-/// Client for the v2 sessions offers endpoint on transactions-api.
-///
-/// Not yet called from any production code path — the SDK still uses
-/// `/rokt-mobile/v1/*` via `RoktNetWorkAPI`. This client describes the
-/// v2 wire contract that mobile will satisfy when v1→v2 migration lands;
-/// at that point the existing networking code switches over to call this.
-///
-/// Lives in Sources/ rather than Tests/ so the consumer pact spec in
-/// `Tests/ContractTests/V2OffersClientPactSpec.swift` constrains the
-/// actual shipping SDK code. A pact contract describing test-only code
-/// can silently diverge from production at migration time; describing
-/// real SDK code closes that gap.
-///
-/// The client owns wire-shape construction — header and body assembly —
-/// based on domain inputs. The pact spec describes the expected wire
-/// shape via matchers, and any drift here will be caught by the pact
-/// mock service. See [[pact-consumer-conventions]] §10a for the rule.
 internal struct V2OffersClient {
     let baseURL: URL
     let accountId: String
@@ -30,7 +11,7 @@ internal struct V2OffersClient {
     let mpid: String
     let sdkVersion: String
     let pageInstanceGuid: String
-    let urlSession: URLSession
+    let httpClient: HTTPClientAdapter
 
     init(
         baseURL: URL,
@@ -41,7 +22,7 @@ internal struct V2OffersClient {
         mpid: String,
         sdkVersion: String,
         pageInstanceGuid: String,
-        urlSession: URLSession = .shared
+        httpClient: HTTPClientAdapter = RoktHTTPClient()
     ) {
         self.baseURL = baseURL
         self.accountId = accountId
@@ -51,26 +32,16 @@ internal struct V2OffersClient {
         self.mpid = mpid
         self.sdkVersion = sdkVersion
         self.pageInstanceGuid = pageInstanceGuid
-        self.urlSession = urlSession
+        self.httpClient = httpClient
     }
 
-    func fetchOffers(input: V2OffersInput) async throws -> (Data, URLResponse) {
+    func fetchOffers(input: V2OffersInput) async throws -> (Data?, HTTPURLResponse?) {
         let url = baseURL
             .appendingPathComponent("v2")
             .appendingPathComponent("sessions")
             .appendingPathComponent("offers")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue(accountId, forHTTPHeaderField: "rokt-account-id")
-        request.setValue(authToken, forHTTPHeaderField: "Authorization")
-        request.setValue("iOS", forHTTPHeaderField: "rokt-platform-type")
-        request.setValue("msdk-ios", forHTTPHeaderField: "rokt-integration-type")
-        request.setValue(input.requestId, forHTTPHeaderField: "x-request-id")
-        request.setValue(pageInstanceGuid, forHTTPHeaderField: "rokt-page-instance-guid")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let body = V2OffersRequest(
+        let requestBody = V2OffersRequest(
             sessionId: sessionId,
             mpSessionId: mpSessionId,
             mpid: mpid,
@@ -80,18 +51,47 @@ internal struct V2OffersClient {
             customer: V2OffersCustomer(email: input.customerEmail),
             attributes: input.attributes
         )
-        request.httpBody = try JSONEncoder().encode(body)
+        let bodyData = try JSONEncoder().encode(requestBody)
+        guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
+            throw V2OffersClientError.bodyEncodingFailed
+        }
 
-        return try await urlSession.data(for: request)
+        let headers: RoktHTTPHeaders = [
+            "rokt-account-id": accountId,
+            "Authorization": authToken,
+            "rokt-platform-type": "iOS",
+            "rokt-integration-type": "msdk-ios",
+            "x-request-id": input.requestId,
+            "rokt-page-instance-guid": pageInstanceGuid,
+            "Content-Type": "application/json"
+        ]
+
+        return try await withCheckedThrowingContinuation { continuation in
+            httpClient.startRequestWith(
+                urlAddress: url.absoluteString,
+                method: .post,
+                parameters: bodyParameters,
+                parameterArray: nil,
+                headers: headers,
+                onRequestStart: nil,
+                requestTimeout: nil,
+                completionQueue: .main,
+                completionHandler: { result in
+                    if let error = result.responseError {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: (result.responseData, result.httpURLResponse))
+                    }
+                }
+            )
+        }
     }
 }
 
-/// Per-call domain inputs for `V2OffersClient.fetchOffers`.
-///
-/// Holds only the values that vary per-request from a caller's perspective.
-/// Session-shaped values (account id, session token, mp ids, etc.) are
-/// injected at client construction time, mirroring how a production iOS
-/// service resolves them from session / config services.
+internal enum V2OffersClientError: Error {
+    case bodyEncodingFailed
+}
+
 internal struct V2OffersInput {
     let requestId: String
     let pageIdentifier: String

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -92,8 +92,7 @@ class V2EventsClientPactSpec: XCTestCase {
                         timestamp: 1_774_474_053_000,
                         data: ["source_message_id": "source-message-001"]
                     )
-                    let (_, response) = try await client.recordEvents(events: [event])
-                    let httpResponse = response as? HTTPURLResponse
+                    let (_, httpResponse) = try await client.recordEvents(events: [event])
                     XCTAssertEqual(httpResponse?.statusCode, 202)
                 } catch {
                     XCTFail("V2EventsClient request failed: \(error)")

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -1,0 +1,107 @@
+import XCTest
+import PactSwift
+@testable import Rokt_Widget
+
+/// Consumer-driven pact spec for the v2 `/v2/sessions/events` endpoint.
+///
+/// Drives `V2EventsClient.recordEvents(events:)` — the test never constructs
+/// request headers or body directly, only domain inputs. Wire-shape
+/// construction lives entirely in `V2EventsClient`, so any drift there
+/// (e.g. switching `rokt-integration-type` from `"msdk-ios"` to
+/// `"ios-mobile"`) gets rejected by the pact mock service.
+///
+/// Mirrors V2OffersClientPactSpec — see that file's docstring for the
+/// matcher policy (exact-match for hardcoded constants, `SomethingLike`
+/// for per-runtime values).
+class V2EventsClientPactSpec: XCTestCase {
+    static var mockService: MockService!
+
+    override class func setUp() {
+        super.setUp()
+        // PACT_OUTPUT_DIR lets CI redirect the generated JSON to a host path
+        // reachable after the simulator exits — without it, PactSwift writes
+        // into the simulator data container where GH Actions can't reach it.
+        let outputPath = ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "pacts"
+        let outputDir = URL(fileURLWithPath: outputPath, isDirectory: true)
+        mockService = MockService(
+            consumer: "rokt-sdk-ios",
+            provider: "transactions-api",
+            writePactTo: outputDir
+        )
+    }
+
+    func test_recordEventsHappyPath_acceptsSingleImpression() {
+        Self.mockService
+            .uponReceiving("a v2 sessions events request from rokt-sdk-ios with one impression event")
+            .given(ProviderState(description: "a valid session token is provided", params: [:]))
+            .withRequest(
+                method: .POST,
+                path: "/v2/sessions/events",
+                headers: [
+                    "rokt-account-id": Matcher.SomethingLike("account-456"),
+                    "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
+                    "rokt-platform-type": "iOS",
+                    "rokt-integration-type": "msdk-ios",
+                    "Content-Type": "application/json"
+                ],
+                body: [
+                    "channel": [
+                        "type": "msdk",
+                        "sdk_version": Matcher.SomethingLike("5.2.2")
+                    ],
+                    "events": Matcher.EachLike([
+                        "event_type": Matcher.SomethingLike("impression"),
+                        "instance_id": Matcher.SomethingLike("instance-001"),
+                        "timestamp": Matcher.SomethingLike(1_774_474_053_000),
+                        "data": [
+                            "source_message_id": Matcher.SomethingLike("source-message-001")
+                        ]
+                    ], min: 1)
+                ]
+            )
+            .willRespondWith(
+                status: 202,
+                headers: ["Content-Type": "application/json"],
+                body: [
+                    "session_token": [
+                        "token": Matcher.SomethingLike("next-session-token"),
+                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
+                    ],
+                    "event_ids": Matcher.EachLike(Matcher.SomethingLike("event-001"), min: 1),
+                    "errors": [],
+                    "warnings": []
+                ]
+            )
+
+        let expectation = expectation(description: "v2 events request completes")
+
+        Self.mockService.run(timeout: 5) { baseURL, done in
+            Task {
+                defer { done() }
+                do {
+                    let url = try XCTUnwrap(URL(string: baseURL))
+                    let client = V2EventsClient(
+                        baseURL: url,
+                        accountId: "account-456",
+                        authToken: "Bearer session-token-abc",
+                        sdkVersion: "5.2.2"
+                    )
+                    let event = V2Event(
+                        eventType: "impression",
+                        instanceId: "instance-001",
+                        timestamp: 1_774_474_053_000,
+                        data: ["source_message_id": "source-message-001"]
+                    )
+                    let (_, response) = try await client.recordEvents(events: [event])
+                    let httpResponse = response as? HTTPURLResponse
+                    XCTAssertEqual(httpResponse?.statusCode, 202)
+                } catch {
+                    XCTFail("V2EventsClient request failed: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 6)
+    }
+}

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -134,8 +134,7 @@ class V2OffersClientPactSpec: XCTestCase {
                             "customer.locale": "en-US"
                         ]
                     )
-                    let (_, response) = try await client.fetchOffers(input: input)
-                    let httpResponse = response as? HTTPURLResponse
+                    let (_, httpResponse) = try await client.fetchOffers(input: input)
                     XCTAssertEqual(httpResponse?.statusCode, 200)
                 } catch {
                     XCTFail("V2OffersClient request failed: \(error)")


### PR DESCRIPTION
## Summary

Adds a forward-looking consumer pact spec for the v2 RecordEvents endpoint (`POST /v2/sessions/events`), mirroring the existing `V2OffersClient` + `V2OffersClientPactSpec` pair (#169). The SDK does not yet call `/v2/sessions/events` in production — events still flow via `/rokt-mobile/v1/*` — so this pins the wire shape that mobile will satisfy at v1→v2 migration time.

## What ships

- **`Sources/Rokt_Widget/Networking/V2EventsClient.swift`** — owns wire-shape construction (headers + body) from domain inputs.
- **`Tests/ContractTests/V2EventsClientPactSpec.swift`** — consumer pact driving `V2EventsClient.recordEvents(events:)`. One happy-path interaction: single impression event, asserts the 202 response shape (`session_token`, `event_ids`, `errors`, `warnings`).

## Pattern parity with the offers spec

- `V2EventsClient` lives in `Sources/` rather than `Tests/` — pact constrains the shipping SDK code, not a test-only shadow.
- Wire-shape construction lives entirely in the client. The spec drives it with domain inputs only.
- Hardcoded constants (`"iOS"`, `"msdk-ios"`, `"msdk"`) are pinned exactly. Per-runtime values (account id, auth token, sdk version, event type, etc.) match by type via `SomethingLike`.

## Endpoint specifics (per `transactions/apps/api/internal/events/handler.go`)

- Session identity comes from the JWT in `Authorization`, not the body.
- `events[].timestamp` is int64 epoch millis (canonical format). RFC 3339 strings are still accepted but trigger a deprecation warning in the response.
- The 202 response always carries a refreshed `session_token` (the server may rotate it), per-event `event_ids`, and `errors` / `warnings` arrays.

## CI note

The `Consumer Test (PactSwift)` job won't appear on this PR's checks until #170 (which adds the `pact-consumer.yml` workflow) merges to `main`. Once #170 is on `main`, rebasing this PR will pick up the workflow and validate the new spec end-to-end.

## Test plan

- [ ] Merge #170 (workflow + path-filter removal).
- [ ] Rebase this PR onto `main`; confirm `Consumer Test (PactSwift)` runs and passes.
- [ ] Merge.
- [ ] Approve the `Publish to Broker` deployment on the resulting push-to-main; verify both `rokt-sdk-ios → transactions-api` pacts (offers + events) land on the broker via anonymous curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)