### PR TITLE
feat(contract): add v2/sessions/init consumer pact for iOS SDK

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -34,6 +34,7 @@ jobs:
             contract:
               - 'Sources/Rokt_Widget/Networking/V2OffersClient.swift'
               - 'Sources/Rokt_Widget/Networking/V2EventsClient.swift'
+              - 'Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift'
               - 'Tests/ContractTests/**'
               - 'Package.swift'
               - '.github/workflows/pact-consumer.yml'

--- a/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
@@ -1,0 +1,91 @@
+// periphery:ignore:all - referenced from Tests/ContractTests/V2SessionsInitClientPactSpec.swift
+
+import Foundation
+
+internal struct V2SessionsInitClient {
+    let baseURL: URL
+    let accountId: String
+    let authToken: String
+    let sdkVersion: String
+    let httpClient: HTTPClientAdapter
+
+    init(
+        baseURL: URL,
+        accountId: String,
+        authToken: String,
+        sdkVersion: String,
+        httpClient: HTTPClientAdapter = RoktHTTPClient()
+    ) {
+        self.baseURL = baseURL
+        self.accountId = accountId
+        self.authToken = authToken
+        self.sdkVersion = sdkVersion
+        self.httpClient = httpClient
+    }
+
+    func initSession(
+        operating_system: String,
+        sdk_version: String,
+        layout_schema_version: String
+    ) async throws -> (Data?, HTTPURLResponse?) {
+        let url = baseURL
+            .appendingPathComponent("v2")
+            .appendingPathComponent("sessions")
+            .appendingPathComponent("init")
+
+        let requestBody = V2SessionsInitRequest(
+            operatingSystem: operating_system,
+            sdkVersion: sdk_version,
+            layoutSchemaVersion: layout_schema_version
+        )
+        let bodyData = try JSONEncoder().encode(requestBody)
+        guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
+            throw V2SessionsInitClientError.bodyEncodingFailed
+        }
+
+        let headers: RoktHTTPHeaders = [
+            "rokt-account-id": accountId,
+            "Authorization": authToken,
+            "rokt-platform-type": "iOS",
+            "rokt-integration-type": "msdk-ios",
+            "x-request-id": UUID().uuidString,
+            "Content-Type": "application/json"
+        ]
+
+        return try await withCheckedThrowingContinuation { continuation in
+            httpClient.startRequestWith(
+                urlAddress: url.absoluteString,
+                method: .post,
+                parameters: bodyParameters,
+                parameterArray: nil,
+                headers: headers,
+                onRequestStart: nil,
+                requestTimeout: nil,
+                completionQueue: .main,
+                completionHandler: { result in
+                    if let error = result.responseError {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: (result.responseData, result.httpURLResponse))
+                    }
+                }
+            )
+        }
+    }
+}
+
+internal enum V2SessionsInitClientError: Error {
+    case bodyEncodingFailed
+}
+
+internal struct V2SessionsInitRequest: Encodable {
+    let operatingSystem: String
+    let sdkVersion: String
+    let layoutSchemaVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case operatingSystem = "operating_system"
+        case sdkVersion = "sdk_version"
+        case layoutSchemaVersion = "layout_schema_version"
+    }
+}

