### PR TITLE
[dont-review] ci: smoke-test broker egress from GH Actions runners

### DIFF
--- a/.github/workflows/broker-egress-smoke.yml
+++ b/.github/workflows/broker-egress-smoke.yml
@@ -1,0 +1,52 @@
+name: Broker Egress Smoke Test
+
+# Throwaway workflow to verify GitHub Actions runners can reach the
+# pact broker before relying on the publish step in pact-consumer.yml.
+# Triggers on any push to any branch + manual dispatch.
+#
+# Delete this workflow after the question is answered (or keep as a
+# permanent canary on a schedule once we know the baseline works).
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu-egress:
+    name: Ubuntu Runner → Broker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Anonymous heartbeat
+        run: |
+          set -e
+          echo "Testing from $(curl -s ifconfig.me 2>/dev/null || echo 'unknown egress IP')"
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            "https://pact.eng.roktinternal.com/diagnostic/status/heartbeat")
+          echo "Anonymous heartbeat from ubuntu-latest: HTTP $status"
+          if [ "$status" = "200" ]; then
+            echo "::notice::Broker reachable from GitHub Actions ubuntu-latest runner"
+          else
+            echo "::error::Broker NOT reachable from GitHub Actions ubuntu-latest runner (HTTP $status). Publish job will fail post-merge."
+            exit 1
+          fi
+
+  macos-egress:
+    name: macOS Runner → Broker
+    runs-on: macos-latest
+    steps:
+      - name: Anonymous heartbeat
+        run: |
+          set -e
+          echo "Testing from $(curl -s ifconfig.me 2>/dev/null || echo 'unknown egress IP')"
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            "https://pact.eng.roktinternal.com/diagnostic/status/heartbeat")
+          echo "Anonymous heartbeat from macos-latest: HTTP $status"
+          if [ "$status" = "200" ]; then
+            echo "::notice::Broker reachable from GitHub Actions macos-latest runner"
+          else
+            echo "::error::Broker NOT reachable from GitHub Actions macos-latest runner (HTTP $status)"
+            exit 1
+          fi

--- a/.github/workflows/broker-egress-smoke.yml
+++ b/.github/workflows/broker-egress-smoke.yml
@@ -1,11 +1,9 @@
 name: Broker Egress Smoke Test
 
-# Throwaway workflow to verify GitHub Actions runners can reach the
-# pact broker before relying on the publish step in pact-consumer.yml.
-# Triggers on any push to any branch + manual dispatch.
-#
-# Delete this workflow after the question is answered (or keep as a
-# permanent canary on a schedule once we know the baseline works).
+# Verifies GitHub Actions runners can reach the pact broker.
+# Tests BOTH stageeng (deployed via kube-configs PR #2501) and eng
+# (still has old allowlist — acts as a control until that PR ships
+# to eng too). stageeng must pass; eng failure is expected for now.
 
 on:
   push:
@@ -15,38 +13,36 @@ permissions:
   contents: read
 
 jobs:
-  ubuntu-egress:
-    name: Ubuntu Runner → Broker
-    runs-on: ubuntu-latest
+  reachability:
+    name: ${{ matrix.runner }} → ${{ matrix.host }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.host == 'pact.eng.roktinternal.com' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+        host:
+          - pact.stageeng.roktinternal.com
+          - pact.eng.roktinternal.com
     steps:
       - name: Anonymous heartbeat
         run: |
           set -e
-          echo "Testing from $(curl -s ifconfig.me 2>/dev/null || echo 'unknown egress IP')"
-          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
-            "https://pact.eng.roktinternal.com/diagnostic/status/heartbeat")
-          echo "Anonymous heartbeat from ubuntu-latest: HTTP $status"
-          if [ "$status" = "200" ]; then
-            echo "::notice::Broker reachable from GitHub Actions ubuntu-latest runner"
-          else
-            echo "::error::Broker NOT reachable from GitHub Actions ubuntu-latest runner (HTTP $status). Publish job will fail post-merge."
-            exit 1
-          fi
+          egress=$(curl -s ifconfig.me 2>/dev/null || echo 'unknown')
+          echo "Runner egress IP: ${egress}"
+          echo "Target: https://${{ matrix.host }}/diagnostic/status/heartbeat"
 
-  macos-egress:
-    name: macOS Runner → Broker
-    runs-on: macos-latest
-    steps:
-      - name: Anonymous heartbeat
-        run: |
-          set -e
-          echo "Testing from $(curl -s ifconfig.me 2>/dev/null || echo 'unknown egress IP')"
           status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
