### PR TITLE
feat: Offer Retry on PayPal Cancel or Payment Failure

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -370,6 +370,11 @@ final class PaymentOrchestrator {
     /// backend webhook finalizes the purchase from the PayPal redirect; the SDK only needs
     /// to surface success/cancel/failure to the UXHelper.
     ///
+    /// If the buyer cancels the hosted step (Safari dismissed or cancel deep link), the SDK
+    /// does **not** invoke `onCompletion` or the deferred Step-1 `completion`; it re-queues the
+    /// same pending checkout so the confirmation UI can stay up and ``presentPendingBuiltInPayPalForForwardPayment``
+    /// can run again.
+    ///
     /// - Parameter onCompletion: called on the main queue with the coordinator outcome.
     /// - Returns: `true` when a pending PayPal checkout existed and was presented; `false`
     ///   when the caller should fall through to the non-PayPal `/v1/cart/purchase` flow.
@@ -410,6 +415,18 @@ final class PaymentOrchestrator {
                 cancelURLString: snapshot.cancelURLString,
                 completion: { [weak self] result in
                     self?.activePayPalCheckout = nil
+                    if result.outcome == .canceled {
+                        if let self {
+                            Self.requeuePendingBuiltInPayPalAfterForwardPaymentCancel(
+                                snapshot: snapshot,
+                                owner: self
+                            )
+                        } else {
+                            snapshot.completion(result)
+                            onCompletion(result)
+                        }
+                        return
+                    }
                     snapshot.completion(result)
                     onCompletion(result)
                 }
@@ -422,6 +439,23 @@ final class PaymentOrchestrator {
             )
         }
         return true
+    }
+
+    private static func requeuePendingBuiltInPayPalAfterForwardPaymentCancel(
+        snapshot: PendingBuiltInPayPalWebCheckout,
+        owner: PaymentOrchestrator
+    ) {
+        let restored = PendingBuiltInPayPalWebCheckout(
+            owner: owner,
+            approvalURL: snapshot.approvalURL,
+            returnURLString: snapshot.returnURLString,
+            cancelURLString: snapshot.cancelURLString,
+            presentingViewController: snapshot.presentingViewController,
+            completion: snapshot.completion
+        )
+        pendingBuiltInTwoStepLock.lock()
+        pendingBuiltInTwoStepCheckout = .paypal(restored)
+        pendingBuiltInTwoStepLock.unlock()
     }
 
     /// Called when forward-payment fails or cannot run, so a deferred two-step session does not leak.

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -95,8 +95,11 @@ final class MockPayPalApprovalPresenter: PayPalApprovalPresenting {
     ) {
         presentCallCount += 1
         lastApprovalURL = approvalURL
+        // Capture when the presenter is called so later changes to `sheetResult` (e.g. a retry
+        // test switching to `.succeeded`) cannot affect an already-scheduled completion.
+        let resultToDeliver = sheetResult
         DispatchQueue.main.async {
-            checkoutCoordinator.completeFromUserDismissal(self.sheetResult)
+            checkoutCoordinator.completeFromUserDismissal(resultToDeliver)
         }
     }
 }
@@ -650,6 +653,67 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchaseCancelURL, "myapp://paypal/cancel")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentMethodType, "Paypal")
         XCTAssertEqual(PaymentOrchestratorAPIHelperSpy.lastInitializePurchasePaymentProvider, "PayPal")
+    }
+
+    func test_presentPendingBuiltInPayPal_canceledRestoresPendingAndDefersStep1Completion() {
+        let payPalPresenter = MockPayPalApprovalPresenter()
+        payPalPresenter.sheetResult = .canceled
+        sut = PaymentOrchestrator(
+            apiHelper: PaymentOrchestratorAPIHelperSpy.self,
+            payPalApprovalPresenter: payPalPresenter
+        )
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validPayPalInitializePurchaseResponse()
+
+        // ``PendingBuiltInPayPalWebCheckout/presentingViewController`` is weak; keep a strong ref
+        // so ``presentPendingBuiltInPayPalForForwardPayment`` does not fall through to the
+        // no-view-controller failure path before the mock can run.
+        let presentingViewController = UIViewController()
+
+        var step1Result: PaymentSheetResult?
+        let billing = ContactAddress(name: "Bo", email: "b@o.com")
+        sut.processPayment(
+            method: .paypal,
+            item: PaymentItem(id: "p1", name: "P", amount: 1, currency: "USD"),
+            context: PaymentContext(
+                billingAddress: billing,
+                returnURL: "myapp://paypal/success",
+                cancelURL: "myapp://paypal/cancel"
+            ),
+            cartItemId: "v1:cart:1",
+            from: presentingViewController,
+            builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
+        ) { result in
+            step1Result = result
+        }
+
+        XCTAssertTrue(sut.presentPendingBuiltInPayPalForForwardPayment { _ in
+            XCTFail("onCompletion must not run when hosted PayPal approval is canceled")
+        })
+
+        // ``presentPendingBuiltInPayPalForForwardPayment`` pops pending synchronously; the mock
+        // presenter and ``PayPalCheckoutCoordinator`` each hop to the main queue before the
+        // cancel path re-queues. One extra async is not enough — drain several turns so requeue
+        // finishes before we assert or call ``presentPending`` again.
+        for _ in 0..<8 {
+            let flush = expectation(description: "main queue flush")
+            DispatchQueue.main.async { flush.fulfill() }
+            wait(for: [flush], timeout: 1.0)
+        }
+        XCTAssertNil(step1Result, "Deferred Step-1 completion must not run on hosted cancel")
+
+        payPalPresenter.sheetResult = .succeeded(transactionId: "retry_ok")
+        var forwardObserverResult: PaymentSheetResult?
+        XCTAssertTrue(sut.presentPendingBuiltInPayPalForForwardPayment { result in
+            forwardObserverResult = result
+        })
+        for _ in 0..<8 {
+            let flush = expectation(description: "main queue flush after success")
+            DispatchQueue.main.async { flush.fulfill() }
+            wait(for: [flush], timeout: 1.0)
+        }
+        XCTAssertEqual(step1Result?.outcome, .succeeded)
+        XCTAssertEqual(step1Result?.transactionId, "retry_ok")
+        XCTAssertEqual(forwardObserverResult?.outcome, .succeeded)
     }
 
     func test_processPayment_payPal_ignoresRegisteredExtensionSupportingPayPal() {


### PR DESCRIPTION
## Background

Built-in PayPal for device pay / shoppable flows opens the processor approval URL in SFSafariViewController. When the buyer left that step without completing approval (Safari dismissed or cancel redirect), the SDK treated it like a finished checkout: it invoked the deferred processPayment completion and the forward-payment completion path, which drove devicePayFinalized and forwardPaymentFinalized with failure semantics. That tore down the confirmation UI and cleared instant-purchase state even though the user had only backed out of the browser step. The pending PayPal checkout snapshot was also consumed on the first forward-payment presentation, so a second tap could not reopen the same hosted approval without starting over.

## What Has Changed

This change keeps the forward-payment confirmation experience usable after a hosted cancel: on .canceled we do not notify UX finalization for that attempt, do not fire the deferred Step-1 completion, and re-queue the same pending PayPal snapshot so the confirm action can launch approval again. Success and real orchestration failures are unchanged.

## How Has This Been Tested

Tested on simulator with spoofed API resposne

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
