### PR TITLE
fix: remove v2 platform and integration type headers

### DIFF
--- a/Sources/Rokt_Widget/Networking/V2EventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2EventsClient.swift
@@ -41,8 +41,6 @@ internal struct V2EventsClient {
         let headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
             "Authorization": authToken,
-            "rokt-platform-type": "iOS",
-            "rokt-integration-type": "msdk-ios",
             "Content-Type": "application/json"
         ]
 

--- a/Sources/Rokt_Widget/Networking/V2OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2OffersClient.swift
@@ -59,8 +59,6 @@ internal struct V2OffersClient {
         let headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
             "Authorization": authToken,
-            "rokt-platform-type": "iOS",
-            "rokt-integration-type": "msdk-ios",
             "x-request-id": input.requestId,
             "rokt-page-instance-guid": pageInstanceGuid,
             "Content-Type": "application/json"

--- a/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
@@ -46,8 +46,6 @@ internal struct V2SessionsInitClient {
         let headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
             "Authorization": authToken,
-            "rokt-platform-type": "iOS",
-            "rokt-integration-type": "msdk-ios",
             "x-request-id": UUID().uuidString,
             "Content-Type": "application/json"
         ]

--- a/Tests/ContractTests/V2EventsClientPactSpec.swift
+++ b/Tests/ContractTests/V2EventsClientPactSpec.swift
@@ -7,8 +7,7 @@ import PactSwift
 /// Drives `V2EventsClient.recordEvents(events:)` — the test never constructs
 /// request headers or body directly, only domain inputs. Wire-shape
 /// construction lives entirely in `V2EventsClient`, so any drift there
-/// (e.g. switching `rokt-integration-type` from `"msdk-ios"` to
-/// `"ios-mobile"`) gets rejected by the pact mock service.
+/// (e.g. changing the `channel.type` body field) gets rejected by the pact mock service.
 ///
 /// Mirrors V2OffersClientPactSpec — see that file's docstring for the
 /// matcher policy (exact-match for hardcoded constants, `SomethingLike`
@@ -40,8 +39,6 @@ class V2EventsClientPactSpec: XCTestCase {
                 headers: [
                     "rokt-account-id": Matcher.SomethingLike("account-456"),
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
-                    "rokt-platform-type": "iOS",
-                    "rokt-integration-type": "msdk-ios",
                     "Content-Type": "application/json"
                 ],
                 body: [

--- a/Tests/ContractTests/V2OffersClientPactSpec.swift
+++ b/Tests/ContractTests/V2OffersClientPactSpec.swift
@@ -8,19 +8,19 @@ import PactSwift
 /// domain inputs (page identifier, customer email, attributes, request-scoped
 /// ids) and internally builds the wire request. The pact matchers below
 /// describe the EXPECTED wire shape; if `V2OffersClient` ever drifts from
-/// those expectations (e.g., sends `rokt-platform-type: "ios-mobile"` instead
-/// of `"iOS"`), the pact mock service rejects the request and this test fails.
+/// those expectations (e.g., changes the `channel.type` body field or drops the
+/// `x-request-id` header), the pact mock service rejects the request and this test fails.
 ///
 /// The test never constructs request headers or body directly, only domain
 /// inputs. Wire-shape construction lives entirely in `V2OffersClient`.
 ///
-/// Matcher policy: fixed-value strings hardcoded in `V2OffersClient`
-/// (`"iOS"`, `"msdk-ios"`, `"msdk"`) are pinned as exact strings rather
-/// than `SomethingLike`. `SomethingLike` only matches by type, which
-/// would let the client drift to `"ios-mobile"` without failing the
-/// consumer test. Per-runtime values (account id, auth token, request id,
-/// session ids, page identifier, etc.) stay as `SomethingLike` because
-/// they legitimately vary per call.
+/// Matcher policy: the fixed-value string hardcoded in `V2OffersClient`
+/// (`channel.type` = `"msdk"`) is pinned as an exact string rather than
+/// `SomethingLike`. `SomethingLike` only matches by type, which would let
+/// the client drift to `"ios-mobile"` without failing the consumer test.
+/// Per-runtime values (account id, auth token, request id, session ids,
+/// page identifier, etc.) stay as `SomethingLike` because they legitimately
+/// vary per call.
 class V2OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -50,8 +50,6 @@ class V2OffersClientPactSpec: XCTestCase {
                 headers: [
                     "rokt-account-id": Matcher.SomethingLike("account-456"),
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
-                    "rokt-platform-type": "iOS",
-                    "rokt-integration-type": "msdk-ios",
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
                     "Content-Type": "application/json"

--- a/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
+++ b/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
@@ -31,8 +31,6 @@ class V2SessionsInitClientPactSpec: XCTestCase {
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
                     "Authorization": Matcher.RegexLike("Bearer session-token-abc", term: #".+"#),
-                    "rokt-platform-type": "iOS",
-                    "rokt-integration-type": "msdk-ios",
                     "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),
                     "Content-Type": "application/json"
                 ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Background

The v2 session clients (`init`, `offers`, `events`) were sending two extra request headers — `rokt-platform-type` and `rokt-integration-type` — that aren't part of the v2 contract. The platform/integration are already conveyed by the request body (`channel`), so these headers were redundant and at risk of drifting out of sync. This removes them so the SDK sends only what the contract expects.

## What Has Changed

- Removed the `rokt-platform-type` and `rokt-integration-type` headers from the v2 init, offers, and events clients.
- Updated the corresponding consumer Pact specs (and their docstrings) to drop those header expectations.
- Legacy v1 networking is untouched.

## How Has This Been Tested

- `trunk check` passes on all changed files.
- `ContractTests` target builds and passes (3/3) via `xcodebuild`, confirming the clients still satisfy the consumer Pact after the header removal.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
