### PR TITLE
feat: Add Card Forwarding Retry Support

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/BuiltInCardForwardingPurchaseCoordinator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/BuiltInCardForwardingPurchaseCoordinator.swift
@@ -1,0 +1,195 @@
+import Foundation
+import RoktContracts
+internal import RoktUXHelper
+
+/// Runs built-in card forwarding after device-pay confirm: begin session, POST `/v1/cart/purchase`,
+/// apply card forwarding retry policy, and notify the host for loading / UX finalization.
+final class BuiltInCardForwardingPurchaseCoordinator {
+    private let paymentOrchestrator: PaymentOrchestrator
+    private let unknownFailureReason: String
+    private let missingPriceFailureReason: String
+    private let resolveCartPurchaseFinalization: (PurchaseResponse) -> (success: Bool, failureReason: String?)
+    private let resolveTransportFailureFinalization: (String) -> (success: Bool, failureReason: String?)
+    private let emitRoktEvent: (String, RoktEvent?) -> Void
+    private let finalizeForwardPayment: (String, String, String, Bool, String?) -> Void
+
+    init(
+        paymentOrchestrator: PaymentOrchestrator,
+        unknownFailureReason: String,
+        missingPriceFailureReason: String,
+        resolveCartPurchaseFinalization: @escaping (PurchaseResponse) -> (success: Bool, failureReason: String?),
+        resolveTransportFailureFinalization: @escaping (String) -> (success: Bool, failureReason: String?),
+        emitRoktEvent: @escaping (String, RoktEvent?) -> Void,
+        finalizeForwardPayment: @escaping (String, String, String, Bool, String?) -> Void
+    ) {
+        self.paymentOrchestrator = paymentOrchestrator
+        self.unknownFailureReason = unknownFailureReason
+        self.missingPriceFailureReason = missingPriceFailureReason
+        self.resolveCartPurchaseFinalization = resolveCartPurchaseFinalization
+        self.resolveTransportFailureFinalization = resolveTransportFailureFinalization
+        self.emitRoktEvent = emitRoktEvent
+        self.finalizeForwardPayment = finalizeForwardPayment
+    }
+
+    /// Runs the forward-payment cart purchase (`/v1/cart/purchase`) for card forwarding:
+    /// in-flight guard, request build, API call, retry handling, and host callbacks.
+    func performCardForwardingCartPurchase(
+        executeId: String,
+        event: RoktUXEvent.CartItemForwardPayment
+    ) {
+        if paymentOrchestrator.isBuiltInCardForwardPaymentInFlight() {
+            RoktLogger.shared.warning(
+                "Card forwarding ignored while a cart purchase request is already in flight."
+            )
+            return
+        }
+
+        let cardStepOneCompletion = paymentOrchestrator.beginBuiltInCardForwardPaymentIfReady()
+        let cardForwardingFlowActive = cardStepOneCompletion != nil
+
+        let fulfillmentDetails = event.transactionData?.shippingAddress.map {
+            FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
+        }
+        guard let request = RoktInternalImplementation.buildForwardPaymentRequest(
+            from: event,
+            fulfillmentDetails: fulfillmentDetails
+        ) else {
+            RoktLogger.shared.warning(
+                "Card forwarding cart purchase skipped: forward-payment event missing price or has non-positive quantity"
+            )
+            if cardForwardingFlowActive {
+                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                    result: .failed(error: missingPriceFailureReason)
+                )
+            }
+            paymentOrchestrator.cancelPendingBuiltInTwoStepIfNeeded()
+            finalizeForwardPayment(
+                executeId,
+                event.layoutId,
+                event.catalogItemId,
+                false,
+                missingPriceFailureReason
+            )
+            return
+        }
+
+        emitRoktEvent(executeId, RoktEvent.ShowLoadingIndicator())
+
+        RoktAPIHelper.forwardPayment(
+            request: request,
+            success: { response in
+                self.emitRoktEvent(executeId, RoktEvent.HideLoadingIndicator())
+                let finalization = self.resolveCartPurchaseFinalization(response)
+                self.handleCartPurchaseHTTP200Response(
+                    cardForwardingFlowActive: cardForwardingFlowActive,
+                    finalization: finalization,
+                    executeId: executeId,
+                    event: event,
+                    cardStepOneCompletion: cardStepOneCompletion
+                )
+            },
+            failure: { error, statusCode, message in
+                self.emitRoktEvent(executeId, RoktEvent.HideLoadingIndicator())
+                self.handleCartPurchaseTransportFailure(
+                    cardForwardingFlowActive: cardForwardingFlowActive,
+                    error: error,
+                    statusCode: statusCode,
+                    message: message,
+                    executeId: executeId,
+                    event: event,
+                    cardStepOneCompletion: cardStepOneCompletion
+                )
+            }
+        )
+    }
+
+    private func handleCartPurchaseHTTP200Response(
+        cardForwardingFlowActive: Bool,
+        finalization: (success: Bool, failureReason: String?),
+        executeId: String,
+        event: RoktUXEvent.CartItemForwardPayment,
+        cardStepOneCompletion: ((PaymentSheetResult) -> Void)?
+    ) {
+        if cardForwardingFlowActive {
+            if finalization.success {
+                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                    result: .succeeded(transactionId: "")
+                )
+                finalizeForwardPayment(
+                    executeId,
+                    event.layoutId,
+                    event.catalogItemId,
+                    true,
+                    nil
+                )
+            } else if CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: finalization.failureReason) {
+                paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
+            } else {
+                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                    result: .failed(error: finalization.failureReason ?? unknownFailureReason)
+                )
+                finalizeForwardPayment(
+                    executeId,
+                    event.layoutId,
+                    event.catalogItemId,
+                    false,
+                    finalization.failureReason
+                )
+            }
+        } else {
+            if finalization.success {
+                cardStepOneCompletion?(.succeeded(transactionId: ""))
+            } else {
+                cardStepOneCompletion?(
+                    .failed(error: finalization.failureReason ?? unknownFailureReason)
+                )
+            }
+            finalizeForwardPayment(
+                executeId,
+                event.layoutId,
+                event.catalogItemId,
+                finalization.success,
+                finalization.failureReason
+            )
+        }
+    }
+
+    private func handleCartPurchaseTransportFailure(
+        cardForwardingFlowActive: Bool,
+        error: Error,
+        statusCode: Int?,
+        message: String,
+        executeId: String,
+        event: RoktUXEvent.CartItemForwardPayment,
+        cardStepOneCompletion: ((PaymentSheetResult) -> Void)?
+    ) {
+        let finalization = resolveTransportFailureFinalization(message)
+        if cardForwardingFlowActive {
+            if CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: error, statusCode: statusCode) {
+                paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
+            } else {
+                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                    result: .failed(error: finalization.failureReason ?? unknownFailureReason)
+                )
+                finalizeForwardPayment(
+                    executeId,
+                    event.layoutId,
+                    event.catalogItemId,
+                    false,
+                    finalization.failureReason
+                )
+            }
+        } else {
+            cardStepOneCompletion?(
+                .failed(error: finalization.failureReason ?? unknownFailureReason)
+            )
+            finalizeForwardPayment(
+                executeId,
+                event.layoutId,
+                event.catalogItemId,
+                false,
+                finalization.failureReason
+            )
+        }
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/CardForwardingRetryRules.swift
+++ b/Sources/Rokt_Widget/Models/Payment/CardForwardingRetryRules.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Client-side retry hints for built-in card forwarding (`/v1/cart/purchase`).
+enum CardForwardingRetryRules {
+    /// HTTP 200 with `PurchaseResponse.success == false` — conservative substring hints for card forwarding retry.
+    static func isCardForwardingErrorRetryable(failureReason: String?) -> Bool {
+        let normalized = failureReason?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        if normalized.isEmpty { return false }
+        let hints = [
+            "timeout",
+            "timed out",
+            "try again",
+            "temporarily unavailable",
+            "service unavailable",
+            "too many requests",
+            "throttle",
+            "unavailable"
+        ]
+        return hints.contains { normalized.contains($0) }
+    }
+
+    /// Transport / HTTP failures where card forwarding may succeed on retry.
+    static func isRetryableCardForwardingTransportFailure(error: Error, statusCode: Int?) -> Bool {
+        if let code = statusCode {
+            if (500...599).contains(code) { return true }
+            if code == 408 || code == 429 { return true }
+            return false
+        }
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorTimedOut,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorNotConnectedToInternet,
+             NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorDNSLookupFailed:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -79,7 +79,10 @@ final class PaymentOrchestrator {
 
     private enum PendingBuiltInTwoStepCheckout {
         case paypal(PendingBuiltInPayPalWebCheckout)
+        /// Card confirm is shown; buyer has not yet started `/v1/cart/purchase` for this session.
         case card(PendingBuiltInCardCheckout)
+        /// Built-in card forward POST is in flight; same snapshot as ``card`` until terminal or retryable restore.
+        case cardInFlight(PendingBuiltInCardCheckout)
     }
 
     private static var pendingBuiltInTwoStepCheckout: PendingBuiltInTwoStepCheckout?
@@ -383,7 +386,7 @@ final class PaymentOrchestrator {
         onCompletion: @escaping (PaymentSheetResult) -> Void
     ) -> Bool {
         Self.pendingBuiltInTwoStepLock.lock()
-        // Only consume PayPal entries; leave a card entry intact for ``popPendingBuiltInCardCompletion``.
+        // Only consume PayPal entries; leave built-in card entries (``card`` / ``cardInFlight``) intact.
         guard case let .paypal(snapshot) = Self.pendingBuiltInTwoStepCheckout,
               snapshot.owner === self
         else {
@@ -470,7 +473,7 @@ final class PaymentOrchestrator {
             switch snapshot {
             case .paypal(let pending):
                 pending.completion(.failed(error: "PayPal checkout was canceled."))
-            case .card(let pending):
+            case .card(let pending), .cardInFlight(let pending):
                 pending.completion(.failed(error: "Card checkout was canceled."))
             }
         }
@@ -519,16 +522,13 @@ final class PaymentOrchestrator {
         }
     }
 
-    /// Card-only forward-payment hook: pop the cached Step-1 completion so the caller can
-    /// fire it after `/v1/cart/purchase` resolves.
+    /// Begins a built-in card forward-payment attempt: moves ``card`` → ``cardInFlight`` and returns
+    /// the Step-1 completion to invoke only after a **terminal** `/v1/cart/purchase` outcome.
     ///
-    /// Card has no orchestrator-driven Step-2 (no WebView). ``handleForwardPayment`` runs the
-    /// standard `/v1/cart/purchase` path; this method just hands back the deferred completion
-    /// so device-pay finalization can chain off the same response.
-    ///
-    /// - Returns: the cached completion when the pending checkout was a card flow owned by
-    ///   this orchestrator; `nil` otherwise (so PayPal entries are left intact).
-    func popPendingBuiltInCardCompletion() -> ((PaymentSheetResult) -> Void)? {
+    /// - Returns: the deferred Step-1 completion when state was ``card`` for this orchestrator;
+    ///   `nil` if there is no card session, PayPal is cached instead, or a card attempt is already
+    ///   ``cardInFlight`` for this owner (avoid duplicate POSTs).
+    func beginBuiltInCardForwardPaymentIfReady() -> ((PaymentSheetResult) -> Void)? {
         Self.pendingBuiltInTwoStepLock.lock()
         defer { Self.pendingBuiltInTwoStepLock.unlock() }
         guard case let .card(snapshot) = Self.pendingBuiltInTwoStepCheckout,
@@ -536,8 +536,48 @@ final class PaymentOrchestrator {
         else {
             return nil
         }
-        Self.pendingBuiltInTwoStepCheckout = nil
+        Self.pendingBuiltInTwoStepCheckout = .cardInFlight(snapshot)
         return snapshot.completion
+    }
+
+    /// `true` when built-in card forward-payment has begun (``cardInFlight``) for this orchestrator.
+    func isBuiltInCardForwardPaymentInFlight() -> Bool {
+        Self.pendingBuiltInTwoStepLock.lock()
+        defer { Self.pendingBuiltInTwoStepLock.unlock() }
+        guard case let .cardInFlight(snapshot) = Self.pendingBuiltInTwoStepCheckout else {
+            return false
+        }
+        return snapshot.owner === self
+    }
+
+    /// After a **retryable** `/v1/cart/purchase` failure, move ``cardInFlight`` back to ``card`` so the
+    /// buyer can tap confirm again without re-running Step-1 ``initializePurchase``.
+    func restoreBuiltInCardForwardPaymentAfterRetryableFailure() {
+        Self.pendingBuiltInTwoStepLock.lock()
+        defer { Self.pendingBuiltInTwoStepLock.unlock() }
+        guard case let .cardInFlight(snapshot) = Self.pendingBuiltInTwoStepCheckout,
+              snapshot.owner === self
+        else {
+            return
+        }
+        Self.pendingBuiltInTwoStepCheckout = .card(snapshot)
+    }
+
+    /// Ends a built-in card forward attempt: clears ``cardInFlight`` and delivers ``result`` to the
+    /// Step-1 ``processPayment`` completion on the main queue.
+    func finishBuiltInCardForwardPaymentAttempt(result: PaymentSheetResult) {
+        var completion: ((PaymentSheetResult) -> Void)?
+        Self.pendingBuiltInTwoStepLock.lock()
+        if case let .cardInFlight(snapshot) = Self.pendingBuiltInTwoStepCheckout,
+           snapshot.owner === self {
+            completion = snapshot.completion
+            Self.pendingBuiltInTwoStepCheckout = nil
+        }
+        Self.pendingBuiltInTwoStepLock.unlock()
+        guard let completion else { return }
+        DispatchQueue.main.async {
+            completion(result)
+        }
     }
 
     // Clears static deferred state without invoking a completion (unit tests).

--- a/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
+++ b/Sources/Rokt_Widget/Models/Payment/PaymentOrchestrator.swift
@@ -69,9 +69,9 @@ final class PaymentOrchestrator {
         let completion: (PaymentSheetResult) -> Void
     }
 
-    /// Card Step-1 cache: just the deferred completion. Step-2 dispatch lives in
-    /// ``RoktInternalImplementation.handleForwardPayment`` (POST `/v1/cart/purchase`); the
-    /// orchestrator only holds the completion so it can fire alongside ``forwardPaymentFinalized``.
+    /// Card Step-1 cache: just the deferred completion. Card forwarding Step-2 (POST `/v1/cart/purchase`)
+    /// runs in ``BuiltInCardForwardingPurchaseCoordinator`` via ``RoktInternalImplementation.handleForwardPayment``;
+    /// the orchestrator only holds the completion so it can fire alongside ``forwardPaymentFinalized``.
     private struct PendingBuiltInCardCheckout {
         weak var owner: PaymentOrchestrator?
         let completion: (PaymentSheetResult) -> Void
@@ -81,7 +81,7 @@ final class PaymentOrchestrator {
         case paypal(PendingBuiltInPayPalWebCheckout)
         /// Card confirm is shown; buyer has not yet started `/v1/cart/purchase` for this session.
         case card(PendingBuiltInCardCheckout)
-        /// Built-in card forward POST is in flight; same snapshot as ``card`` until terminal or retryable restore.
+        /// Card forwarding cart purchase POST is in flight; same snapshot as ``card`` until terminal or retryable restore.
         case cardInFlight(PendingBuiltInCardCheckout)
     }
 
@@ -481,13 +481,13 @@ final class PaymentOrchestrator {
 
     // MARK: - Built-in Card forwarding (no PaymentExtension)
 
-    /// Entry point for Card device-pay (Step-1 of the two-step Card forward-payment flow).
+    /// Entry point for Card device-pay (Step-1 of the two-step card forwarding flow).
     ///
     /// Runs the same cart ``initializePurchase`` preparation as PayPal but without return/cancel URLs
     /// (no hosted approval step). Passes `paymentMethodType` / `paymentProvider` as `Card` / `Card`.
     /// After cart prepare, triggers ``RoktUX/devicePayShowConfirmation`` so the layout transitions
     /// to the Step-2 confirm button, and caches `completion` so it can fire alongside
-    /// ``forwardPaymentFinalized`` once ``handleForwardPayment`` posts to `/v1/cart/purchase`.
+    /// ``forwardPaymentFinalized`` once card forwarding completes in ``handleForwardPayment``.
     private func processBuiltInCardPayment(
         item: PaymentItem,
         context: PaymentContext,
@@ -522,7 +522,7 @@ final class PaymentOrchestrator {
         }
     }
 
-    /// Begins a built-in card forward-payment attempt: moves ``card`` → ``cardInFlight`` and returns
+    /// Begins a built-in card forwarding cart purchase attempt: moves ``card`` → ``cardInFlight`` and returns
     /// the Step-1 completion to invoke only after a **terminal** `/v1/cart/purchase` outcome.
     ///
     /// - Returns: the deferred Step-1 completion when state was ``card`` for this orchestrator;
@@ -540,7 +540,7 @@ final class PaymentOrchestrator {
         return snapshot.completion
     }
 
-    /// `true` when built-in card forward-payment has begun (``cardInFlight``) for this orchestrator.
+    /// `true` when built-in card forwarding has begun (``cardInFlight``) for this orchestrator.
     func isBuiltInCardForwardPaymentInFlight() -> Bool {
         Self.pendingBuiltInTwoStepLock.lock()
         defer { Self.pendingBuiltInTwoStepLock.unlock() }
@@ -550,7 +550,7 @@ final class PaymentOrchestrator {
         return snapshot.owner === self
     }
 
-    /// After a **retryable** `/v1/cart/purchase` failure, move ``cardInFlight`` back to ``card`` so the
+    /// After a retryable card forwarding `/v1/cart/purchase` failure, move ``cardInFlight`` back to ``card`` so the
     /// buyer can tap confirm again without re-running Step-1 ``initializePurchase``.
     func restoreBuiltInCardForwardPaymentAfterRetryableFailure() {
         Self.pendingBuiltInTwoStepLock.lock()
@@ -563,7 +563,7 @@ final class PaymentOrchestrator {
         Self.pendingBuiltInTwoStepCheckout = .card(snapshot)
     }
 
-    /// Ends a built-in card forward attempt: clears ``cardInFlight`` and delivers ``result`` to the
+    /// Ends a built-in card forwarding attempt: clears ``cardInFlight`` and delivers ``result`` to the
     /// Step-1 ``processPayment`` completion on the main queue.
     func finishBuiltInCardForwardPaymentAttempt(result: PaymentSheetResult) {
         var completion: ((PaymentSheetResult) -> Void)?
@@ -586,6 +586,17 @@ final class PaymentOrchestrator {
         pendingBuiltInTwoStepLock.lock()
         pendingBuiltInTwoStepCheckout = nil
         pendingBuiltInTwoStepLock.unlock()
+    }
+
+    // Unit test hook: installs deferred built-in card Step-1 without calling `initializePurchase`.
+    // Use the same `PaymentOrchestrator` instance as production when exercising `handleForwardPayment`
+    // together with `beginBuiltInCardForwardPaymentIfReady`.
+    // periphery:ignore
+    internal func unitTest_seedDeferredBuiltInCardForwardPayment(completion: @escaping (PaymentSheetResult) -> Void) {
+        let pending = PendingBuiltInCardCheckout(owner: self, completion: completion)
+        Self.pendingBuiltInTwoStepLock.lock()
+        Self.pendingBuiltInTwoStepCheckout = .card(pending)
+        Self.pendingBuiltInTwoStepLock.unlock()
     }
 
     private static func clearPendingBuiltInTwoStepStateUnderLock() {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -682,6 +682,48 @@ class RoktInternalImplementation {
         return (false, failureReason)
     }
 
+    /// Conservative client-side policy for when the buyer may retry built-in card forward-payment
+    /// without leaving the confirm step (HTTP 200 with ``PurchaseResponse/success`` == `false`).
+    private static func isRetryableForwardPaymentBusinessFailure(failureReason: String?) -> Bool {
+        let normalized = failureReason?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        if normalized.isEmpty { return false }
+        let hints = [
+            "timeout",
+            "timed out",
+            "try again",
+            "temporarily unavailable",
+            "service unavailable",
+            "too many requests",
+            "throttle",
+            "unavailable"
+        ]
+        return hints.contains { normalized.contains($0) }
+    }
+
+    /// Conservative client-side policy for transport failures where a retry may succeed.
+    private static func isRetryableForwardPaymentTransportFailure(error: Error, statusCode: Int?) -> Bool {
+        if let code = statusCode {
+            if (500...599).contains(code) { return true }
+            if code == 408 || code == 429 { return true }
+            return false
+        }
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorTimedOut,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorNotConnectedToInternet,
+             NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorDNSLookupFailed:
+            return true
+        default:
+            return false
+        }
+    }
+
     func handleForwardPayment(executeId: String,
                               event: RoktUXEvent.CartItemForwardPayment) {
         let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment { [weak self] result in
@@ -725,9 +767,15 @@ class RoktInternalImplementation {
             return
         }
 
-        // Built-in card forwarding caches its Step-1 completion in PaymentOrchestrator;
-        // pop it here so device-pay finalization can chain off the same `/v1/cart/purchase` outcome.
-        let cardStepOneCompletion = paymentOrchestrator.popPendingBuiltInCardCompletion()
+        if paymentOrchestrator.isBuiltInCardForwardPaymentInFlight() {
+            RoktLogger.shared.warning(
+                "Built-in card forward-payment ignored while a purchase request is already in flight."
+            )
+            return
+        }
+
+        let cardStepOneCompletion = paymentOrchestrator.beginBuiltInCardForwardPaymentIfReady()
+        let builtInCardForwardFlowActive = cardStepOneCompletion != nil
 
         let fulfillmentDetails = event.transactionData?.shippingAddress.map {
             FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
@@ -739,8 +787,12 @@ class RoktInternalImplementation {
             RoktLogger.shared.warning(
                 "Forward-payment event missing price or has non-positive quantity"
             )
+            if builtInCardForwardFlowActive {
+                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                    result: .failed(error: Self.missingForwardPaymentPriceReason)
+                )
+            }
             paymentOrchestrator.cancelPendingBuiltInTwoStepIfNeeded()
-            cardStepOneCompletion?(.failed(error: Self.missingForwardPaymentPriceReason))
             forwardPaymentFinalized(
                 executeId: executeId,
                 layoutId: event.layoutId,
@@ -759,33 +811,84 @@ class RoktInternalImplementation {
                 guard let self else { return }
                 self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(from: response)
-                if finalization.success {
-                    cardStepOneCompletion?(.succeeded(transactionId: ""))
+                if builtInCardForwardFlowActive {
+                    if finalization.success {
+                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                            result: .succeeded(transactionId: "")
+                        )
+                        self.forwardPaymentFinalized(
+                            executeId: executeId,
+                            layoutId: event.layoutId,
+                            catalogItemId: event.catalogItemId,
+                            success: true,
+                            failureReason: nil
+                        )
+                    } else if Self.isRetryableForwardPaymentBusinessFailure(
+                        failureReason: finalization.failureReason
+                    ) {
+                        self.paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
+                    } else {
+                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                            result: .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
+                        )
+                        self.forwardPaymentFinalized(
+                            executeId: executeId,
+                            layoutId: event.layoutId,
+                            catalogItemId: event.catalogItemId,
+                            success: false,
+                            failureReason: finalization.failureReason
+                        )
+                    }
                 } else {
-                    cardStepOneCompletion?(.failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason))
+                    if finalization.success {
+                        cardStepOneCompletion?(.succeeded(transactionId: ""))
+                    } else {
+                        cardStepOneCompletion?(
+                            .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
+                        )
+                    }
+                    self.forwardPaymentFinalized(
+                        executeId: executeId,
+                        layoutId: event.layoutId,
+                        catalogItemId: event.catalogItemId,
+                        success: finalization.success,
+                        failureReason: finalization.failureReason
+                    )
                 }
-                self.forwardPaymentFinalized(
-                    executeId: executeId,
-                    layoutId: event.layoutId,
-                    catalogItemId: event.catalogItemId,
-                    success: finalization.success,
-                    failureReason: finalization.failureReason
-                )
             },
-            failure: { [weak self] _, _, message in
+            failure: { [weak self] error, statusCode, message in
                 guard let self else { return }
                 self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
                 let finalization = Self.resolveForwardPaymentFinalization(
                     fromFailureMessage: message
                 )
-                cardStepOneCompletion?(.failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason))
-                self.forwardPaymentFinalized(
-                    executeId: executeId,
-                    layoutId: event.layoutId,
-                    catalogItemId: event.catalogItemId,
-                    success: finalization.success,
-                    failureReason: finalization.failureReason
-                )
+                if builtInCardForwardFlowActive {
+                    if Self.isRetryableForwardPaymentTransportFailure(error: error, statusCode: statusCode) {
+                        self.paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
+                    } else {
+                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
+                            result: .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
+                        )
+                        self.forwardPaymentFinalized(
+                            executeId: executeId,
+                            layoutId: event.layoutId,
+                            catalogItemId: event.catalogItemId,
+                            success: false,
+                            failureReason: finalization.failureReason
+                        )
+                    }
+                } else {
+                    cardStepOneCompletion?(
+                        .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
+                    )
+                    self.forwardPaymentFinalized(
+                        executeId: executeId,
+                        layoutId: event.layoutId,
+                        catalogItemId: event.catalogItemId,
+                        success: false,
+                        failureReason: finalization.failureReason
+                    )
+                }
             }
         )
     }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import AppTrackingTransparency
+import RoktContracts
 internal import RoktUXHelper
 
 class RoktInternalImplementation {
@@ -73,6 +74,10 @@ class RoktInternalImplementation {
 
     // Payment orchestrator for Shoppable Ads
     private lazy var paymentOrchestrator = PaymentOrchestrator()
+
+    // Exposes `PaymentOrchestrator` for unit tests that exercise built-in card forwarding.
+    // periphery:ignore
+    internal var paymentOrchestratorForTesting: PaymentOrchestrator { paymentOrchestrator }
 
     /// Bare URL scheme (no `://`) for built-in PayPal device-pay redirects: `\(scheme)://rokt-paypal-return` / `rokt-paypal-cancel`.
     /// Set via ``Rokt/setBuiltInPayPalRedirectURLScheme(_:)`` before PayPal device pay; required for that flow.
@@ -682,48 +687,6 @@ class RoktInternalImplementation {
         return (false, failureReason)
     }
 
-    /// Conservative client-side policy for when the buyer may retry built-in card forward-payment
-    /// without leaving the confirm step (HTTP 200 with ``PurchaseResponse/success`` == `false`).
-    private static func isRetryableForwardPaymentBusinessFailure(failureReason: String?) -> Bool {
-        let normalized = failureReason?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() ?? ""
-        if normalized.isEmpty { return false }
-        let hints = [
-            "timeout",
-            "timed out",
-            "try again",
-            "temporarily unavailable",
-            "service unavailable",
-            "too many requests",
-            "throttle",
-            "unavailable"
-        ]
-        return hints.contains { normalized.contains($0) }
-    }
-
-    /// Conservative client-side policy for transport failures where a retry may succeed.
-    private static func isRetryableForwardPaymentTransportFailure(error: Error, statusCode: Int?) -> Bool {
-        if let code = statusCode {
-            if (500...599).contains(code) { return true }
-            if code == 408 || code == 429 { return true }
-            return false
-        }
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorNotConnectedToInternet,
-             NSURLErrorCannotFindHost,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
-    }
-
     func handleForwardPayment(executeId: String,
                               event: RoktUXEvent.CartItemForwardPayment) {
         let presentedPayPal = paymentOrchestrator.presentPendingBuiltInPayPalForForwardPayment { [weak self] result in
@@ -767,129 +730,29 @@ class RoktInternalImplementation {
             return
         }
 
-        if paymentOrchestrator.isBuiltInCardForwardPaymentInFlight() {
-            RoktLogger.shared.warning(
-                "Built-in card forward-payment ignored while a purchase request is already in flight."
-            )
-            return
-        }
-
-        let cardStepOneCompletion = paymentOrchestrator.beginBuiltInCardForwardPaymentIfReady()
-        let builtInCardForwardFlowActive = cardStepOneCompletion != nil
-
-        let fulfillmentDetails = event.transactionData?.shippingAddress.map {
-            FulfillmentDetails(shippingAttributes: ShippingAttributes(from: $0))
-        }
-        guard let request = Self.buildForwardPaymentRequest(
-            from: event,
-            fulfillmentDetails: fulfillmentDetails
-        ) else {
-            RoktLogger.shared.warning(
-                "Forward-payment event missing price or has non-positive quantity"
-            )
-            if builtInCardForwardFlowActive {
-                paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
-                    result: .failed(error: Self.missingForwardPaymentPriceReason)
-                )
-            }
-            paymentOrchestrator.cancelPendingBuiltInTwoStepIfNeeded()
-            forwardPaymentFinalized(
-                executeId: executeId,
-                layoutId: event.layoutId,
-                catalogItemId: event.catalogItemId,
-                success: false,
-                failureReason: Self.missingForwardPaymentPriceReason
-            )
-            return
-        }
-
-        callOnRoktEvent(executeId, event: RoktEvent.ShowLoadingIndicator())
-
-        RoktAPIHelper.forwardPayment(
-            request: request,
-            success: { [weak self] response in
-                guard let self else { return }
-                self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
-                let finalization = Self.resolveForwardPaymentFinalization(from: response)
-                if builtInCardForwardFlowActive {
-                    if finalization.success {
-                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
-                            result: .succeeded(transactionId: "")
-                        )
-                        self.forwardPaymentFinalized(
-                            executeId: executeId,
-                            layoutId: event.layoutId,
-                            catalogItemId: event.catalogItemId,
-                            success: true,
-                            failureReason: nil
-                        )
-                    } else if Self.isRetryableForwardPaymentBusinessFailure(
-                        failureReason: finalization.failureReason
-                    ) {
-                        self.paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
-                    } else {
-                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
-                            result: .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
-                        )
-                        self.forwardPaymentFinalized(
-                            executeId: executeId,
-                            layoutId: event.layoutId,
-                            catalogItemId: event.catalogItemId,
-                            success: false,
-                            failureReason: finalization.failureReason
-                        )
-                    }
-                } else {
-                    if finalization.success {
-                        cardStepOneCompletion?(.succeeded(transactionId: ""))
-                    } else {
-                        cardStepOneCompletion?(
-                            .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
-                        )
-                    }
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: finalization.success,
-                        failureReason: finalization.failureReason
-                    )
-                }
+        let cardForwardingPurchase = BuiltInCardForwardingPurchaseCoordinator(
+            paymentOrchestrator: paymentOrchestrator,
+            unknownFailureReason: Self.unknownForwardPaymentFailureReason,
+            missingPriceFailureReason: Self.missingForwardPaymentPriceReason,
+            resolveCartPurchaseFinalization: { RoktInternalImplementation.resolveForwardPaymentFinalization(from: $0) },
+            resolveTransportFailureFinalization: {
+            RoktInternalImplementation.resolveForwardPaymentFinalization(fromFailureMessage: $0) },
+            emitRoktEvent: { [weak self] executeId, event in
+                self?.callOnRoktEvent(executeId, event: event)
             },
-            failure: { [weak self] error, statusCode, message in
-                guard let self else { return }
-                self.callOnRoktEvent(executeId, event: RoktEvent.HideLoadingIndicator())
-                let finalization = Self.resolveForwardPaymentFinalization(
-                    fromFailureMessage: message
+            finalizeForwardPayment: { [weak self] executeId, layoutId, catalogItemId, success, failureReason in
+                self?.forwardPaymentFinalized(
+                    executeId: executeId,
+                    layoutId: layoutId,
+                    catalogItemId: catalogItemId,
+                    success: success,
+                    failureReason: failureReason
                 )
-                if builtInCardForwardFlowActive {
-                    if Self.isRetryableForwardPaymentTransportFailure(error: error, statusCode: statusCode) {
-                        self.paymentOrchestrator.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
-                    } else {
-                        self.paymentOrchestrator.finishBuiltInCardForwardPaymentAttempt(
-                            result: .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
-                        )
-                        self.forwardPaymentFinalized(
-                            executeId: executeId,
-                            layoutId: event.layoutId,
-                            catalogItemId: event.catalogItemId,
-                            success: false,
-                            failureReason: finalization.failureReason
-                        )
-                    }
-                } else {
-                    cardStepOneCompletion?(
-                        .failed(error: finalization.failureReason ?? Self.unknownForwardPaymentFailureReason)
-                    )
-                    self.forwardPaymentFinalized(
-                        executeId: executeId,
-                        layoutId: event.layoutId,
-                        catalogItemId: event.catalogItemId,
-                        success: false,
-                        failureReason: finalization.failureReason
-                    )
-                }
             }
+        )
+        cardForwardingPurchase.performCardForwardingCartPurchase(
+            executeId: executeId,
+            event: event
         )
     }
 

--- a/Tests/Rokt_WidgetTests/TestCardForwardingPurchaseCoordinator.swift
+++ b/Tests/Rokt_WidgetTests/TestCardForwardingPurchaseCoordinator.swift
@@ -1,0 +1,279 @@
+import XCTest
+@testable import Rokt_Widget
+@testable internal import RoktUXHelper
+import Mocker
+
+/// Card forwarding cart purchase coordinator: finalize vs restore when `/v1/cart/purchase` returns,
+/// plus ``RoktInternalImplementation/handleForwardPayment`` instant-purchase flag behavior with card in flight.
+final class TestCardForwardingPurchaseCoordinator: XCTestCase {
+
+    private let purchaseURL = URL(string: "https://apps.rokt.com/rokt-mobile/v1/cart/purchase")!
+    private let executeId = "card-forwarding-coordinator-test"
+
+    private var originalTagId: String?
+
+    private let forwardPaymentTestTagId = "test-tag-id"
+
+    override func setUp() {
+        super.setUp()
+        Rokt.setEnvironment(environment: .Prod)
+        originalTagId = Rokt.shared.roktImplementation.roktTagId
+        Rokt.shared.roktImplementation.roktTagId = forwardPaymentTestTagId
+        PaymentOrchestrator.resetBuiltInTwoStepDeferredStateForTesting()
+    }
+
+    override func tearDown() {
+        PaymentOrchestrator.resetBuiltInTwoStepDeferredStateForTesting()
+        Rokt.shared.roktImplementation.roktTagId = originalTagId
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// ``RoktNetWorkAPI.forwardPayment`` reads the tag id on ``Rokt/shared``; parallel suites can clear it in `tearDown`, so re-apply before each network call.
+    private func ensureForwardPaymentTagIdForNetwork() {
+        Rokt.shared.roktImplementation.roktTagId = forwardPaymentTestTagId
+    }
+
+    private func makeForwardPaymentEvent() -> RoktUXEvent.CartItemForwardPayment {
+        RoktUXEvent.CartItemForwardPayment(
+            layoutId: "layout-1",
+            name: "Test item",
+            cartItemId: "cart-1",
+            catalogItemId: "catalog-1",
+            currency: "USD",
+            description: "desc",
+            linkedProductId: nil,
+            providerData: "provider",
+            quantity: 1,
+            totalPrice: 9.99,
+            unitPrice: 9.99,
+            transactionData: nil
+        )
+    }
+
+    private func installMockingHTTPClient() {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockingURLProtocol.self]
+        NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
+    }
+
+    private func registerPurchaseMock(statusCode: Int, body: String, onRequest: ((URLRequest) -> Void)? = nil) {
+        var mock = Mock(
+            url: purchaseURL,
+            dataType: .json,
+            statusCode: statusCode,
+            data: [.post: Data(body.utf8)]
+        )
+        mock.onRequest = { request, _ in
+            onRequest?(request)
+        }
+        mock.register()
+    }
+
+    /// - Parameter assertNoStepOneCompletion: When `true`, Step-1 completion fails the test if invoked (used for retry / restore flows where Step-1 must stay open). When `false`, Step-1 may complete after a terminal ``finishBuiltInCardForwardPaymentAttempt``.
+    private func seedDeferredBuiltInCardForwardPaymentReady(
+        orch: PaymentOrchestrator,
+        assertNoStepOneCompletion: Bool = true
+    ) {
+        orch.unitTest_seedDeferredBuiltInCardForwardPayment { _ in
+            if assertNoStepOneCompletion {
+                XCTFail("Step-1 completion must not run until terminal finish")
+            }
+        }
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight(), "Coordinator expects .card, not .cardInFlight, before begin")
+    }
+
+    private final class FinalizeInvocationLog {
+        private(set) var invocations: [(success: Bool, failureReason: String?)] = []
+        func record(success: Bool, failureReason: String?) {
+            invocations.append((success, failureReason))
+        }
+    }
+
+    private func makeCoordinator(
+        orch: PaymentOrchestrator,
+        finalizeLog: FinalizeInvocationLog,
+        hideLoadingExpectation: XCTestExpectation? = nil
+    ) -> BuiltInCardForwardingPurchaseCoordinator {
+        BuiltInCardForwardingPurchaseCoordinator(
+            paymentOrchestrator: orch,
+            unknownFailureReason: RoktInternalImplementation.unknownForwardPaymentFailureReason,
+            missingPriceFailureReason: RoktInternalImplementation.missingForwardPaymentPriceReason,
+            resolveCartPurchaseFinalization: { RoktInternalImplementation.resolveForwardPaymentFinalization(from: $0) },
+            resolveTransportFailureFinalization: {
+            RoktInternalImplementation.resolveForwardPaymentFinalization(fromFailureMessage: $0) },
+            emitRoktEvent: { _, event in
+                if event is RoktEvent.HideLoadingIndicator {
+                    hideLoadingExpectation?.fulfill()
+                }
+            },
+            finalizeForwardPayment: { _, _, _, success, failureReason in
+                finalizeLog.record(success: success, failureReason: failureReason)
+            }
+        )
+    }
+
+    // MARK: - Coordinator + PaymentOrchestrator
+
+    func test_cardInFlight_retryableHTTP503_skipsFinalize_restoresPendingCard() {
+        let finalizeLog = FinalizeInvocationLog()
+        let hideExp = expectation(description: "Hide loading after transport failure")
+        let orch = PaymentOrchestrator()
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch)
+
+        registerPurchaseMock(statusCode: 503, body: "{}")
+        installMockingHTTPClient()
+
+        let sut = makeCoordinator(orch: orch, finalizeLog: finalizeLog, hideLoadingExpectation: hideExp)
+        ensureForwardPaymentTagIdForNetwork()
+        sut.performCardForwardingCartPurchase(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [hideExp], timeout: 3.0)
+        XCTAssertTrue(finalizeLog.invocations.isEmpty, "Retryable transport failure must not call forwardPaymentFinalized")
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight(), "Restore moves cardInFlight back to card")
+        XCTAssertNotNil(orch.beginBuiltInCardForwardPaymentIfReady(), "Buyer can start a second cart purchase after restore")
+    }
+
+    func test_cardInFlight_retryableBusinessReason_skipsFinalize_restoresPendingCard() {
+        let finalizeLog = FinalizeInvocationLog()
+        let hideExp = expectation(description: "Hide loading after HTTP 200 business failure")
+        let orch = PaymentOrchestrator()
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch)
+
+        registerPurchaseMock(statusCode: 200, body: #"{"success":false,"reason":"Upstream timeout"}"#)
+        installMockingHTTPClient()
+
+        let sut = makeCoordinator(orch: orch, finalizeLog: finalizeLog, hideLoadingExpectation: hideExp)
+        ensureForwardPaymentTagIdForNetwork()
+        sut.performCardForwardingCartPurchase(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [hideExp], timeout: 3.0)
+        XCTAssertTrue(finalizeLog.invocations.isEmpty)
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+        XCTAssertNotNil(orch.beginBuiltInCardForwardPaymentIfReady())
+    }
+
+    func test_cardInFlight_terminalBusinessReason_invokesFinalizeAndClearsDeferredState() {
+        let finalizeLog = FinalizeInvocationLog()
+        let hideExp = expectation(description: "Hide loading")
+        let orch = PaymentOrchestrator()
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch, assertNoStepOneCompletion: false)
+
+        registerPurchaseMock(statusCode: 200, body: #"{"success":false,"reason":"declined"}"#)
+        installMockingHTTPClient()
+
+        let sut = makeCoordinator(orch: orch, finalizeLog: finalizeLog, hideLoadingExpectation: hideExp)
+        ensureForwardPaymentTagIdForNetwork()
+        sut.performCardForwardingCartPurchase(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [hideExp], timeout: 3.0)
+        XCTAssertEqual(finalizeLog.invocations.count, 1)
+        XCTAssertEqual(finalizeLog.invocations.first?.success, false)
+        XCTAssertEqual(finalizeLog.invocations.first?.failureReason, "declined")
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+        XCTAssertNil(orch.beginBuiltInCardForwardPaymentIfReady())
+    }
+
+    func test_cardInFlight_success_invokesFinalizeWithSuccess() {
+        let finalizeLog = FinalizeInvocationLog()
+        let hideExp = expectation(description: "Hide loading")
+        let orch = PaymentOrchestrator()
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch, assertNoStepOneCompletion: false)
+
+        registerPurchaseMock(statusCode: 200, body: #"{"success":true}"#)
+        installMockingHTTPClient()
+
+        let sut = makeCoordinator(orch: orch, finalizeLog: finalizeLog, hideLoadingExpectation: hideExp)
+        ensureForwardPaymentTagIdForNetwork()
+        sut.performCardForwardingCartPurchase(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [hideExp], timeout: 3.0)
+        XCTAssertEqual(finalizeLog.invocations.count, 1)
+        XCTAssertEqual(finalizeLog.invocations.first?.success, true)
+        XCTAssertNil(finalizeLog.invocations.first?.failureReason)
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+    }
+
+    func test_cardInFlight_nonRetryableTransport_invokesFinalize() {
+        let finalizeLog = FinalizeInvocationLog()
+        let hideExp = expectation(description: "Hide loading")
+        let orch = PaymentOrchestrator()
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch, assertNoStepOneCompletion: false)
+
+        registerPurchaseMock(statusCode: 400, body: #"{"error":"bad request"}"#)
+        installMockingHTTPClient()
+
+        let sut = makeCoordinator(orch: orch, finalizeLog: finalizeLog, hideLoadingExpectation: hideExp)
+        ensureForwardPaymentTagIdForNetwork()
+        sut.performCardForwardingCartPurchase(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [hideExp], timeout: 3.0)
+        XCTAssertEqual(finalizeLog.invocations.count, 1)
+        XCTAssertEqual(finalizeLog.invocations.first?.success, false)
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+    }
+
+    // MARK: - RoktInternalImplementation + instant purchase flag
+
+    private func expectFlagCleared(_ bag: ExecuteStateBag) -> XCTestExpectation {
+        let exp = expectation(description: "instantPurchaseInitiated cleared")
+        func check() {
+            if !bag.instantPurchaseInitiated {
+                exp.fulfill()
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.02, execute: check)
+            }
+        }
+        DispatchQueue.main.async(execute: check)
+        return exp
+    }
+
+    func test_handleForwardPayment_cardInFlight_retryableBusinessReason_keepsInstantPurchaseInitiated() {
+        let impl = RoktInternalImplementation()
+        let orch = impl.paymentOrchestratorForTesting
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch)
+
+        let bag = ExecuteStateBag(uxHelper: nil, onRoktEvent: nil)
+        bag.loadedPlacements = 1
+        bag.instantPurchaseInitiated = true
+        impl.stateManager.addState(id: executeId, state: bag)
+
+        registerPurchaseMock(statusCode: 200, body: #"{"success":false,"reason":"Please try again"}"#)
+        installMockingHTTPClient()
+
+        ensureForwardPaymentTagIdForNetwork()
+        impl.handleForwardPayment(executeId: executeId, event: makeForwardPaymentEvent())
+
+        let settled = expectation(description: "async network settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 2.0)
+
+        XCTAssertTrue(bag.instantPurchaseInitiated, "forwardPaymentFinalized must be skipped until a terminal outcome")
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+    }
+
+    func test_handleForwardPayment_cardInFlight_terminalBusinessReason_clearsInstantPurchaseInitiated() {
+        let impl = RoktInternalImplementation()
+        let orch = impl.paymentOrchestratorForTesting
+        seedDeferredBuiltInCardForwardPaymentReady(orch: orch, assertNoStepOneCompletion: false)
+
+        let bag = ExecuteStateBag(uxHelper: nil, onRoktEvent: nil)
+        bag.loadedPlacements = 1
+        bag.instantPurchaseInitiated = true
+        impl.stateManager.addState(id: executeId, state: bag)
+
+        registerPurchaseMock(statusCode: 200, body: #"{"success":false,"reason":"declined"}"#)
+        installMockingHTTPClient()
+
+        let cleared = expectFlagCleared(bag)
+        ensureForwardPaymentTagIdForNetwork()
+        impl.handleForwardPayment(executeId: executeId, event: makeForwardPaymentEvent())
+
+        wait(for: [cleared], timeout: 3.0)
+        XCTAssertFalse(bag.instantPurchaseInitiated)
+        XCTAssertFalse(orch.isBuiltInCardForwardPaymentInFlight())
+    }
+}

--- a/Tests/Rokt_WidgetTests/TestCardForwardingRetryRules.swift
+++ b/Tests/Rokt_WidgetTests/TestCardForwardingRetryRules.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class TestCardForwardingRetryRules: XCTestCase {
+
+    func test_isCardForwardingErrorRetryable_nilAndEmpty_notRetryable() {
+        XCTAssertFalse(CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: nil))
+        XCTAssertFalse(CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: ""))
+        XCTAssertFalse(CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: "   "))
+    }
+
+    func test_isCardForwardingErrorRetryable_declined_notRetryable() {
+        XCTAssertFalse(CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: "declined"))
+    }
+
+    func test_isCardForwardingErrorRetryable_hintSubstrings_retryable() {
+        let hints = [
+            "Request timeout",
+            "The operation timed out",
+            "Please try again later",
+            "TEMPORARILY UNAVAILABLE",
+            "service unavailable",
+            "Too many requests",
+            "Throttled",
+            "Service unavailable"
+        ]
+        for reason in hints {
+            XCTAssertTrue(
+                CardForwardingRetryRules.isCardForwardingErrorRetryable(failureReason: reason),
+                "Expected retryable: \(reason)"
+            )
+        }
+    }
+
+    func test_isRetryableCardForwardingTransportFailure_serverErrors_retryable() {
+        let err = NSError(domain: "test", code: 1)
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 500))
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 503))
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 408))
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 429))
+    }
+
+    func test_isRetryableCardForwardingTransportFailure_clientErrors_notRetryable() {
+        let err = NSError(domain: "test", code: 1)
+        XCTAssertFalse(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 400))
+        XCTAssertFalse(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: err, statusCode: 404))
+    }
+
+    func test_isRetryableCardForwardingTransportFailure_nilStatusCode_usesURLErrorDomain() {
+        let retryable = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: retryable, statusCode: nil))
+
+        let notConnected = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        XCTAssertTrue(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: notConnected, statusCode: nil))
+
+        let other = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+        XCTAssertFalse(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: other, statusCode: nil))
+
+        let nonURL = NSError(domain: "RoktSDK", code: -1)
+        XCTAssertFalse(CardForwardingRetryRules.isRetryableCardForwardingTransportFailure(error: nonURL, statusCode: nil))
+    }
+}