--- a/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
+++ b/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
@@ -1,0 +1,103 @@
+import XCTest
+import PactSwift
+@testable import Rokt_Widget
+
+/// Consumer-driven pact spec for `POST /v2/sessions/init`. Drives
+/// `V2SessionsInitClient.initSession` through the pact mock service so any drift
+/// in the client's wire shape fails here.
+class V2SessionsInitClientPactSpec: XCTestCase {
+    static var mockService: MockService!
+
+    override class func setUp() {
+        super.setUp()
+        // PACT_OUTPUT_DIR redirects the JSON to a host path CI can read after the
+        // simulator exits; without it PactSwift writes into the sim data container.
+        let outputPath = ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "pacts"
+        let outputDir = URL(fileURLWithPath: outputPath, isDirectory: true)
+        mockService = MockService(
+            consumer: "rokt-sdk-ios",
+            provider: "transactions-api",
+            writePactTo: outputDir
+        )
+    }
+
+    func test_sessionInitHappyPath_returnsSessionAndFeatureFlags() {
+        Self.mockService
+            .uponReceiving("a v2 sessions init request from rokt-sdk-ios initializes a session and returns feature flags")
+            .given(ProviderState(description: "a valid session initialization request is submitted", params: [:]))
+            .withRequest(
+                method: .POST,
+                path: "/v2/sessions/init",
+                headers: [
+                    "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
+                    "Authorization": Matcher.RegexLike("Bearer session-token-abc", term: #".+"#),
+                    "rokt-platform-type": "iOS",
+                    "rokt-integration-type": "msdk-ios",
+                    "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),
+                    "Content-Type": "application/json"
+                ],
+                body: [
+                    "operating_system": "ios",
+                    "sdk_version": Matcher.SomethingLike("5.2.2"),
+                    "layout_schema_version": Matcher.SomethingLike("2.1.0")
+                ]
+            )
+            // fonts is a literal `[]` (exact match), not EachLike: the provider always
+            // returns empty today, and EachLike's default min:1 would demand a non-empty array.
+            .willRespondWith(
+                status: 200,
+                headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
+                body: [
+                    "session_id": Matcher.SomethingLike("550e8400-e29b-41d4-a716-446655440000"),
+                    "session_token": [
+                        "token": Matcher.SomethingLike("pact-stub-session-token"),
+                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
+                    ],
+                    "feature_flags": [
+                        "rokt-tracking-status": Matcher.SomethingLike(true),
+                        "client-timeout-ms": Matcher.SomethingLike(30_000),
+                        "ios-sdk-log-font-happy-path": Matcher.SomethingLike(true),
+                        "ios-sdk-use-font-register-with-url": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-bounding-box": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-partner-events": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-open-url-from-rokt": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-timings-api": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-safe-area-removed": Matcher.SomethingLike(false),
+                        "mobile-sdk-use-sdk-cache": Matcher.SomethingLike(false),
+                        "is-post-purchase-enabled": Matcher.SomethingLike(false),
+                        "minimum-post-purchase-schema": Matcher.SomethingLike("2.3.0")
+                    ],
+                    "fonts": []
+                ]
+            )
+
+        let expectation = expectation(description: "v2 sessions init request completes")
+
+        // Timeout sized for CI cold-start. See V2EventsClientPactSpec.
+        Self.mockService.run(timeout: 30) { baseURL, done in
+            Task {
+                defer { done() }
+                do {
+                    let url = try XCTUnwrap(URL(string: baseURL))
+                    let client = V2SessionsInitClient(
+                        baseURL: url,
+                        accountId: "account-456",
+                        authToken: "Bearer session-token-abc",
+                        sdkVersion: "5.2.2"
+                    )
+                    let (_, httpResponse) = try await client.initSession(
+                        operating_system: "ios",
+                        sdk_version: "5.2.2",
+                        layout_schema_version: "2.1.0"
+                    )
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+                } catch {
+                    XCTFail("V2SessionsInitClient request failed: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 35)
+    }
+}


### PR DESCRIPTION
## What

Adds consumer-driven contract coverage for `POST /v2/sessions/init` to the iOS SDK:

- **`Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift`** — new networking client that owns the wire-shape construction (headers + JSON body), following the existing `V2OffersClient` / `V2EventsClient` pattern. Public method:
  `initSession(operating_system:sdk_version:layout_schema_version:) async throws -> (Data?, HTTPURLResponse?)`.
- **`Tests/ContractTests/V2SessionsInitClientPactSpec.swift`** — a PactSwift consumer spec (`test_sessionInitHappyPath_returnsSessionAndFeatureFlags`) that drives the client through the pact mock service. Because the test only supplies domain inputs and never builds headers/body itself, any drift in the wire shape fails the test.
- **`.github/workflows/pact-consumer.yml`** — registers the new client in the contract paths filter so future changes to it re-trigger the consumer job.

## Contract shape

- **Request** — `POST /v2/sessions/init`, body `{ operating_system, sdk_version, layout_schema_version }`. The enum value `"ios"` and the `rokt-platform-type` / `rokt-integration-type` headers are pinned as exact strings (catches client drift); per-call headers (account id, auth token, request id) use a regex `.+` matcher and per-call body values use type matchers — matching the shared contract and the Android consumer.
- **Response** — HTTP 200 asserting `session_id`, `session_token` (`token` + `expires_at`) and the `feature_flags` map, all with type matchers (server-evaluated flags vary by environment). `fonts` is pinned as an exact empty array, since the provider always returns `[]` and the item shape is not yet frozen.

## Rollout

Part of a three-repo rollout — transactions provider + iOS and Android consumers. Pacts publish under the **forward-looking** tag: the SDK does not yet call `/v2/sessions/init` in shipped code, so provider verification is advisory (soft-fail) until both mobile SDKs consume v2 in production. Provider-state string and interaction description are coordinated byte-for-byte across all three repos.

## Verification

- `xcodebuild test -only-testing:ContractTests` — all three specs (Offers, Events, SessionsInit) pass locally.
- Generated pact confirmed: `POST /v2/sessions/init`, correct provider state, 200 response with the asserted fields and `fonts: []`.
- `trunk check` clean on the new files (swiftlint + swiftformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)