### PR TITLE
feat: add v2 init coordinator service

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -1,0 +1,127 @@
+// periphery:ignore:all - net-new v2 init coordinator, not yet wired into the live path
+import Foundation
+
+internal struct TxnInitService {
+    enum TxnInitError: Error, Equatable {
+        case invalidBaseURL
+        case missingResponseData
+        case unexpectedStatusCode(Int)
+    }
+
+    struct InitResult {
+        let response: TxnInitResponse
+        let featureFlags: InitFeatureFlags
+    }
+
+    let environment: TxnEnvironment
+    let accountId: String
+    let sdkVersion: String
+    let layoutSchemaVersion: String
+    let sessionManager: TxnSessionManager
+    let httpClient: HTTPClientAdapter
+    let maxRetries: Int
+    let requestTimeout: TimeInterval
+    let baseBackoff: TimeInterval
+    let sleep: (TimeInterval) async throws -> Void
+
+    init(
+        environment: TxnEnvironment,
+        accountId: String,
+        sdkVersion: String,
+        layoutSchemaVersion: String,
+        sessionManager: TxnSessionManager,
+        httpClient: HTTPClientAdapter = RoktHTTPClient(),
+        maxRetries: Int = 3,
+        requestTimeout: TimeInterval = 7,
+        baseBackoff: TimeInterval = 0.2,
+        sleep: @escaping (TimeInterval) async throws -> Void = { seconds in
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
+    ) {
+        self.environment = environment
+        self.accountId = accountId
+        self.sdkVersion = sdkVersion
+        self.layoutSchemaVersion = layoutSchemaVersion
+        self.sessionManager = sessionManager
+        self.httpClient = httpClient
+        self.maxRetries = maxRetries
+        self.requestTimeout = requestTimeout
+        self.baseBackoff = baseBackoff
+        self.sleep = sleep
+    }
+
+    func initSession() async throws -> InitResult {
+        guard let baseURL = URL(string: environment.gatewayBaseURL) else {
+            throw TxnInitError.invalidBaseURL
+        }
+
+        httpClient.updateTimeout(timeout: requestTimeout)
+
+        let client = V2SessionsInitClient(
+            baseURL: baseURL,
+            accountId: accountId,
+            authToken: sessionManager.authorizationHeader,
+            sdkVersion: sdkVersion,
+            httpClient: httpClient
+        )
+
+        var attempt = 0
+        while true {
+            do {
+                let (data, response) = try await client.initSession(
+                    operating_system: "ios",
+                    sdk_version: sdkVersion,
+                    layout_schema_version: layoutSchemaVersion
+                )
+                let statusCode = response?.statusCode ?? 0
+
+                if isRetryable(statusCode: statusCode), attempt < maxRetries {
+                    try await sleep(backoffDelay(attempt: attempt))
+                    attempt += 1
+                    continue
+                }
+
+                guard (200..<300).contains(statusCode) else {
+                    throw TxnInitError.unexpectedStatusCode(statusCode)
+                }
+                guard let data else {
+                    throw TxnInitError.missingResponseData
+                }
+
+                let decoded = try JSONDecoder().decode(TxnInitResponse.self, from: data)
+                sessionManager.update(sessionId: decoded.sessionId, sessionToken: decoded.sessionToken)
+                return InitResult(response: decoded, featureFlags: decoded.featureFlags.toInitFeatureFlags())
+            } catch let error where isRetryable(error: error) && attempt < maxRetries {
+                try await sleep(backoffDelay(attempt: attempt))
+                attempt += 1
+                continue
+            }
+        }
+    }
+
+    private func isRetryable(statusCode: Int) -> Bool {
+        [500, 502, 503].contains(statusCode)
+    }
+
+    // Transient transport failures only; a hard-offline device fails fast.
+    private func isRetryable(error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorTimedOut,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorCannotFindHost,
+             NSURLErrorDNSLookupFailed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    // Exponential backoff with jitter to avoid hammering a struggling gateway.
+    private func backoffDelay(attempt: Int) -> TimeInterval {
+        let base = baseBackoff * pow(2, Double(attempt))
+        return base + Double.random(in: 0...(base/2))
+    }
+}

--- a/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
@@ -5,14 +5,14 @@ import Foundation
 internal struct V2SessionsInitClient {
     let baseURL: URL
     let accountId: String
-    let authToken: String
+    let authToken: String?
     let sdkVersion: String
     let httpClient: HTTPClientAdapter
 
     init(
         baseURL: URL,
         accountId: String,
-        authToken: String,
+        authToken: String? = nil,
         sdkVersion: String,
         httpClient: HTTPClientAdapter = RoktHTTPClient()
     ) {
@@ -43,12 +43,15 @@ internal struct V2SessionsInitClient {
             throw V2SessionsInitClientError.bodyEncodingFailed
         }
 
-        let headers: RoktHTTPHeaders = [
+        var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
-            "Authorization": authToken,
             "x-request-id": UUID().uuidString,
             "Content-Type": "application/json"
         ]
+        // Authorization is optional: with no stored token the server mints a fresh session.
+        if let authToken, !authToken.isEmpty {
+            headers["Authorization"] = authToken
+        }
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class TestTxnInitService: XCTestCase {
+
+    private var now: Date!
+    private var sessionManager: TxnSessionManager!
+    private var httpClient: MockTxnHTTPClient!
+
+    override func setUp() {
+        super.setUp()
+        now = Date(timeIntervalSince1970: 1_000_000)
+        sessionManager = TxnSessionManager(clock: { self.now })
+        httpClient = MockTxnHTTPClient()
+    }
+
+    override func tearDown() {
+        now = nil
+        sessionManager = nil
+        httpClient = nil
+        super.tearDown()
+    }
+
+    private func makeService(environment: TxnEnvironment = .prod, maxRetries: Int = 3) -> TxnInitService {
+        TxnInitService(
+            environment: environment,
+            accountId: "account-1",
+            sdkVersion: "5.2.2",
+            layoutSchemaVersion: "2.3",
+            sessionManager: sessionManager,
+            httpClient: httpClient,
+            maxRetries: maxRetries,
+            baseBackoff: 0,
+            sleep: { _ in }
+        )
+    }
+
+    private func successJSON(token: String = "minted-jwt", expiresAt: Int64 = 2_000_000_000_000) -> Data {
+        Data(
+            """
+            {
+              "session_id": "sess-123",
+              "session_token": { "token": "\(token)", "expires_at": \(expiresAt) },
+              "feature_flags": {
+                "rokt-tracking-status": true,
+                "client-timeout-ms": 30000,
+                "mobile-sdk-use-bounding-box": false,
+                "minimum-post-purchase-schema": "2.3.0"
+              },
+              "fonts": []
+            }
+            """.utf8
+        )
+    }
+
+    func test_initSession_success_decodesAndStoresSession() async throws {
+        httpClient.results = [.success(data: successJSON())]
+        let result = try await makeService().initSession()
+
+        XCTAssertEqual(result.response.sessionId, "sess-123")
+        XCTAssertEqual(result.response.sessionToken.token, "minted-jwt")
+        XCTAssertEqual(sessionManager.currentSessionId, "sess-123")
+        XCTAssertEqual(sessionManager.authorizationHeader, "Bearer minted-jwt")
+        XCTAssertTrue(result.featureFlags.isEnabled(.roktTrackingStatus))
+        XCTAssertTrue(result.featureFlags.isEnabled(.minimumPostPurchaseSchema))
+        XCTAssertEqual(httpClient.capturedHeaders.count, 1)
+    }
+
+    func test_initSession_withValidStoredToken_sendsAuthorizationHeader() async throws {
+        let expiryMs = Int64(now.addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        sessionManager.update(sessionId: "existing", sessionToken: TxnSessionToken(token: "stored-jwt", expiresAt: expiryMs))
+        httpClient.results = [.success(data: successJSON())]
+
+        _ = try await makeService().initSession()
+
+        XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
+    }
+
+    func test_initSession_withoutToken_omitsAuthorizationHeader() async throws {
+        httpClient.results = [.success(data: successJSON())]
+
+        _ = try await makeService().initSession()
+
+        XCTAssertNil(httpClient.capturedHeaders.first?["Authorization"])
+    }
+
+    func test_initSession_retriesOnTransient500_thenSucceeds() async throws {
+        httpClient.results = [.status(500), .status(503), .success(data: successJSON())]
+
+        let result = try await makeService().initSession()
+
+        XCTAssertEqual(result.response.sessionId, "sess-123")
+        XCTAssertEqual(httpClient.callCount, 3)
+    }
+
+    func test_initSession_retriesOnTimeout_thenSucceeds() async throws {
+        httpClient.results = [.transport(NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)),
+                              .success(data: successJSON())]
+
+        let result = try await makeService().initSession()
+
+        XCTAssertEqual(result.response.sessionId, "sess-123")
+        XCTAssertEqual(httpClient.callCount, 2)
+    }
+
+    func test_initSession_exhaustsRetries_throwsUnexpectedStatus() async {
+        httpClient.results = [.status(503)]
+
+        do {
+            _ = try await makeService(maxRetries: 3).initSession()
+            XCTFail("Expected init to fail after exhausting retries")
+        } catch let error as TxnInitService.TxnInitError {
+            XCTAssertEqual(error, .unexpectedStatusCode(503))
+            XCTAssertEqual(httpClient.callCount, 4)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_initSession_nonRetryableStatus_doesNotRetry() async {
+        httpClient.results = [.status(400)]
+
+        do {
+            _ = try await makeService().initSession()
+            XCTFail("Expected init to fail on 400")
+        } catch let error as TxnInitService.TxnInitError {
+            XCTAssertEqual(error, .unexpectedStatusCode(400))
+            XCTAssertEqual(httpClient.callCount, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_initSession_offline_isNotRetried() async {
+        httpClient.results = [.transport(NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet))]
+
+        do {
+            _ = try await makeService().initSession()
+            XCTFail("Expected init to fail when offline")
+        } catch {
+            XCTAssertEqual(httpClient.callCount, 1)
+        }
+    }
+
+    func test_initSession_decodeError_propagatesWithoutRetry() async {
+        httpClient.results = [.success(data: Data("not json".utf8))]
+
+        do {
+            _ = try await makeService().initSession()
+            XCTFail("Expected decoding to fail")
+        } catch is DecodingError {
+            XCTAssertEqual(httpClient.callCount, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_initSession_invalidBaseURL_throws() async {
+        let service = makeService(environment: .custom(baseURL: "ht tp://bad url"))
+
+        do {
+            _ = try await service.initSession()
+            XCTFail("Expected invalid base URL to fail")
+        } catch let error as TxnInitService.TxnInitError {
+            XCTAssertEqual(error, .invalidBaseURL)
+            XCTAssertEqual(httpClient.callCount, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+private final class MockTxnHTTPClient: HTTPClientAdapter {
+    enum Response {
+        case success(data: Data)
+        case status(Int)
+        case transport(Error)
+    }
+
+    var results: [Response] = []
+    private(set) var callCount = 0
+    private(set) var capturedHeaders: [RoktHTTPHeaders] = []
+    private(set) var timeout: Double?
+
+    func updateTimeout(timeout: Double) {
+        self.timeout = timeout
+    }
+
+    @discardableResult
+    func startRequestWith(
+        urlAddress: String,
+        method: RoktHTTPMethod,
+        parameters: RoktHTTPParameters?,
+        parameterArray: RoktHTTPParameterArray?,
+        headers: RoktHTTPHeaders?,
+        onRequestStart: (() -> Void)?,
+        requestTimeout: TimeInterval?,
+        completionQueue: DispatchQueue,
+        completionHandler: ((RoktHTTPRequestResult) -> Void)?
+    ) -> URLRequest? {
+        capturedHeaders.append(headers ?? [:])
+        let response = results[min(callCount, results.count - 1)]
+        callCount += 1
+
+        let url = URL(string: urlAddress) ?? URL(string: "https://apps.rokt.com")!
+        let result: RoktHTTPRequestResult
+        switch response {
+        case .success(let data):
+            result = RoktHTTPRequestResult(
+                httpURLResponse: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil),
+                responseData: data,
+                responseError: nil,
+                jsonSerialisedResponseData: .success(NSNull())
+            )
+        case .status(let code):
+            result = RoktHTTPRequestResult(
+                httpURLResponse: HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil),
+                responseData: nil,
+                responseError: nil,
+                jsonSerialisedResponseData: .success(NSNull())
+            )
+        case .transport(let error):
+            result = RoktHTTPRequestResult(
+                httpURLResponse: nil,
+                responseData: nil,
+                responseError: error,
+                jsonSerialisedResponseData: .failure(error)
+            )
+        }
+
+        completionQueue.async { completionHandler?(result) }
+        return nil
+    }
+
+    func downloadFile(
+        source urlAddress: String,
+        destinationURL: URL,
+        options: [RoktDownloadOptions],
+        parameters: RoktHTTPParameters?,
+        headers: RoktHTTPHeaders?,
+        requestTimeout: TimeInterval?,
+        completionQueue: DispatchQueue,
+        completionHandler: ((RoktDownloadResult) -> Void)?
+    ) {}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Part of the v2 transactions init migration. PR1 added the dependency-free foundation (gateway config, response models, session store); this PR adds the coordinator that ties them together with the v2 sessions init client into one callable init flow. Everything stays net-new and un-wired — nothing in the live `Rokt.initialize()` path calls it yet.

Stacks on #185

## What Has Changed

- **`TxnInitService`** (net-new): resolves the gateway base URL from config, sends the init request, decodes the response, updates the session store, and returns the mapped feature flags.
- **Transient-failure retry**: exponential backoff with jitter (max 3 retries, 7s timeout) on timeouts/5xx/connection errors; fails fast on offline, 4xx, and decode errors — restoring the resilience the legacy path had.
- **Init client auth token is now optional**: a missing/expired token omits the `Authorization` header so the server mints a fresh session (matches the server contract; existing Pact spec stays green).

## How Has This Been Tested

- New `TestTxnInitService` (10 unit tests) on the iOS simulator — all green: success path (decode + store + header populated), `Authorization` header present-with-token / omitted-without, retry-then-succeed on 500 and timeout, retry exhaustion, non-retryable 400 / offline / decode error, and invalid base URL.
- `trunk check` clean on all changed files.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
