### PR TITLE
feat(ci): consumer pact publishing + advisory can-i-deploy

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -136,13 +136,15 @@ jobs:
               --build-url "${BUILD_URL}"
 
   can-i-deploy:
-    name: Can I Deploy
+    name: Can I Deploy (advisory)
     needs: [publish]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Advisory until the provider side is bootstrapped for environment-based
-    # can-i-deploy; flip to false to make this a blocking merge gate.
-    continue-on-error: true
+    # Advisory: the published pacts are forward-looking V2 contracts the SDK
+    # does not consume yet, so there is no `stage` deployment to verify
+    # against — the step reports the broker's answer but never fails the job.
+    # When the SDK starts consuming the V2 APIs, make this a blocking gate
+    # (remove the advisory wrapper in the step below) and re-validate end-to-end.
     environment: pact-publish
     steps:
       - name: Check provider verification
@@ -152,10 +154,10 @@ jobs:
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
-          docker run --rm \
+          if docker run --rm \
             -e PACT_BROKER_BASE_URL \
             -e PACT_BROKER_USERNAME \
             -e PACT_BROKER_PASSWORD \
@@ -163,4 +165,8 @@ jobs:
             broker can-i-deploy \
               --pacticipant rokt-sdk-ios \
               --version "${GITHUB_SHA}" \
-              --to-environment stage
+              --to-environment stage; then
+            echo "can-i-deploy: deployable."
+          else
+            echo "::warning::can-i-deploy is advisory and non-blocking: these are forward-looking V2 contracts the SDK does not consume yet, so there is no stage deployment to verify against."
+          fi

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -156,12 +156,20 @@ jobs:
             exit 1
           fi
 
+          # Image pinned to manifest digest (not :latest). Renovate keeps it
+          # current via the `# renovate: datasource=docker depName=...` comment
+          # convention. Don't replace with :latest or a moving tag; this step
+          # runs with broker write credentials, so a compromised upstream image
+          # would have direct credential-exfiltration access. See security
+          # review note from 2026-05-27 (Sushant Adhikari) for the threat model.
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \
             -v "${PWD}/pacts:/pacts" \
             -e PACT_BROKER_BASE_URL \
             -e PACT_BROKER_USERNAME \
             -e PACT_BROKER_PASSWORD \
-            pactfoundation/pact-cli:latest \
+            "${PACT_CLI_IMAGE}" \
             broker publish /pacts \
               --consumer-app-version "${GITHUB_SHA}" \
               --branch "${GITHUB_REF_NAME}" \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -18,17 +18,17 @@ name: Pact Consumer
 on:
   pull_request:
     paths:
