### PR TITLE
chore: bump minimum RoktUXHelper to 0.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.10.12"),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.11.0"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/surpher/PactSwift.git", .upToNextMajor(from: "1.2.0"))
     ],

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.2', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.10.12', '< 1.0'
+  s.dependency 'RoktUXHelper', '>= 0.11.0', '< 1.0'
 end


### PR DESCRIPTION
## Background

The `RoktUXHelper` dependency minimum was previously `0.10.12`. This raises the floor to `0.11.0` while keeping the upper bound at the next major version, so consumers pull in `0.11.x`+ but never an unreviewed `1.0.0`.

`Package.swift`'s `from:` is shorthand for `.upToNextMajor(from:)`, so it resolves to the same range the podspec spells out explicitly — the two manifests stay in lockstep.

## What Has Changed

- `Package.swift`: `from: "0.10.12"` → `from: "0.11.0"` (resolves to `>= 0.11.0, < 1.0.0`)
- `Rokt-Widget.podspec`: `>= 0.10.12', '< 1.0` → `>= 0.11.0', '< 1.0`

## How Has This Been Tested

- `swift package resolve` re-resolves RoktUXHelper cleanly to `0.11.0` under the new constraint.

## Notes

`Package.resolved` is gitignored, so no lockfile change is included. CHANGELOG.md is intentionally untouched — per `AGENTS.md`, release notes are auto-generated from commit history at release time.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)