-            "https://pact.eng.roktinternal.com/diagnostic/status/heartbeat")
-          echo "Anonymous heartbeat from macos-latest: HTTP $status"
+            "https://${{ matrix.host }}/diagnostic/status/heartbeat" || echo "timeout")
+          echo "Result: HTTP ${status}"
+
           if [ "$status" = "200" ]; then
-            echo "::notice::Broker reachable from GitHub Actions macos-latest runner"
+            echo "::notice::Reachable from ${{ matrix.runner }} (egress ${egress})"
           else
-            echo "::error::Broker NOT reachable from GitHub Actions macos-latest runner (HTTP $status)"
+            if [ "${{ matrix.host }}" = "pact.eng.roktinternal.com" ]; then
+              echo "::warning::eng unreachable (expected — kube-configs PR #2501 hasn't deployed to eng yet)"
+            else
+              echo "::error::stageeng unreachable from ${{ matrix.runner }} (HTTP ${status})"
+            fi
             exit 1
           fi

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -84,16 +84,20 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-  pr-publish:
-    name: Publish to Broker (PR)
+  publish:
+    name: Publish to Broker
     needs: [consumer-test, detect-changes]
-    # Fork PRs are excluded: head.repo.full_name matches base only when the PR
-    # comes from a branch in this repo, so broker write creds never enter a
-    # fork's CI environment.
+    # Runs on:
+    #   - Push to main with contract changes
+    #   - Non-fork PR push with contract changes (release PRs included — they
+    #     go through the normal pull_request flow via release-draft.yml)
+    # Fork PRs are excluded to keep broker write creds out of fork CI.
     if: |