-      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
-      - "Tests/ContractTests/**"
-      - "Package.swift"
-      - ".github/workflows/pact-consumer.yml"
+      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
+      - Tests/ContractTests/**
+      - Package.swift
+      - .github/workflows/pact-consumer.yml
   push:
     branches: [main]
     paths:
-      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
-      - "Tests/ContractTests/**"
-      - "Package.swift"
-      - ".github/workflows/pact-consumer.yml"
+      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
+      - Tests/ContractTests/**
+      - Package.swift
+      - .github/workflows/pact-consumer.yml
 
 permissions:
   contents: read

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -2,16 +2,21 @@ name: Pact Consumer
 
 # Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
 #
-# Two jobs:
-#  - `consumer-test` runs on every PR + every push to `main`. It executes the
-#    PactSwift spec against the in-process mock server, generates a pact JSON,
-#    and uploads it as a workflow artifact. No Rokt secrets are exposed; PR code
-#    from public forks is safe to run here because the GitHub-provided runner is
-#    fully isolated from Rokt infrastructure.
-#  - `publish` runs only on push to `main` and is gated by the `pact-publish`
-#    GitHub environment (required-reviewers + main-branch-only). On approval,
-#    broker write credentials are exposed and the pact JSON is published
-#    directly to the pact broker.
+# Three jobs:
+#  - `detect-changes` runs first on every PR + every push to `main`. It uses
+#    dorny/paths-filter to check whether contract-relevant files changed
+#    (V2 clients, contract tests, Package.swift, this workflow). Its output
+#    gates the publish job below.
+#  - `consumer-test` runs unconditionally on every PR + every push to `main`,
+#    regardless of which files changed. This catches *indirect* drift — e.g.
+#    a refactor to a shared networking helper that V2OffersClient calls would
+#    still run the pact spec. Uses macos-latest for the iOS Simulator. No
+#    Rokt secrets are exposed; fork-PR code is safe to run here.
+#  - `publish` runs only on push to `main` AND only when contract-relevant
+#    files actually changed (per `detect-changes`). It is gated by the
+#    `pact-publish` GitHub environment (required-reviewers + main-branch-only).
+#    Skipping publish on no-op merges saves maintainer approval clicks while
+#    keeping the consumer-test safety net unconditional.
 #
 # Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
 
@@ -28,6 +33,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect Contract Changes
+    runs-on: ubuntu-latest
+    outputs:
+      contract: ${{ steps.filter.outputs.contract }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # paths-filter needs git history on push events to diff against the
+          # previous main commit. Full clone for safety; this job is tiny.
+          fetch-depth: 0
+
+      - name: Filter contract paths
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # `contract` is true when any of these paths changed in the PR /
+          # push. The publish job below gates on this. consumer-test runs
+          # unconditionally regardless of this output.
+          filters: |
+            contract:
+              - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
+              - 'Sources/Rokt_Widget/Networking/V2EventsClient.swift'
+              - 'Tests/ContractTests/**'
+              - 'Package.swift'
+              - '.github/workflows/pact-consumer.yml'
+
   consumer-test:
     name: Consumer Test (PactSwift)
     runs-on: macos-latest
@@ -79,8 +113,17 @@ jobs:
 
   publish:
     name: Publish to Broker
-    needs: consumer-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [consumer-test, detect-changes]
+    # Publish only when:
+    #   1. This is a push to main (not a PR)
+    #   2. Contract-relevant files actually changed (per detect-changes)
+    # The second gate prevents approval-click fatigue on no-op merges. The
+    # broker would dedup byte-identical content anyway, but skipping the
+    # publish job entirely also skips the env-protected approval prompt.
+    if: |
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.detect-changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
     # `pact-publish` is configured with required reviewers + main-only deployment
     # branches. Broker write credentials are exposed only after maintainer approval.

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -140,11 +140,10 @@ jobs:
     needs: [publish]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Advisory: the published pacts are forward-looking V2 contracts the SDK
-    # does not consume yet, so there is no `stage` deployment to verify
-    # against — the step reports the broker's answer but never fails the job.
-    # When the SDK starts consuming the V2 APIs, make this a blocking gate
-    # (remove the advisory wrapper in the step below) and re-validate end-to-end.
+    # Advisory — never fails the job. Forward-looking pacts: the SDK doesn't consume
+    # V2 yet and no deploy environment is wired up, so `--to-environment stage` is a
+    # deliberate no-op (`stage` is a placeholder). When the SDK consumes V2, make it
+    # blocking against the environment a released SDK calls (likely production).
     environment: pact-publish
     steps:
       - name: Check provider verification

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -156,12 +156,10 @@ jobs:
             exit 1
           fi
 
-          # Image pinned to manifest digest (not :latest). Renovate keeps it
-          # current via the `# renovate: datasource=docker depName=...` comment
-          # convention. Don't replace with :latest or a moving tag; this step
-          # runs with broker write credentials, so a compromised upstream image
-          # would have direct credential-exfiltration access. See security
-          # review note from 2026-05-27 (Sushant Adhikari) for the threat model.
+          # Image pinned to manifest digest (not :latest). This step runs with
+          # write credentials in env, so a moving tag would be a credential-
+          # exfiltration vector if the upstream image were ever compromised.
+          # Renovate keeps the digest current via the comment below.
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,25 +1,5 @@
 name: Pact Consumer
 
-# Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
-#
-# Three jobs:
-#  - `detect-changes` runs first on every PR + every push to `main`. It uses
-#    dorny/paths-filter to check whether contract-relevant files changed
-#    (V2 clients, contract tests, Package.swift, this workflow). Its output
-#    gates the publish job below.
-#  - `consumer-test` runs unconditionally on every PR + every push to `main`,
-#    regardless of which files changed. This catches *indirect* drift — e.g.
-#    a refactor to a shared networking helper that V2OffersClient calls would
-#    still run the pact spec. Uses macos-latest for the iOS Simulator. No
-#    Rokt secrets are exposed; fork-PR code is safe to run here.
-#  - `publish` runs only on push to `main` AND only when contract-relevant
-#    files actually changed (per `detect-changes`). It is gated by the
-#    `pact-publish` GitHub environment (required-reviewers + main-branch-only).
-#    Skipping publish on no-op merges saves maintainer approval clicks while
-#    keeping the consumer-test safety net unconditional.
-#
-# Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
-
 on:
   pull_request:
   push:
@@ -43,17 +23,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          # paths-filter needs git history on push events to diff against the
-          # previous main commit. Full clone for safety; this job is tiny.
+          # paths-filter needs history to diff against the previous commit on push.
           fetch-depth: 0
 
       - name: Filter contract paths
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
-          # `contract` is true when any of these paths changed in the PR /
-          # push. The publish job below gates on this. consumer-test runs
-          # unconditionally regardless of this output.
           filters: |
             contract:
               - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
@@ -79,10 +55,7 @@ jobs:
 
       - name: Run contract tests
         env:
-          # PactSwift writes inside the simulator data container by default. The
-          # TEST_RUNNER_ prefix is xcodebuild's mechanism for propagating env vars
-          # to the test runner inside the simulator (the prefix is stripped on
-          # arrival, so the test reads `PACT_OUTPUT_DIR` directly).
+          # TEST_RUNNER_ prefix propagates env vars to the simulator test runner; prefix is stripped on arrival.
           TEST_RUNNER_PACT_OUTPUT_DIR: ${{ runner.temp }}/pacts
         run: |
           mkdir -p "${{ runner.temp }}/pacts"
@@ -114,20 +87,11 @@ jobs:
   publish:
     name: Publish to Broker
     needs: [consumer-test, detect-changes]
-    # Publish only when:
-    #   1. This is a push to main (not a PR)
-    #   2. Contract-relevant files actually changed (per detect-changes)
-    # The second gate prevents approval-click fatigue on no-op merges. The
-    # broker would dedup byte-identical content anyway, but skipping the
-    # publish job entirely also skips the env-protected approval prompt.
     if: |
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
       && needs.detect-changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
-    # `pact-publish` is configured with required reviewers + main-only deployment
-    # branches. Broker write credentials are exposed only after maintainer approval.
-    # See documentation/pact-v2-migration.md for setup details.
     environment: pact-publish
     steps:
       - name: Download pact JSON
@@ -156,10 +120,6 @@ jobs:
             exit 1
           fi
 
-          # Image pinned to manifest digest (not :latest). This step runs with
-          # write credentials in env, so a moving tag would be a credential-
-          # exfiltration vector if the upstream image were ever compromised.
-          # Renovate keeps the digest current via the comment below.
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
           docker run --rm \

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,0 +1,136 @@
+name: Pact Consumer
+
+# Consumer-driven pact testing for the iOS SDK against `transactions-api` v2.
+#
+# Two jobs:
+#  - `consumer-test` runs on every PR + every push to `main`. It executes the
+#    PactSwift spec against the in-process mock server, generates a pact JSON,
+#    and uploads it as a workflow artifact. No Rokt secrets are exposed; PR code
+#    from public forks is safe to run here because the GitHub-provided runner is
+#    fully isolated from Rokt infrastructure.
+#  - `publish` runs only on push to `main` and is gated by the `pact-publish`
+#    GitHub environment (required-reviewers + main-branch-only). On approval,
+#    broker write credentials are exposed and the pact JSON is published
+#    directly to the pact broker.
+#
+# Reading: ../../documentation/pact-v2-migration.md (lands with a later PR).
+
+on:
+  pull_request:
+    paths:
+      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
+      - "Tests/ContractTests/**"
+      - "Package.swift"
+      - ".github/workflows/pact-consumer.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Sources/Rokt_Widget/Networking/V2OffersClient.swift"
+      - "Tests/ContractTests/**"
+      - "Package.swift"
+      - ".github/workflows/pact-consumer.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  consumer-test:
+    name: Consumer Test (PactSwift)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: "26.2"
+
+      - name: Run contract tests
+        env:
+          # PactSwift writes inside the simulator data container by default. The
+          # TEST_RUNNER_ prefix is xcodebuild's mechanism for propagating env vars
+          # to the test runner inside the simulator (the prefix is stripped on
+          # arrival, so the test reads `PACT_OUTPUT_DIR` directly).
+          TEST_RUNNER_PACT_OUTPUT_DIR: ${{ runner.temp }}/pacts
+        run: |
+          mkdir -p "${{ runner.temp }}/pacts"
+          xcodebuild test \
+            -scheme Rokt-Widget \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -only-testing:ContractTests \
+            -resultBundlePath "${{ runner.temp }}/test-results.xcresult"
+
+      - name: Verify pact JSON generated
+        run: |
+          if ! ls "${{ runner.temp }}/pacts/"*.json >/dev/null 2>&1; then
+            echo "::error::No pact JSON generated under ${{ runner.temp }}/pacts/" >&2
+            echo "Listing simulator data container as a fallback diagnostic:"
+            find ~/Library/Developer/CoreSimulator/Devices -name "rokt-sdk-ios-*.json" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Generated pact files:"
+          ls -la "${{ runner.temp }}/pacts/"
+
+      - name: Upload pact JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pact-json
+          path: ${{ runner.temp }}/pacts/
+          retention-days: 14
+          if-no-files-found: error
+
+  publish:
+    name: Publish to Broker
+    needs: consumer-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # `pact-publish` is configured with required reviewers + main-only deployment
+    # branches. Broker write credentials are exposed only after maintainer approval.
+    # See documentation/pact-v2-migration.md for setup details.
+    environment: pact-publish
+    steps:
+      - name: Download pact JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pact-json
+          path: pacts/
+
+      - name: Publish to pact broker
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
+            echo "::error::PACT_BROKER_BASE_URL is unset. Configure the pact-publish environment." >&2
+            exit 1
+          fi
+          if [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
+            echo "::error::PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD missing." >&2
+            exit 1
+          fi
+
+          docker run --rm \
+            -v "${PWD}/pacts:/pacts" \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            pactfoundation/pact-cli:latest \
+            broker publish /pacts \
+              --consumer-app-version "${GITHUB_SHA}" \
+              --branch "${GITHUB_REF_NAME}" \
+              --tag "forward-looking" \
+              --build-url "${BUILD_URL}"

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -87,10 +87,13 @@ jobs:
   publish:
     name: Publish to Broker
     needs: [consumer-test, detect-changes]
+    # Main pushes and same-repo (non-fork) PR pushes with contract changes.
     if: |
-      github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
-      && needs.detect-changes.outputs.contract == 'true'
+      needs.detect-changes.outputs.contract == 'true'
+      && (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
     runs-on: ubuntu-latest
     environment: pact-publish
     steps:
@@ -106,17 +109,15 @@ jobs:
           PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           GITHUB_SHA: ${{ github.sha }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          # On PR runs `github.head_ref` is the source branch; on main pushes
+          # it's empty and falls through to `github.ref_name` ("main").
+          PACT_BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
-          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
-            echo "::error::PACT_BROKER_BASE_URL is unset. Configure the pact-publish environment." >&2
-            exit 1
-          fi
-          if [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
-            echo "::error::PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD missing." >&2
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ] || [ -z "${PACT_BROKER_USERNAME:-}" ] || [ -z "${PACT_BROKER_PASSWORD:-}" ]; then
+            echo "::error::Broker credentials are not set." >&2
             exit 1
           fi
 
@@ -130,6 +131,36 @@ jobs:
             "${PACT_CLI_IMAGE}" \
             broker publish /pacts \
               --consumer-app-version "${GITHUB_SHA}" \
-              --branch "${GITHUB_REF_NAME}" \
+              --branch "${PACT_BRANCH}" \
               --tag "forward-looking" \
               --build-url "${BUILD_URL}"
+
+  can-i-deploy:
+    name: Can I Deploy
+    needs: [publish]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Advisory until the provider side is bootstrapped for environment-based
+    # can-i-deploy; flip to false to make this a blocking merge gate.
+    continue-on-error: true
+    environment: pact-publish
+    steps:
+      - name: Check provider verification
+        env:
+          PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # renovate: datasource=docker depName=pactfoundation/pact-cli
+          PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
+          docker run --rm \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_BROKER_USERNAME \
+            -e PACT_BROKER_PASSWORD \
+            "${PACT_CLI_IMAGE}" \
+            broker can-i-deploy \
+              --pacticipant rokt-sdk-ios \
+              --version "${GITHUB_SHA}" \
+              --to-environment stage

--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -17,18 +17,8 @@ name: Pact Consumer
 
 on:
   pull_request:
-    paths:
-      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
-      - Tests/ContractTests/**
-      - Package.swift
-      - .github/workflows/pact-consumer.yml
   push:
     branches: [main]
-    paths:
-      - Sources/Rokt_Widget/Networking/V2OffersClient.swift
-      - Tests/ContractTests/**
-      - Package.swift
-      - .github/workflows/pact-consumer.yml
 
 permissions:
   contents: read

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -49,9 +49,11 @@ class V2EventsClientPactSpec: XCTestCase {
                         "type": "msdk",
                         "sdk_version": Matcher.SomethingLike("5.2.2")
                     ],
+                    // instance_id must be a canonical 36-character, non-nil UUID;
+                    // the API rejects other forms, so the example uses a valid one.
                     "events": Matcher.EachLike([
                         "event_type": Matcher.SomethingLike("impression"),
-                        "instance_id": Matcher.SomethingLike("instance-001"),
+                        "instance_id": Matcher.SomethingLike("00000000-0000-0000-0000-000000000001"),
                         "timestamp": Matcher.SomethingLike(1_774_474_053_000),
                         "data": [
                             "source_message_id": Matcher.SomethingLike("source-message-001")
@@ -59,17 +61,18 @@ class V2EventsClientPactSpec: XCTestCase {
                     ], min: 1)
                 ]
             )
+            // Assert only the minimal success shape: session_token and event_ids.
+            // errors and warnings are present in the response but not asserted, so
+            // the contract stays minimal and tolerant of their contents.
             .willRespondWith(
                 status: 202,
-                headers: ["Content-Type": "application/json"],
+                headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
                 body: [
                     "session_token": [
                         "token": Matcher.SomethingLike("next-session-token"),
                         "expires_at": Matcher.SomethingLike(1_774_474_053_000)
                     ],
-                    "event_ids": Matcher.EachLike(Matcher.SomethingLike("event-001"), min: 1),
-                    "errors": [],
-                    "warnings": []
+                    "event_ids": Matcher.EachLike(Matcher.SomethingLike("event-001"), min: 1)
                 ]
             )
 
@@ -91,7 +94,7 @@ class V2EventsClientPactSpec: XCTestCase {
                     )
                     let event = V2Event(
                         eventType: "impression",
-                        instanceId: "instance-001",
+                        instanceId: "00000000-0000-0000-0000-000000000001",
                         timestamp: 1_774_474_053_000,
                         data: ["source_message_id": "source-message-001"]
                     )

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -75,7 +75,10 @@ class V2EventsClientPactSpec: XCTestCase {
 
         let expectation = expectation(description: "v2 events request completes")
 
-        Self.mockService.run(timeout: 5) { baseURL, done in
+        // Timeout sized for CI cold-start: first PactSwift mock-service spin-up +
+        // simulator Network.framework init can take 5+ seconds before the request
+        // even begins. Once warm, the actual round trip is <100ms.
+        Self.mockService.run(timeout: 30) { baseURL, done in
             Task {
                 defer { done() }
                 do {
@@ -101,6 +104,6 @@ class V2EventsClientPactSpec: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 6)
+        wait(for: [expectation], timeout: 35)
     }
 }

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -27,7 +27,11 @@ class V2OffersClientPactSpec: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        let outputDir = URL(fileURLWithPath: "pacts", isDirectory: true)
+        // PACT_OUTPUT_DIR lets CI redirect the generated JSON to a host path that
+        // can be picked up after the simulator exits — without it, PactSwift writes
+        // into the simulator data container where GH Actions can't reach it.
+        let outputPath = ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "pacts"
+        let outputDir = URL(fileURLWithPath: outputPath, isDirectory: true)
         mockService = MockService(
             consumer: "rokt-sdk-ios",
             provider: "transactions-api",

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -113,7 +113,8 @@ class V2OffersClientPactSpec: XCTestCase {
 
         let expectation = expectation(description: "v2 offers request completes")
 
-        Self.mockService.run(timeout: 5) { baseURL, done in
+        // See V2EventsClientPactSpec for why this is sized for CI cold-start.
+        Self.mockService.run(timeout: 30) { baseURL, done in
             Task {
                 defer { done() }
                 do {
@@ -147,6 +148,6 @@ class V2OffersClientPactSpec: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 6)
+        wait(for: [expectation], timeout: 35)
     }
 }

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -11,8 +11,7 @@ import PactSwift
 /// those expectations (e.g., sends `rokt-platform-type: "ios-mobile"` instead
 /// of `"iOS"`), the pact mock service rejects the request and this test fails.
 ///
-/// Pattern mirrors sdk-web's consumer-pact specs (see PR ROKT/sdk-web#1372):
-/// the test never constructs request headers or body directly, only domain
+/// The test never constructs request headers or body directly, only domain
 /// inputs. Wire-shape construction lives entirely in `V2OffersClient`.
 ///
 /// Matcher policy: fixed-value strings hardcoded in `V2OffersClient`
@@ -83,9 +82,15 @@ class V2OffersClientPactSpec: XCTestCase {
                     ]
                 ]
             )
+            // Assert only the response fields V2OffersClient consumes and that
+            // the v2 API returns for a configured page: session and token data,
+            // the resolved page_instance_guid, and a page_context limited to
+            // page_instance_guid, page_id, page_type and is_page_detected. Any
+            // other page_context keys and the plugins / placements / event_data
+            // / privacy_control blocks are not part of this contract.
             .willRespondWith(
                 status: 200,
-                headers: ["Content-Type": "application/json"],
+                headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
                 body: [
                     "session_id": Matcher.SomethingLike("session-123"),
                     "session_token": [
@@ -93,21 +98,12 @@ class V2OffersClientPactSpec: XCTestCase {
                         "expires_at": Matcher.SomethingLike(1_774_474_053_000)
                     ],
                     "page_context": [
-                        "rokt_tag_id": Matcher.SomethingLike("tag-123"),
                         "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123"),
                         "page_id": Matcher.SomethingLike("checkout-page"),
                         "page_type": Matcher.RegexLike("checkout", term: validPageTypes),
-                        "language": Matcher.SomethingLike("en-US"),
-                        "is_page_detected": Matcher.SomethingLike(true),
-                        "page_variant_name": Matcher.SomethingLike("control")
+                        "is_page_detected": Matcher.SomethingLike(true)
                     ],
-                    "plugins": [],
-                    "placements": [],
-                    "event_data": [:],
-                    "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    "privacy_control": [
-                        "limited_use": Matcher.SomethingLike(false)
-                    ]
+                    "page_instance_guid": Matcher.SomethingLike("page-instance-guid-123")
                 ]
             )
 


### PR DESCRIPTION
## What

Adds the consumer-side Pact contract-testing workflow for the SDK:

- **`consumer-test`** runs the PactSwift contract specs in an iOS simulator and uploads the generated pact JSON as an artifact.
- **`publish`** posts the pact to the Pact broker on `main` pushes and same-repo (non-fork) PR pushes that touch contract-relevant paths, tagged with the source branch so per-branch pacts don't pollute the `main` contract.
- **`can-i-deploy`** queries the broker on PRs. Advisory for now (`continue-on-error: true`); becomes a blocking merge gate once the provider side is bootstrapped.

Broker connection details come entirely from repository/environment configuration (`vars`/`secrets` on the `pact-publish` environment) — nothing infrastructure-specific is hardcoded in the workflow.

## Notes

- Replaces the earlier **closed #170** (which used a manual approval gate). Publishing is now fully automated per team agreement; the environment is referenced only to scope the broker write credentials to the publish/can-i-deploy jobs.
- **Fork PRs** run the contract tests but skip `publish` (no credentials exposed).

## Validation

Validated end-to-end on a throwaway branch: the pact published successfully and is readable on the broker; `can-i-deploy` runs advisory (the provider-side `stage` environment isn't bootstrapped yet, so it reports not-deployable without blocking).

## How has this been tested?

- **Contract specs** (`ContractTests`, PactSwift) run in CI on every PR and generate the pact JSON.
- **Publish path** validated end-to-end via a throwaway smoke PR — #180 — which ran the `Publish to Broker` job from CI and confirmed the pact publishes successfully to the broker. The smoke branch was deleted afterward; its run history remains on #180 for reference.