--- a/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
+++ b/Tests/Rokt_WidgetTests/TestPaymentOrchestrator.swift
@@ -870,8 +870,8 @@ class TestPaymentOrchestrator: XCTestCase {
             from: UIViewController(),
             builtInCardDevicePaySession: cardSession
         ) { _ in
-            // Step-1 completion is held until popPendingBuiltInCardCompletion fires it.
-            XCTFail("Card Step-1 completion fired before Step-2 popped it")
+            // Step-1 completion is held until the forward-payment attempt finishes (see ``beginBuiltInCardForwardPaymentIfReady()``).
+            XCTFail("Card Step-1 completion fired before forward-payment terminal finish")
         }
 
         wait(for: [confirmationExpectation], timeout: 1.0)
@@ -885,7 +885,7 @@ class TestPaymentOrchestrator: XCTestCase {
         XCTAssertNotNil(confirmationData)
     }
 
-    func test_popPendingBuiltInCardCompletion_returnsCompletionAndClearsCache() {
+    func test_builtInCardForward_beginFinishTerminalSuccess_deliversCompletionAndClearsInFlight() {
         sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
         PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
 
@@ -897,7 +897,7 @@ class TestPaymentOrchestrator: XCTestCase {
             confirmationExpectation.fulfill()
         }
 
-        let stepOneCompletionExpectation = expectation(description: "Step-1 completion fires once popped")
+        let stepOneCompletionExpectation = expectation(description: "Step-1 completion fires after terminal finish")
         sut.processPayment(
             method: .card,
             item: PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD"),
@@ -911,18 +911,55 @@ class TestPaymentOrchestrator: XCTestCase {
         }
         wait(for: [confirmationExpectation], timeout: 1.0)
 
-        guard let popped = sut.popPendingBuiltInCardCompletion() else {
-            XCTFail("Expected card Step-1 completion to be available after prepare")
+        guard sut.beginBuiltInCardForwardPaymentIfReady() != nil else {
+            XCTFail("Expected begin after prepare")
             return
         }
-        // Second pop should return nil — cache is one-shot.
-        XCTAssertNil(sut.popPendingBuiltInCardCompletion())
+        XCTAssertTrue(sut.isBuiltInCardForwardPaymentInFlight())
+        XCTAssertNil(
+            sut.beginBuiltInCardForwardPaymentIfReady(),
+            "Second begin must return nil while in flight"
+        )
 
-        popped(.succeeded(transactionId: "card_txn"))
+        sut.finishBuiltInCardForwardPaymentAttempt(result: .succeeded(transactionId: "card_txn"))
         wait(for: [stepOneCompletionExpectation], timeout: 1.0)
+        XCTAssertFalse(sut.isBuiltInCardForwardPaymentInFlight())
+        XCTAssertNil(sut.beginBuiltInCardForwardPaymentIfReady(), "No pending card after terminal finish")
     }
 
-    func test_popPendingBuiltInCardCompletion_returnsNilWhenCacheHoldsPayPal() {
+    func test_restoreBuiltInCardForwardPaymentAfterRetryableFailure_allowsSecondBegin() {
+        sut = PaymentOrchestrator(apiHelper: PaymentOrchestratorAPIHelperSpy.self)
+        PaymentOrchestratorAPIHelperSpy.initializePurchaseResponse = Self.validInitializePurchaseResponse()
+
+        let confirmationExpectation = expectation(description: "Card showConfirmation fires")
+        let cardSession = BuiltInTwoStepDevicePaySession(
+            layoutId: "test_layout",
+            catalogItemId: "test_catalog"
+        ) { _, _, _ in
+            confirmationExpectation.fulfill()
+        }
+
+        sut.processPayment(
+            method: .card,
+            item: PaymentItem(id: "item-card", name: "Widget", amount: 9.99, currency: "USD"),
+            context: PaymentContext(),
+            cartItemId: "v1:cart-card:canal",
+            from: UIViewController(),
+            builtInCardDevicePaySession: cardSession
+        ) { _ in
+            XCTFail("Step-1 completion must not run until terminal finish")
+        }
+        wait(for: [confirmationExpectation], timeout: 1.0)
+
+        XCTAssertNotNil(sut.beginBuiltInCardForwardPaymentIfReady())
+        XCTAssertTrue(sut.isBuiltInCardForwardPaymentInFlight())
+        sut.restoreBuiltInCardForwardPaymentAfterRetryableFailure()
+        XCTAssertFalse(sut.isBuiltInCardForwardPaymentInFlight())
+        XCTAssertNotNil(sut.beginBuiltInCardForwardPaymentIfReady())
+        XCTAssertTrue(sut.isBuiltInCardForwardPaymentInFlight())
+    }
+
+    func test_beginBuiltInCardForwardPaymentIfReady_returnsNilWhenCacheHoldsPayPal() {
         let payPalPresenter = MockPayPalApprovalPresenter()
         sut = PaymentOrchestrator(
             apiHelper: PaymentOrchestratorAPIHelperSpy.self,
@@ -945,8 +982,8 @@ class TestPaymentOrchestrator: XCTestCase {
             builtInPayPalDevicePaySession: paypalDeviceSessionForTests()
         ) { _ in }
 
-        // PayPal cache is set; popPendingBuiltInCardCompletion must NOT consume it.
-        XCTAssertNil(sut.popPendingBuiltInCardCompletion())
+        // PayPal cache is set; built-in card begin must not apply.
+        XCTAssertNil(sut.beginBuiltInCardForwardPaymentIfReady())
         XCTAssertTrue(sut.presentPendingBuiltInPayPalForForwardPayment { _ in })
     }
 


### PR DESCRIPTION
## Background

Built-in card forward payment popped Step‑1 state as soon as the user tapped confirm, so any /v1/cart/purchase outcome immediately drove Step‑1 completion and forwardPaymentFinalized. There was no way to stay on the confirm step and retry after transient failures. This PR adds an in‑flight state and client‑side retry vs terminal handling so a retryable error can return the session to “ready to confirm” without finalizing the flow. No new dependencies. Validate confirm UI with the pinned RoktUXHelper when forwardPaymentFinalized is omitted on retryable errors.

## What Has Changed

- PaymentOrchestrator: Pattern B — new cardInFlight case; beginBuiltInCardForwardPaymentIfReady(), isBuiltInCardForwardPaymentInFlight(), restoreBuiltInCardForwardPaymentAfterRetryableFailure(), finishBuiltInCardForwardPaymentAttempt(result:); removed popPendingBuiltInCardCompletion(); cancelPendingBuiltInTwoStepIfNeeded() treats cardInFlight like idle card pending.
- handleForwardPayment: Blocks a second POST while card forward is in flight; on retryable HTTP / business failures → restore only (no Step‑1 completion, no forwardPaymentFinalized); terminal paths unchanged (finish + finalize).

## How Has This Been Tested

Orchestrator tests updated for begin / finish / restore and PayPal coexistence.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