-      github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && needs.detect-changes.outputs.contract == 'true'
+      needs.detect-changes.outputs.contract == 'true'
+      && (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Download pact JSON
@@ -108,7 +112,9 @@ jobs:
           PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           GITHUB_SHA: ${{ github.sha }}
-          PACT_BRANCH: ${{ github.head_ref }}
+          # On PR runs `github.head_ref` is the source branch; on main pushes
+          # it's empty and falls through to `github.ref_name` ("main").
+          PACT_BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -134,13 +140,15 @@ jobs:
 
   can-i-deploy:
     name: Can I Deploy
-    needs: [pr-publish]
+    needs: [publish]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Advisory while `transactions-api` stage-tag bootstrap is pending — no
-    # provider version is currently tagged `stage`, so can-i-deploy fails
-    # closed even when contracts are compatible. Flip to false once bootstrap
-    # lands. See sdk-web for the same pattern.
+    # TODO: flip continue-on-error to false once `transactions-api` is tagging
+    # `stage` deploys. Today no provider version is tagged `stage`, so
+    # can-i-deploy fails closed even when contracts are compatible — running
+    # advisory keeps the PR check informational. See sdk-web for the same
+    # pattern. The intent (per team agreement) is for this to become a real
+    # merge gate as soon as the provider-side bootstrap lands.
     continue-on-error: true
     steps:
       - name: Check provider verification
@@ -162,55 +170,3 @@ jobs:
               --pacticipant rokt-sdk-ios \
               --version "${GITHUB_SHA}" \
               --to-environment stage
-
-  main-publish:
-    name: Publish to Broker (main)
-    needs: [consumer-test, detect-changes]
-    if: |
-      github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
-      && needs.detect-changes.outputs.contract == 'true'
-    runs-on: ubuntu-latest
-    # Approval gate retained for main publishes — `pact-publish` env requires
-    # @ROKT/sdk-engineering approval before broker write creds are released.
-    environment: pact-publish
-    steps:
-      - name: Download pact JSON
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pact-json
-          path: pacts/
-
-      - name: Publish to pact broker
-        env:
-          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
-          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
-            echo "::error::PACT_BROKER_BASE_URL is unset. Configure the pact-publish environment." >&2
-            exit 1
-          fi
-          if [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
-            echo "::error::PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD missing." >&2
-            exit 1
-          fi
-
-          # renovate: datasource=docker depName=pactfoundation/pact-cli
-          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
-          docker run --rm \
-            -v "${PWD}/pacts:/pacts" \
-            -e PACT_BROKER_BASE_URL \
-            -e PACT_BROKER_USERNAME \
-            -e PACT_BROKER_PASSWORD \
-            "${PACT_CLI_IMAGE}" \
-            broker publish /pacts \
-              --consumer-app-version "${GITHUB_SHA}" \
-              --branch "${GITHUB_REF_NAME}" \
-              --tag "forward-looking" \
-              --build-url "${BUILD_URL}"

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -99,6 +99,11 @@ jobs:
         || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     runs-on: ubuntu-latest
+    # Scopes the broker write credentials to this job only, rather than making
+    # them readable by every workflow on this public repo. The environment has
+    # no required-reviewer gate — the merge-time `can-i-deploy` check is the
+    # gate instead, so publishing stays fully automated.
+    environment: pact-publish
     steps:
       - name: Download pact JSON
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -120,7 +125,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${PACT_BROKER_BASE_URL:-}" ] || [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
-            echo "::error::Broker credentials missing — set PACT_BROKER_PASSWORD as a repo-level secret." >&2
+            echo "::error::Broker credentials missing — check the pact-publish environment vars/secret are set." >&2
             exit 1
           fi
 
@@ -150,6 +155,9 @@ jobs:
     # pattern. The intent (per team agreement) is for this to become a real
     # merge gate as soon as the provider-side bootstrap lands.
     continue-on-error: true
+    # Same env as publish: scopes broker creds to this job (reads the URL +
+    # auth from the pact-publish environment, no reviewer gate).
+    environment: pact-publish
     steps:
       - name: Check provider verification
         env:

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,0 +1,216 @@
+name: Pact Consumer
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    name: Detect Contract Changes
+    runs-on: ubuntu-latest
+    outputs:
+      contract: ${{ steps.filter.outputs.contract }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # paths-filter needs history to diff against the previous commit on push.
+          fetch-depth: 0
+
+      - name: Filter contract paths
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            contract:
+              - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
+              - 'Sources/Rokt_Widget/Networking/V2EventsClient.swift'
+              - 'Tests/ContractTests/**'
+              - 'Package.swift'
+              - '.github/workflows/pact-consumer.yml'
+
+  consumer-test:
+    name: Consumer Test (PactSwift)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: "26.2"
+
+      - name: Run contract tests
+        env:
+          # TEST_RUNNER_ prefix propagates env vars to the simulator test runner; prefix is stripped on arrival.
+          TEST_RUNNER_PACT_OUTPUT_DIR: ${{ runner.temp }}/pacts
+        run: |
+          mkdir -p "${{ runner.temp }}/pacts"
+          xcodebuild test \
+            -scheme Rokt-Widget \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -only-testing:ContractTests \
+            -resultBundlePath "${{ runner.temp }}/test-results.xcresult"
+
+      - name: Verify pact JSON generated
+        run: |
+          if ! ls "${{ runner.temp }}/pacts/"*.json >/dev/null 2>&1; then
+            echo "::error::No pact JSON generated under ${{ runner.temp }}/pacts/" >&2
+            echo "Listing simulator data container as a fallback diagnostic:"
+            find ~/Library/Developer/CoreSimulator/Devices -name "rokt-sdk-ios-*.json" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Generated pact files:"
+          ls -la "${{ runner.temp }}/pacts/"
+
+      - name: Upload pact JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pact-json
+          path: ${{ runner.temp }}/pacts/
+          retention-days: 14
+          if-no-files-found: error
+
+  pr-publish:
+    name: Publish to Broker (PR)
+    needs: [consumer-test, detect-changes]
+    # Fork PRs are excluded: head.repo.full_name matches base only when the PR
+    # comes from a branch in this repo, so broker write creds never enter a
+    # fork's CI environment.
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && needs.detect-changes.outputs.contract == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download pact JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pact-json
+          path: pacts/
+
+      - name: Publish to pact broker
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+          PACT_BRANCH: ${{ github.head_ref }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ] || [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
+            echo "::error::Broker credentials missing — set PACT_BROKER_PASSWORD as a repo-level secret." >&2
+            exit 1
+          fi
+
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
+          docker run --rm \
+            -v "${PWD}/pacts:/pacts" \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            "${PACT_CLI_IMAGE}" \
+            broker publish /pacts \
+              --consumer-app-version "${GITHUB_SHA}" \
+              --branch "${PACT_BRANCH}" \
+              --tag "forward-looking" \
+              --build-url "${BUILD_URL}"
+
+  can-i-deploy:
+    name: Can I Deploy
+    needs: [pr-publish]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Advisory while `transactions-api` stage-tag bootstrap is pending — no
+    # provider version is currently tagged `stage`, so can-i-deploy fails
+    # closed even when contracts are compatible. Flip to false once bootstrap
+    # lands. See sdk-web for the same pattern.
+    continue-on-error: true
+    steps:
+      - name: Check provider verification
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
+          docker run --rm \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            "${PACT_CLI_IMAGE}" \
+            broker can-i-deploy \
+              --pacticipant rokt-sdk-ios \
+              --version "${GITHUB_SHA}" \
+              --to-environment stage
+
+  main-publish:
+    name: Publish to Broker (main)
+    needs: [consumer-test, detect-changes]
+    if: |
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.detect-changes.outputs.contract == 'true'
+    runs-on: ubuntu-latest
+    # Approval gate retained for main publishes — `pact-publish` env requires
+    # @ROKT/sdk-engineering approval before broker write creds are released.
+    environment: pact-publish
+    steps:
+      - name: Download pact JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pact-json
+          path: pacts/
+
+      - name: Publish to pact broker
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
+            echo "::error::PACT_BROKER_BASE_URL is unset. Configure the pact-publish environment." >&2
+            exit 1
+          fi
+          if [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
+            echo "::error::PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD missing." >&2
+            exit 1
+          fi
+
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
+          docker run --rm \
+            -v "${PWD}/pacts:/pacts" \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            "${PACT_CLI_IMAGE}" \
+            broker publish /pacts \
+              --consumer-app-version "${GITHUB_SHA}" \
+              --branch "${GITHUB_REF_NAME}" \
+              --tag "forward-looking" \
+              --build-url "${BUILD_URL}"

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -75,7 +75,10 @@ class V2EventsClientPactSpec: XCTestCase {
 
         let expectation = expectation(description: "v2 events request completes")
 
-        Self.mockService.run(timeout: 5) { baseURL, done in
+        // Timeout sized for CI cold-start: first PactSwift mock-service spin-up +
+        // simulator Network.framework init can take 5+ seconds before the request
+        // even begins. Once warm, the actual round trip is <100ms.
+        Self.mockService.run(timeout: 30) { baseURL, done in
             Task {
                 defer { done() }
                 do {
@@ -101,6 +104,6 @@ class V2EventsClientPactSpec: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 6)
+        wait(for: [expectation], timeout: 35)
     }
 }

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -27,7 +27,11 @@ class V2OffersClientPactSpec: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        let outputDir = URL(fileURLWithPath: "pacts", isDirectory: true)
+        // PACT_OUTPUT_DIR lets CI redirect the generated JSON to a host path that
+        // can be picked up after the simulator exits — without it, PactSwift writes
+        // into the simulator data container where GH Actions can't reach it.
+        let outputPath = ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "pacts"
+        let outputDir = URL(fileURLWithPath: outputPath, isDirectory: true)
         mockService = MockService(
             consumer: "rokt-sdk-ios",
             provider: "transactions-api",
@@ -109,7 +113,8 @@ class V2OffersClientPactSpec: XCTestCase {
 
         let expectation = expectation(description: "v2 offers request completes")
 
-        Self.mockService.run(timeout: 5) { baseURL, done in
+        // See V2EventsClientPactSpec for why this is sized for CI cold-start.
+        Self.mockService.run(timeout: 30) { baseURL, done in
             Task {
                 defer { done() }
                 do {
@@ -143,6 +148,6 @@ class V2OffersClientPactSpec: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 6)
+        wait(for: [expectation], timeout: 35)
     }
 }


### PR DESCRIPTION
## ⚠️ Smoke test only — do not review or merge

This is a throwaway PR to trigger CI and verify GitHub Actions runners (both \`ubuntu-latest\` and \`macos-latest\`) can reach \`pact.eng.roktinternal.com\` over the network.

### Why

Earlier in this session we discovered the pact broker is **not** openly publicly accessible — it's network-gated (VPN/allowlist-restricted) despite app-layer \`pactBrokerAllowPublicRead: true\`. Anonymous curl from a 5G hotspot times out; same curl over Rokt VPN returns HTTP 200.

This means the iOS \`publish\` job in PR #170's workflow will only succeed if GitHub Actions runner egress is on the broker's network allowlist. **We don't know that today**, and PR #170 hasn't merged yet so we haven't observed a real publish attempt.

This PR adds a temporary workflow that runs two trivial jobs (Ubuntu + macOS) doing an anonymous heartbeat against the broker. The result tells us definitively whether GH Actions egress is allowlisted.

### How to read the result

| Both jobs pass (HTTP 200) | GH Actions egress IS allowlisted. PR #170 will work post-merge. Proceed. |
| Both jobs fail (HTTP 000 / timeout) | GH Actions egress is NOT allowlisted. Need to file ticket with client-integrations BEFORE merging PR #170. |
| Mixed result | Investigate — both runner types share GitHub's egress range, so this would be unexpected. |

The workflow also echoes the runner's egress IP via \`ifconfig.me\` so we have a concrete data point to share with client-integrations if allowlisting is needed.

### Next steps after this PR

- **If pass:** close this PR without merging; delete the branch.
- **If fail:** keep this PR open as the canary; share the captured egress IPs with client-integrations to get allowlisted; revisit PR #170 timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)