### PR TITLE
fix(payment): send payment method under paymentMethodType key

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
+++ b/Sources/Rokt_Widget/Models/Payment/InitializePurchaseRequest.swift
@@ -9,10 +9,14 @@ struct InitializePurchaseRequest {
     let returnURL: String?
     /// Optional cancel URL for the cart initialize-purchase API.
     let cancelURL: String?
-    /// Cart API `paymentMethod` discriminator (UPPERCASE, e.g. `"CARD"`, `"APPLE_PAY"`,
-    /// `"PAYPAL"`, `"AFTERPAY"`). Matches the `LayoutPaymentMethodType` enum (web SDK) and
-    /// the `PaymentMethod.MethodType` rawValues decoded from backend `transactionData`.
-    let paymentMethod: String?
+    /// Cart API `paymentMethodType` discriminator. PascalCase tokens matching the cart-api
+    /// `PaymentMethodType` member names (`"Card"`, `"ApplePay"`, `"Paypal"`, `"Afterpay"`) —
+    /// the same values DCUI returns in `paymentProvider`, so the method is sent back in the
+    /// vocabulary it arrives in. Accepted by the cart-api `InitializePurchaseApiRequest`
+    /// contract (Newtonsoft matches enum member names case-insensitively). Distinct from the
+    /// short `TransactionData.type` tokens (`"CARD"`, `"APPLE_PAY"`, …); note `"APPLE_PAY"`
+    /// itself would not deserialize into the cart-api enum.
+    let paymentMethodType: String?
     /// Cart API `paymentProvider` discriminator (PascalCase, e.g. `"Stripe"`, `"PayPal"`,
     /// `"Card"`, `"Afterpay"`, `"ApplePay"`). Pass-through of the DcuiSchema `PaymentProvider`
     /// enum so the backend can disambiguate routing (e.g. Stripe-routed ApplePay vs built-in
@@ -35,8 +39,8 @@ struct InitializePurchaseRequest {
         if let cancelURL {
             dict["cancelURL"] = cancelURL
         }
-        if let paymentMethod {
-            dict["paymentMethod"] = paymentMethod
+        if let paymentMethodType {
+            dict["paymentMethodType"] = paymentMethodType
         }
         if let paymentProvider {
             dict["paymentProvider"] = paymentProvider

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -27,17 +27,19 @@ final class PaymentOrchestrator {
     /// Built-in PayPal uses ``PaymentContext/returnURL`` to detect completion when PayPal redirects after approval.
     static let payPalReturnURLMissingMessage =
         "PaymentContext.returnURL is required for PayPal checkout."
-    /// Cart `initialize-purchase` body `paymentMethod` wire value. UPPERCASE tokens that match
-    /// the `LayoutPaymentMethodType` enum (see ROKT/rokt-web-plugin-dcui PR #966) and the
-    /// `PaymentMethod.MethodType` rawValues decoded from backend `transactionData`.
-    /// Distinct from ``PaymentMethodType/wireValue`` (which is for extension matching and uses
-    /// `"afterpay_clearpay"` for `.afterpay`).
-    static func cartPaymentMethodWireValue(for method: PaymentMethodType) -> String {
+    /// Cart `initialize-purchase` body `paymentMethodType` wire value. PascalCase tokens that
+    /// match both the cart-api `PaymentMethodType` member names and the values DCUI returns in
+    /// `paymentProvider` — so iOS sends the method back in the same vocabulary it receives.
+    /// Accepted by the cart-api `InitializePurchaseApiRequest` contract (Newtonsoft matches enum
+    /// member names case-insensitively). Distinct from the short `TransactionData.type` tokens
+    /// (`"CARD"`, `"APPLE_PAY"`, …) — `"APPLE_PAY"` would not deserialize — and from
+    /// ``PaymentMethodType/wireValue`` (extension matching; uses `"afterpay_clearpay"`).
+    static func cartPaymentMethodTypeWireValue(for method: PaymentMethodType) -> String {
         switch method {
-        case .applePay: return "APPLE_PAY"
-        case .card: return "CARD"
-        case .afterpay: return "AFTERPAY"
-        case .paypal: return "PAYPAL"
+        case .applePay: return "ApplePay"
+        case .card: return "Card"
+        case .afterpay: return "Afterpay"
+        case .paypal: return "Paypal"
         }
     }
 
@@ -169,13 +171,13 @@ final class PaymentOrchestrator {
     ///
     /// - Parameters:
     ///   - method: The payment method to use (e.g. `.applePay`). Forwarded to the cart
-    ///     `initialize-purchase` body as an UPPERCASE token (e.g. `"APPLE_PAY"`) via
-    ///     ``cartPaymentMethodWireValue(for:)``.
+    ///     `initialize-purchase` body as a `paymentMethodType` value (e.g. `"ApplePay"`)
+    ///     via ``cartPaymentMethodTypeWireValue(for:)``.
     ///   - paymentProvider: PascalCase cart wire value for the upstream processor (e.g. `"Stripe"`,
     ///     `"Afterpay"`). Forwarded as `paymentProvider` on the cart `initialize-purchase` body
     ///     for extension-routed flows. Ignored for built-in PayPal and built-in card forwarding,
-    ///     which hardcode their own `paymentMethod` / `paymentProvider` (`"PAYPAL"` / `"PayPal"`,
-    ///     `"CARD"` / `"Card"`).
+    ///     which hardcode their own `paymentMethodType` / `paymentProvider`
+    ///     (`"Paypal"` / `"PayPal"`, `"Card"` / `"Card"`).
     ///   - item: The item being purchased (from RoktContracts)
     ///   - cartItemId: The backend cart item ID (format `"v1:uuid:canal"`)
     ///   - viewController: The view controller to present the payment sheet from
@@ -243,9 +245,9 @@ final class PaymentOrchestrator {
                 contactAddress: contactAddress,
                 returnURL: nil,
                 cancelURL: nil,
-                // `cartPaymentMethodWireValue` is total and guaranteed non-empty; only the
+                // `cartPaymentMethodTypeWireValue` is total and guaranteed non-empty; only the
                 // caller-supplied provider needs whitespace/empty normalization.
-                paymentMethod: Self.cartPaymentMethodWireValue(for: method),
+                paymentMethodType: Self.cartPaymentMethodTypeWireValue(for: method),
                 paymentProvider: Self.nonEmptyTrimmed(paymentProvider)
             ) { result in
                 switch result {
@@ -286,7 +288,7 @@ final class PaymentOrchestrator {
     ///
     /// Runs the same cart ``initializePurchase`` preparation as extension-based flows, passing
     /// ``PaymentContext/returnURL`` and ``PaymentContext/cancelURL`` through to the API body when present,
-    /// and `paymentMethod` / `paymentProvider` as `PAYPAL` / `PayPal` for the cart API.
+    /// and `paymentMethodType` / `paymentProvider` as `Paypal` / `PayPal` for the cart API.
     /// For device pay from a placement, ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` supplies those URLs on ``PaymentContext``.
     /// After cart prepare, calls ``RoktUX/devicePayShowConfirmation`` (via ``BuiltInTwoStepDevicePaySession``) and defers the hosted
     /// PayPal approve step until ``presentPendingBuiltInPayPalForForwardPayment(onCompletion:)`` runs from the forward-payment handler.
@@ -305,7 +307,7 @@ final class PaymentOrchestrator {
             contactAddress: contactAddress,
             returnURL: context.returnURL,
             cancelURL: context.cancelURL,
-            paymentMethod: Self.cartPaymentMethodWireValue(for: .paypal),
+            paymentMethodType: Self.cartPaymentMethodTypeWireValue(for: .paypal),
             paymentProvider: Self.cartPaymentProviderWireValue(for: .paypal)
         ) { result in
             switch result {
@@ -445,7 +447,7 @@ final class PaymentOrchestrator {
     /// Entry point for Card device-pay (Step-1 of the two-step Card forward-payment flow).
     ///
     /// Runs the same cart ``initializePurchase`` preparation as PayPal but without return/cancel URLs
-    /// (no hosted approval step). Passes `paymentMethod` / `paymentProvider` as `CARD` / `Card`.
+    /// (no hosted approval step). Passes `paymentMethodType` / `paymentProvider` as `Card` / `Card`.
     /// After cart prepare, triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions
     /// to the Step-2 confirm button, and caches `completion` so it can fire alongside
     /// ``forwardPaymentFinalized`` once ``handleForwardPayment`` posts to `/v1/cart/purchase`.
@@ -463,7 +465,7 @@ final class PaymentOrchestrator {
             contactAddress: contactAddress,
             returnURL: nil,
             cancelURL: nil,
-            paymentMethod: Self.cartPaymentMethodWireValue(for: .card),
+            paymentMethodType: Self.cartPaymentMethodTypeWireValue(for: .card),
             paymentProvider: Self.cartPaymentProviderWireValue(for: .card)
         ) { result in
             switch result {
@@ -638,7 +640,7 @@ final class PaymentOrchestrator {
         contactAddress: ContactAddress,
         returnURL: String? = nil,
         cancelURL: String? = nil,
-        paymentMethod: String? = nil,
+        paymentMethodType: String? = nil,
         paymentProvider: String? = nil,
         completion: @escaping (Result<PaymentPreparation, Error>) -> Void
     ) {
@@ -658,7 +660,7 @@ final class PaymentOrchestrator {
             shippingAttributes: shippingAttributes,
             returnURL: returnURL,
             cancelURL: cancelURL,
-            paymentMethod: paymentMethod,
+            paymentMethodType: paymentMethodType,
             paymentProvider: paymentProvider,
             success: { response in
                 guard let clientSecret = response.paymentDetails.clientSecret,

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -221,8 +221,8 @@ internal class RoktAPIHelper {
     ///   - shippingAttributes: Shipping address
     ///   - returnURL: Optional redirect success URL (e.g. built-in PayPal)
     ///   - cancelURL: Optional redirect cancel URL (e.g. built-in PayPal)
-    ///   - paymentMethod: Optional cart body `paymentMethod` (UPPERCASE, e.g. `"CARD"`,
-    ///     `"APPLE_PAY"`, `"PAYPAL"`, `"AFTERPAY"`).
+    ///   - paymentMethodType: Optional cart body `paymentMethodType` (PascalCase cart-api
+    ///     `PaymentMethodType` member name, e.g. `"Card"`, `"ApplePay"`, `"Paypal"`, `"Afterpay"`).
     ///   - paymentProvider: Optional cart body `paymentProvider` (PascalCase, e.g. `"Stripe"`,
     ///     `"PayPal"`, `"Card"`, `"Afterpay"`, `"ApplePay"`).
     ///   - success: Callback with the initialize-purchase response
@@ -231,7 +231,7 @@ internal class RoktAPIHelper {
                                   shippingAttributes: ShippingAttributes,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
-                                  paymentMethod: String? = nil,
+                                  paymentMethodType: String? = nil,
                                   paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
@@ -240,7 +240,7 @@ internal class RoktAPIHelper {
                                            shippingAttributes: shippingAttributes,
                                            returnURL: returnURL,
                                            cancelURL: cancelURL,
-                                           paymentMethod: paymentMethod,
+                                           paymentMethodType: paymentMethodType,
                                            paymentProvider: paymentProvider,
                                            success: success,
                                            failure: failure)
@@ -249,7 +249,7 @@ internal class RoktAPIHelper {
                                               shippingAttributes: shippingAttributes,
                                               returnURL: returnURL,
                                               cancelURL: cancelURL,
-                                              paymentMethod: paymentMethod,
+                                              paymentMethodType: paymentMethodType,
                                               paymentProvider: paymentProvider,
                                               success: success,
                                               failure: failure)

--- a/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
@@ -107,11 +107,11 @@ internal class RoktMockAPI {
                                   shippingAttributes: ShippingAttributes? = nil,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
-                                  paymentMethod: String? = nil,
+                                  paymentMethodType: String? = nil,
                                   paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
-        _ = (returnURL, cancelURL, paymentMethod, paymentProvider, shippingAttributes, failure)
+        _ = (returnURL, cancelURL, paymentMethodType, paymentProvider, shippingAttributes, failure)
         let mockResponse = InitializePurchaseResponse(
             success: true,
             totalUpsellPrice: upsellItems.reduce(Decimal.zero) { $0 + $1.totalPrice },

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -392,8 +392,8 @@ internal class RoktNetWorkAPI {
     ///   - shippingAttributes: Shipping address for the order
     ///   - returnURL: Optional redirect success URL for payment flows that need it
     ///   - cancelURL: Optional redirect cancel URL for payment flows that need it
-    ///   - paymentMethod: Optional cart body `paymentMethod` (UPPERCASE, e.g. `"CARD"`,
-    ///     `"APPLE_PAY"`, `"PAYPAL"`, `"AFTERPAY"`).
+    ///   - paymentMethodType: Optional cart body `paymentMethodType` (PascalCase cart-api
+    ///     `PaymentMethodType` member name, e.g. `"Card"`, `"ApplePay"`, `"Paypal"`, `"Afterpay"`).
     ///   - paymentProvider: Optional cart body `paymentProvider` (PascalCase, e.g. `"Stripe"`,
     ///     `"PayPal"`, `"Card"`, `"Afterpay"`, `"ApplePay"`).
     ///   - success: Callback with the parsed response
@@ -402,7 +402,7 @@ internal class RoktNetWorkAPI {
                                   shippingAttributes: ShippingAttributes,
                                   returnURL: String? = nil,
                                   cancelURL: String? = nil,
-                                  paymentMethod: String? = nil,
+                                  paymentMethodType: String? = nil,
                                   paymentProvider: String? = nil,
                                   success: ((InitializePurchaseResponse) -> Void)? = nil,
                                   failure: ((Error, Int?, String) -> Void)? = nil) {
@@ -427,7 +427,7 @@ internal class RoktNetWorkAPI {
             fulfillmentDetails: fulfillmentDetails,
             returnURL: returnURL,
             cancelURL: cancelURL,
-            paymentMethod: paymentMethod,
+            paymentMethodType: paymentMethodType,
             paymentProvider: paymentProvider)
 
         let headers = getDefaultHeaders(tagId: tagId)

--- a/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
+++ b/Tests/Rokt_WidgetTests/InitializePurchaseRequestTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Rokt_Widget
 
 final class InitializePurchaseRequestTests: XCTestCase {
-    func test_toDictionary_omitsPaymentMethodAndProviderWhenNil() {
+    func test_toDictionary_omitsPaymentMethodTypeAndProviderWhenNil() {
         let upsell = UpsellItem(
             cartItemId: "c1",
             catalogItemId: "cat1",
@@ -18,17 +18,17 @@ final class InitializePurchaseRequestTests: XCTestCase {
             fulfillmentDetails: nil,
             returnURL: nil,
             cancelURL: nil,
-            paymentMethod: nil,
+            paymentMethodType: nil,
             paymentProvider: nil
         )
 
         let dict = request.toDictionary()
 
-        XCTAssertNil(dict["paymentMethod"] as? String)
+        XCTAssertNil(dict["paymentMethodType"] as? String)
         XCTAssertNil(dict["paymentProvider"] as? String)
     }
 
-    func test_toDictionary_includesPaymentMethodAndProviderWhenSet() {
+    func test_toDictionary_includesPaymentMethodTypeAndProviderWhenSet() {
         let upsell = UpsellItem(
             cartItemId: "c1",
             catalogItemId: "cat1",
@@ -44,13 +44,13 @@ final class InitializePurchaseRequestTests: XCTestCase {
             fulfillmentDetails: nil,
             returnURL: nil,
             cancelURL: nil,
-            paymentMethod: "APPLE_PAY",
+            paymentMethodType: "ApplePay",
             paymentProvider: "Stripe"
         )
 
         let dict = request.toDictionary()
 
-        XCTAssertEqual(dict["paymentMethod"] as? String, "APPLE_PAY")
+        XCTAssertEqual(dict["paymentMethodType"] as? String, "ApplePay")
         XCTAssertEqual(dict["paymentProvider"] as? String, "Stripe")
     }
 }

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -450,7 +450,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "ApplePay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -555,7 +555,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "ApplePay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -607,10 +607,10 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
         // Tripwire against re-introducing the legacy lowercase tokens.
-        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "paypal")
+        XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "paypal")
         XCTAssertNotEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "paypal")
         XCTAssertEqual(payPalPresenter.presentCallCount, 1)
         XCTAssertEqual(payPalPresenter.lastApprovalURL?.absoluteString, "https://www.paypal.com/checkoutnow?token=MOCK")
@@ -648,7 +648,7 @@ class TestPaymentOrchestrator: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL, "myapp://paypal/success")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
     }
 
@@ -682,7 +682,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         _ = sut.presentPendingBuiltInPayPalForForwardPayment { _ in }
         wait(for: [paypalExpectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
         XCTAssertEqual(ext.presentPaymentSheetCallCount, 0, "PayPal must not use PaymentExtension.presentPaymentSheet")
 
@@ -777,7 +777,7 @@ class TestPaymentOrchestrator: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "ApplePay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -814,7 +814,7 @@ class TestPaymentOrchestrator: XCTestCase {
 
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.initializePurchaseCallCount, 1)
         // Built-in card forwarding passes `CARD` / `Card` as the cart wire values.
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Card")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Card")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseReturnURL)
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL)
@@ -1054,15 +1054,17 @@ class TestPaymentOrchestrator: XCTestCase {
 
     // MARK: - cart wire-value helpers
 
-    func test_cartPaymentMethodWireValue_returnsUppercaseTokensForAllMethods() {
-        // Matches LayoutPaymentMethodType (web SDK) and PaymentMethod.MethodType rawValues
-        // decoded from backend transactionData.
-        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .applePay), "APPLE_PAY")
-        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .card), "CARD")
-        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .paypal), "PAYPAL")
-        // Cart wire (`AFTERPAY`) intentionally diverges from `PaymentMethodType.wireValue`
+    func test_cartPaymentMethodTypeWireValue_returnsPascalCaseMemberNamesForAllMethods() {
+        // PascalCase cart-api `PaymentMethodType` member names — the same vocabulary DCUI
+        // returns in `paymentProvider`, accepted by cart-api (Newtonsoft matches member names
+        // case-insensitively). Note `.applePay` is `"ApplePay"`, NOT the `TransactionData.type`
+        // token `"APPLE_PAY"`, which would not deserialize into the cart-api enum.
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodTypeWireValue(for: .applePay), "ApplePay")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodTypeWireValue(for: .card), "Card")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodTypeWireValue(for: .paypal), "Paypal")
+        // Cart wire (`Afterpay`) intentionally diverges from `PaymentMethodType.wireValue`
         // (`afterpay_clearpay`, used for extension matching).
-        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodWireValue(for: .afterpay), "AFTERPAY")
+        XCTAssertEqual(PaymentOrchestrator.cartPaymentMethodTypeWireValue(for: .afterpay), "Afterpay")
         XCTAssertEqual(PaymentMethodType.afterpay.wireValue, "afterpay_clearpay")
     }
 
@@ -1107,7 +1109,7 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "ApplePay")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Stripe")
     }
 
@@ -1142,7 +1144,7 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Card")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Stripe")
     }
 
@@ -1176,8 +1178,8 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        // Cart wire is "AFTERPAY", not the extension-matching "afterpay_clearpay".
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "AFTERPAY")
+        // Cart wire is "Afterpay" (cart-api member name), not the extension-matching "afterpay_clearpay".
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Afterpay")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Afterpay")
     }
 
@@ -1211,7 +1213,7 @@ class TestPaymentOrchestrator: XCTestCase {
         preparePayment(address) { _, _ in expectation.fulfill() }
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "APPLE_PAY")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "ApplePay")
         XCTAssertNil(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider)
     }
 
@@ -1235,7 +1237,7 @@ class TestPaymentOrchestrator: XCTestCase {
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { _ in }
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "PAYPAL")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
     }
 
@@ -1266,7 +1268,7 @@ class TestPaymentOrchestrator: XCTestCase {
 
         wait(for: [confirmationExpectation], timeout: 1.0)
 
-        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethod, "CARD")
+        XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Card")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "Card")
     }
 }
@@ -1276,7 +1278,7 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
     static var initializePurchaseCallCount = 0
     static var lastInitializePurchaseReturnURL: String?
     static var lastInitializePurchaseCancelURL: String?
-    static var lastInitializePurchasePaymentMethod: String?
+    static var lastInitializePurchasePaymentMethodType: String?
     static var lastInitializePurchasePaymentProvider: String?
     static var lastInitializePurchaseShippingAttributes: ShippingAttributes?
     static var sendDiagnosticsCallCount = 0
@@ -1290,7 +1292,7 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         initializePurchaseCallCount = 0
         lastInitializePurchaseReturnURL = nil
         lastInitializePurchaseCancelURL = nil
-        lastInitializePurchasePaymentMethod = nil
+        lastInitializePurchasePaymentMethodType = nil
         lastInitializePurchasePaymentProvider = nil
         lastInitializePurchaseShippingAttributes = nil
         sendDiagnosticsCallCount = 0
@@ -1305,7 +1307,7 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         shippingAttributes: ShippingAttributes,
         returnURL: String? = nil,
         cancelURL: String? = nil,
-        paymentMethod: String? = nil,
+        paymentMethodType: String? = nil,
         paymentProvider: String? = nil,
         success: ((InitializePurchaseResponse) -> Void)?,
         failure: ((Error, Int?, String) -> Void)?
@@ -1313,7 +1315,7 @@ class PaymentOrchestratorAPIHelperSpy: RoktAPIHelper {
         initializePurchaseCallCount += 1
         lastInitializePurchaseReturnURL = returnURL
         lastInitializePurchaseCancelURL = cancelURL
-        lastInitializePurchasePaymentMethod = paymentMethod
+        lastInitializePurchasePaymentMethodType = paymentMethodType
         lastInitializePurchasePaymentProvider = paymentProvider
         lastInitializePurchaseShippingAttributes = shippingAttributes
         if let initializePurchaseResponse {


### PR DESCRIPTION
## Background

When initializing a device-pay purchase, the SDK sent the payment method under a field name the server's initialize-purchase contract does not read, so the method was dropped from the request. This sends it under the field name the contract expects (`paymentMethodType`) and in a value format the contract accepts.

## What Has Changed

- Send the payment method on the initialize-purchase body under `paymentMethodType` (was `paymentMethod`).
- Use the same payment-method value vocabulary the SDK already works with, so the value matches the server contract (`Card` / `ApplePay` / `Paypal` / `Afterpay`).
- Threaded the rename through the networking helpers and payment orchestrator.
- Updated unit tests accordingly.
- Fixes Apple Pay specifically — its previous value was not accepted.

## How Has This Been Tested

- Built the SDK framework (`Rokt-Widget`) for the iOS Simulator — succeeds.
- Ran the affected unit suites (`InitializePurchaseRequestTests`, `TestPaymentOrchestrator`) — 47/47 pass.

## Notes

Wire field/value alignment only; no public API change.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. (doc comments)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.