### PR TITLE
feat(timings): parse experience once and report performance metrics

### DIFF
--- a/Example/Tests/RoktExperienceCacheExecuteTests.swift
+++ b/Example/Tests/RoktExperienceCacheExecuteTests.swift
@@ -11,22 +11,21 @@ let kValidInitWithCacheFilename = "validInitWithCache"
 var mockImplementation: MockRoktInternalImplementation!
 
 class MockRoktInternalImplementation: RoktInternalImplementation {
-    var executingLayoutPage: LayoutPageExecutePayload?
-    var executingPluginIds: [String]? {
-        guard let page = executingLayoutPage?.page,
-              let pageData = page.data(using: .utf8),
-              let pageDecodedData = try? JSONDecoder().decode(RoktUXExperienceResponse.self, from: pageData),
-              let pageModel = pageDecodedData.getPageModel()
-        else {
-            return nil
+    var executingLayoutPage: LayoutPageExecutePayload? {
+        didSet {
+            if executingLayoutPage == nil { executingPageString = nil }
         }
-        guard let layoutPlugins = pageModel.layoutPlugins else { return nil }
-        return layoutPlugins.compactMap { (plugin) -> String? in plugin.pluginId }
+    }
+    // Raw experience JSON for the in-flight execute; cleared whenever executingLayoutPage is.
+    var executingPageString: String?
+    var executingPluginIds: [String]? {
+        executingLayoutPage?.pageModel.layoutPlugins?.compactMap { $0.pluginId }
     }
     override func processLayoutPageExecutePayload(_ page: String,
                                                   selectionId: String,
                                                   viewName: String? = nil,
                                                   attributes: [String: String]) -> LayoutPageExecutePayload? {
+        executingPageString = page
         executingLayoutPage = super.processLayoutPageExecutePayload(
             page,
             selectionId: selectionId,
@@ -106,7 +105,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with original response
                     self.executeRokt()
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString), timeout: .seconds(5)
                     )
 
@@ -120,7 +119,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     self.executeRokt()
 
                     // Check uses new response
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubNewResponseAsString), timeout: .seconds(60)
                     )
                 }
@@ -136,7 +135,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with original response
                     self.executeRokt(config: config)
-                    expect(mockImplementation.executingLayoutPage?.page)
+                    expect(mockImplementation.executingPageString)
                         .toEventually(equal(stubCachedResponseAsString), timeout: .seconds(5))
 
                     // Stub execute to return new response
@@ -146,7 +145,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     self.executeRokt(config: config)
 
                     // Check uses original (cached) response
-                    expect(mockImplementation.executingLayoutPage?.page)
+                    expect(mockImplementation.executingPageString)
                         .toEventually(equal(stubCachedResponseAsString), timeout: .seconds(5))
                 }
 
@@ -161,7 +160,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with original response
                     self.executeRokt(config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -179,7 +178,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Check uses new response
                     let stubNewResponseAsString = self.getJsonFileContents(kValidLayoutGroupedFilename)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubNewResponseAsString),
                         timeout: .seconds(1)
                     )
@@ -194,7 +193,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with execute attributes, returning original response
                     self.executeRokt(attributes: self.mockedAttributes, config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -206,7 +205,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     self.executeRokt(attributes: self.mockedAttributes, config: config)
 
                     // Check uses original response
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -221,7 +220,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with execute attributes, returning original response
                     self.executeRokt(attributes: self.mockedAttributes, config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -234,7 +233,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Check uses new response
                     let stubNewResponseAsString = self.getJsonFileContents(kValidLayoutGroupedFilename)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubNewResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -249,7 +248,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with execute attributes, returning original response
                     self.executeRokt(attributes: self.mockedAttributes, config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -261,7 +260,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     self.executeRokt(attributes: self.mockedReorderedAttributes, config: config)
 
                     // Check uses original response
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -276,7 +275,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with execute viewName and attributes, returning original response
                     self.executeRokt(viewName: self.mockedViewName, attributes: self.mockedAttributes, config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -288,7 +287,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     self.executeRokt(viewName: self.mockedViewName, attributes: self.mockedAttributes, config: config)
 
                     // Check uses original response
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -303,7 +302,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Initial execute with execute attributes, returning original response
                     self.executeRokt(attributes: self.mockedAttributes, config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -320,7 +319,7 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
 
                     // Check uses new response
                     let stubNewResponseAsString = self.getJsonFileContents(kValidLayoutGroupedFilename)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubNewResponseAsString),
                         timeout: .seconds(5)
                     )
@@ -505,14 +504,14 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     let stubNewResponseAsString = self.getJsonFileContents(kValidLayoutGroupedFilename)
 
                     self.executeRokt(config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubCachedResponseAsString),
                         timeout: .seconds(5)
                     )
 
                     self.stubExecute(kValidLayoutGroupedFilename, isLayout: true)
                     self.executeRokt(config: config)
-                    expect(mockImplementation.executingLayoutPage?.page).toEventually(
+                    expect(mockImplementation.executingPageString).toEventually(
                         equal(stubNewResponseAsString),
                         timeout: .seconds(5)
                     )

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.11.0"),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.12.0"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/surpher/PactSwift.git", .upToNextMajor(from: "1.2.0"))
     ],

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.2', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.11.0', '< 1.0'
+  s.dependency 'RoktUXHelper', '>= 0.12.0', '< 1.0'
 end

--- a/Sources/Rokt_Widget/Models/Timings/TimingData.swift
+++ b/Sources/Rokt_Widget/Models/Timings/TimingData.swift
@@ -6,6 +6,8 @@ import Foundation
 class TimingData {
     var experiencesRequestStart: Date?
     var experiencesRequestEnd: Date?
+    var experienceJsonParseStart: Date?
+    var experienceJsonParseEnd: Date?
     var selectionStart: Date?
     var selectionEnd: Date?
     var pageInit: Date?

--- a/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
+++ b/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
@@ -2,31 +2,33 @@ import Foundation
 
 /// Request payload for the `v1/timings/events` endpoint, carrying performance
 /// metrics (experiences request latency and experience JSON parse duration).
+///
+/// The mobile SDK sends only the fields the backend actually consumes for an
+/// `msdk` event: the `timingMetrics` array (the sole required body field) plus the
+/// optional plugin attributes used for downstream segmentation. Fields that the
+/// endpoint exposes purely for the web SDK — or that the backend overwrites — are
+/// intentionally omitted to keep the payload minimal:
+///   - `eventTime`   — overwritten server-side with the receive time, body value dropped.
+///   - `isCached`    — a WSDK concept (browser static-asset cache); always false here
+///                     since cache hits never reach this endpoint.
+///   - `expectedTti` — a WSDK time-to-interactive metric; not applicable to mobile.
+///
+/// `pageId` / `pageInstanceGuid` are carried on the model only to populate request
+/// headers (`rokt-page-id` / `rokt-page-instance-guid`); they are not part of the body.
 class TimingEventsRequest: Codable {
     static let timingMetricsKey = "timingMetrics"
-    private static let isCachedKey = "isCached"
-    private static let expectedTtiKey = "expectedTti"
 
-    let eventTime: Date
-    let isCached: Bool
-    let expectedTti: Int64
     let pageId: String?
     let pageInstanceGuid: String?
     let pluginId: String?
     let pluginName: String?
     let timings: [TimingMetric]
 
-    init(eventTime: Date = RoktSDKDateHandler.currentDate(),
-         isCached: Bool = false,
-         expectedTti: Int64 = 0,
-         pageId: String? = nil,
+    init(pageId: String? = nil,
          pageInstanceGuid: String? = nil,
          pluginId: String? = nil,
          pluginName: String? = nil,
          timings: [TimingMetric]) {
-        self.eventTime = eventTime
-        self.isCached = isCached
-        self.expectedTti = expectedTti
         self.pageId = pageId
         self.pageInstanceGuid = pageInstanceGuid
         self.pluginId = pluginId
@@ -36,9 +38,6 @@ class TimingEventsRequest: Codable {
 
     internal func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [
-            timingsEventTimeKey: EventDateFormatter.getDateString(self.eventTime),
-            Self.isCachedKey: isCached,
-            Self.expectedTtiKey: expectedTti,
             Self.timingMetricsKey: timings.map { $0.toDictionary() }
         ]
 

--- a/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
+++ b/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Request payload for the `v1/timings/events` endpoint, carrying performance
+/// metrics (experiences request latency and experience JSON parse duration).
+class TimingEventsRequest: Codable {
+    static let timingMetricsKey = "timingMetrics"
+    private static let isCachedKey = "isCached"
+    private static let expectedTtiKey = "expectedTti"
+
+    let eventTime: Date
+    let isCached: Bool
+    let expectedTti: Int64
+    let pageId: String?
+    let pageInstanceGuid: String?
+    let pluginId: String?
+    let pluginName: String?
+    let timings: [TimingMetric]
+
+    init(eventTime: Date = RoktSDKDateHandler.currentDate(),
+         isCached: Bool = false,
+         expectedTti: Int64 = 0,
+         pageId: String? = nil,
+         pageInstanceGuid: String? = nil,
+         pluginId: String? = nil,
+         pluginName: String? = nil,
+         timings: [TimingMetric]) {
+        self.eventTime = eventTime
+        self.isCached = isCached
+        self.expectedTti = expectedTti
+        self.pageId = pageId
+        self.pageInstanceGuid = pageInstanceGuid
+        self.pluginId = pluginId
+        self.pluginName = pluginName
+        self.timings = timings
+    }
+
+    internal func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            timingsEventTimeKey: EventDateFormatter.getDateString(self.eventTime),
+            Self.isCachedKey: isCached,
+            Self.expectedTtiKey: expectedTti,
+            Self.timingMetricsKey: timings.map { $0.toDictionary() }
+        ]
+
+        if let pluginId = self.pluginId {
+            dict[timingsPluginIdKey] = pluginId
+        }
+        if let pluginName = self.pluginName {
+            dict[timingsPluginNameKey] = pluginName
+        }
+
+        return dict
+    }
+}

--- a/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
+++ b/Sources/Rokt_Widget/Models/Timings/TimingEventsRequest.swift
@@ -1,20 +1,7 @@
 import Foundation
 
-/// Request payload for the `v1/timings/events` endpoint, carrying performance
-/// metrics (experiences request latency and experience JSON parse duration).
-///
-/// The mobile SDK sends only the fields the backend actually consumes for an
-/// `msdk` event: the `timingMetrics` array (the sole required body field) plus the
-/// optional plugin attributes used for downstream segmentation. Fields that the
-/// endpoint exposes purely for the web SDK — or that the backend overwrites — are
-/// intentionally omitted to keep the payload minimal:
-///   - `eventTime`   — overwritten server-side with the receive time, body value dropped.
-///   - `isCached`    — a WSDK concept (browser static-asset cache); always false here
-///                     since cache hits never reach this endpoint.
-///   - `expectedTti` — a WSDK time-to-interactive metric; not applicable to mobile.
-///
-/// `pageId` / `pageInstanceGuid` are carried on the model only to populate request
-/// headers (`rokt-page-id` / `rokt-page-instance-guid`); they are not part of the body.
+/// Request body for `v1/timings/events`: the performance `timingMetrics` the SDK sends
+/// (experiences-request latency and experience JSON-parse duration).
 class TimingEventsRequest: Codable {
     static let timingMetricsKey = "timingMetrics"
 

--- a/Sources/Rokt_Widget/Models/Timings/TimingMetric.swift
+++ b/Sources/Rokt_Widget/Models/Timings/TimingMetric.swift
@@ -25,4 +25,7 @@ enum TimingType: String, Codable {
     case experiencesRequestEnd
     case placementInteractive
     case jointSdkSelectPlacements
+    // Function-level timings use the dynamic `fn:<name>:start|end` naming convention
+    case experienceJsonParseStart = "fn:experienceJsonParse:start"
+    case experienceJsonParseEnd = "fn:experienceJsonParse:end"
 }

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -297,4 +297,24 @@ internal class RoktAPIHelper {
             RoktNetWorkAPI.sendTimings(timingsRequest: timingsRequest, sessionId: sessionId, selectionId: selectionId)
         }
     }
+
+    /// Rokt timing events collection API call (performance metrics)
+    ///
+    /// - Parameters:
+    ///   - timingEventsRequest: TimingEventsRequest object containing metadata and collected timing metrics
+    ///   - sessionId: Session identifier for the request
+    ///   - selectionId: Selection identifier (UUID) to be sent as x-rokt-trace-id header
+    class func sendTimingEvents(_ timingEventsRequest: TimingEventsRequest,
+                                sessionId: String?,
+                                selectionId: String) {
+        guard Rokt.shared.roktImplementation.roktTagId != nil else { return }
+
+        if isMock() {
+            RoktMockAPI.sendTimingEvents(timingEventsRequest: timingEventsRequest, selectionId: selectionId)
+        } else {
+            RoktNetWorkAPI.sendTimingEvents(timingEventsRequest: timingEventsRequest,
+                                            sessionId: sessionId,
+                                            selectionId: selectionId)
+        }
+    }
 }

--- a/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktMockAPI.swift
@@ -162,4 +162,13 @@ internal class RoktMockAPI {
             RoktLogger.shared.verbose(String(bytes: params, encoding: .utf8) ?? "")
         } catch {}
     }
+
+    class func sendTimingEvents(timingEventsRequest: TimingEventsRequest, selectionId: String) {
+        do {
+            var requestData = timingEventsRequest.toDictionary()
+            requestData["selectionId"] = selectionId
+            let params = try JSONSerialization.data(withJSONObject: requestData, options: [])
+            RoktLogger.shared.verbose(String(bytes: params, encoding: .utf8) ?? "")
+        } catch {}
+    }
 }

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -10,6 +10,7 @@ var experiencesResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/exper
 var eventResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v2/events" }
 var diagnosticsResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/diagnostics" }
 var timingsResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/timings" }
+var timingsEventsResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/timings/events" }
 var initializePurchaseResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/cart/initialize-purchase" }
 var purchaseResourceURL: String { "\(baseURL)/\(mobileAPIPathPrefix)/v1/cart/purchase" }
 
@@ -281,7 +282,9 @@ internal class RoktNetWorkAPI {
         }
     }
 
-    private class func getTimingsRequestHeaders(tagId: String, timingsRequest: TimingsRequest,
+    private class func getTimingsRequestHeaders(tagId: String,
+                                                pageInstanceGuid: String?,
+                                                pageId: String?,
                                                 selectionId: String) -> [String: String] {
         var headers: [String: String] = getDefaultHeaders(tagId: tagId)
 
@@ -289,11 +292,11 @@ internal class RoktNetWorkAPI {
         headers[headerIntegrationTypeKey] = timingsSdkType
         headers["x-rokt-trace-id"] = selectionId
 
-        if let pageInstanceGuid = timingsRequest.pageInstanceGuid {
+        if let pageInstanceGuid {
             headers[headerPageInstanceGuidKey] = pageInstanceGuid
         }
 
-        if let pageId = timingsRequest.pageId {
+        if let pageId {
             headers[headerPageIdKey] = pageId
         }
 
@@ -368,10 +371,44 @@ internal class RoktNetWorkAPI {
                            selectionId: String) {
         guard let tagId = Rokt.shared.roktImplementation.roktTagId else { return }
 
-        let timingsHeaders = getTimingsRequestHeaders(tagId: tagId, timingsRequest: timingsRequest, selectionId: selectionId)
+        let timingsHeaders = getTimingsRequestHeaders(tagId: tagId,
+                                                      pageInstanceGuid: timingsRequest.pageInstanceGuid,
+                                                      pageId: timingsRequest.pageId,
+                                                      selectionId: selectionId)
 
         NetworkingHelper.performPost(url: timingsResourceURL,
                                      body: timingsRequest.toDictionary(),
+                                     headers: timingsHeaders,
+                                     failure: { (error, statusCode, response) in
+                                        let callStack = String(format: timingsAPIFailureMsg,
+                                                               response,
+                                                               String(describing: statusCode),
+                                                               error.localizedDescription)
+                                        RoktAPIHelper.sendDiagnostics(
+                                            message: timingsDiagnosticCode,
+                                            callStack: callStack,
+                                            sessionId: sessionId)
+                                        RoktLogger.shared.verbose(callStack) })
+    }
+
+    /// Rokt timing events collection API call (performance metrics)
+    ///
+    /// - Parameters:
+    ///   - timingEventsRequest: TimingEventsRequest object containing metadata and collected timing metrics
+    ///   - sessionId: Session identifier for the request
+    ///   - selectionId: Selection identifier (UUID) to be sent as x-rokt-trace-id header
+    class func sendTimingEvents(timingEventsRequest: TimingEventsRequest,
+                                sessionId: String?,
+                                selectionId: String) {
+        guard let tagId = Rokt.shared.roktImplementation.roktTagId else { return }
+
+        let timingsHeaders = getTimingsRequestHeaders(tagId: tagId,
+                                                      pageInstanceGuid: timingEventsRequest.pageInstanceGuid,
+                                                      pageId: timingEventsRequest.pageId,
+                                                      selectionId: selectionId)
+
+        NetworkingHelper.performPost(url: timingsEventsResourceURL,
+                                     body: timingEventsRequest.toDictionary(),
                                      headers: timingsHeaders,
                                      failure: { (error, statusCode, response) in
                                         let callStack = String(format: timingsAPIFailureMsg,

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -271,7 +271,7 @@ class RoktInternalImplementation {
         if let swiftUiExecuteLayout {
             uxHelper.loadLayout(
                 startDate: startDate,
-                experienceResponse: layoutPage.page,
+                pageModel: layoutPage.pageModel,
                 layoutPluginViewStates: layoutPage.cacheProperties?.pluginViewStates,
                 defaultLayoutLoader: swiftUiExecuteLayout,
                 config: roktConfig.getUXConfig(),
@@ -296,7 +296,7 @@ class RoktInternalImplementation {
         } else {
             uxHelper.loadLayout(
                 startDate: startDate,
-                experienceResponse: layoutPage.page,
+                pageModel: layoutPage.pageModel,
                 layoutPluginViewStates: layoutPage.cacheProperties?.pluginViewStates,
                 layoutLoaders: placements,
                 config: roktConfig.getUXConfig(),
@@ -1080,12 +1080,20 @@ class RoktInternalImplementation {
             return nil
         }
 
-        guard let pageDecodedData = try? decodeOnSeparateThread(RoktUXExperienceResponse.self, pageData) else {
+        // Single parse: the UX helper decodes the experience response once and reports
+        // the parse window; the resulting page model is reused for rendering.
+        guard let parseResult = RoktUX.parseExperience(page) else {
             return nil
         }
-        sessionManager.updateSessionId(newSessionId: pageDecodedData.sessionId)
+        sessionManager.updateSessionId(newSessionId: parseResult.sessionId)
 
-        guard let pageModel = pageDecodedData.getPageModel() else {
+        processedTimingsRequests?.setExperienceJsonParseTimes(
+            selectionId: selectionId,
+            start: parseResult.parseStart,
+            end: parseResult.parseEnd
+        )
+
+        guard let pageModel = parseResult.pageModel else {
             return nil
         }
         let events = try? decodeOnSeparateThread(UntriggeredEventsContainer.self, pageData)
@@ -1095,7 +1103,7 @@ class RoktInternalImplementation {
 
         processedTimingsRequests?.setPageProperties(
             selectionId: selectionId,
-            sessionId: pageDecodedData.sessionId,
+            sessionId: parseResult.sessionId,
             pageId: pageModel.pageId,
             pageInstanceGuid: pageModel.pageInstanceGuid
         )
@@ -1126,10 +1134,10 @@ class RoktInternalImplementation {
                 pluginViewStates: pluginViewStates,
                 onPluginViewStateChange: onPluginViewStateChange
             )
-            return LayoutPageExecutePayload(page: page,
+            return LayoutPageExecutePayload(pageModel: pageModel,
                                             cacheProperties: cacheProperties)
         } else {
-            return LayoutPageExecutePayload(page: page,
+            return LayoutPageExecutePayload(pageModel: pageModel,
                                             cacheProperties: nil)
         }
     }
@@ -1340,7 +1348,9 @@ struct ExecutePayload {
 }
 
 struct LayoutPageExecutePayload {
-    let page: String
+    /// Pre-parsed experience page model; rendering reuses it so the
+    /// experience response is decoded exactly once.
+    let pageModel: RoktUXPageModel
     let cacheProperties: LayoutPageCacheProperties?
 }
 

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -411,18 +411,12 @@ class RoktInternalImplementation {
             placements = nil
             _swiftUiExecuteLayout = nil
         } else if (uxEvent as? RoktUXEvent.LayoutInteractive) != nil {
-            // Placement load bookkeeping — replaces the former onLoad view-lifecycle closure
-            // (the SDK-only loadLayout(pageModel:) overload no longer takes one). LayoutInteractive
-            // fires once per placement when it becomes interactable, keeping the loaded-placement
-            // count balanced against the unload events below.
+            // Track placement load (count gates clearCallBacks).
             callOnLoad(executeId)
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
         } else if (uxEvent as? RoktUXEvent.LayoutClosed) != nil
                     || (uxEvent as? RoktUXEvent.LayoutCompleted) != nil {
-            // Placement unload bookkeeping — replaces the former onUnload view-lifecycle closure.
-            // Exactly one of LayoutClosed / LayoutCompleted fires per placement at dismissal
-            // (mirrors how LayoutFailure already drives callOnUnLoad above), so clearCallBacks
-            // still runs once the last placement is gone.
+            // Track placement unload.
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
             callOnUnLoad(executeId)
         } else if let event = uxEvent as? RoktUXEvent.CartItemInstantPurchase {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -275,8 +275,6 @@ class RoktInternalImplementation {
                 layoutPluginViewStates: layoutPage.cacheProperties?.pluginViewStates,
                 defaultLayoutLoader: swiftUiExecuteLayout,
                 config: roktConfig.getUXConfig(),
-                onLoad: {[weak self] in self?.callOnLoad(selectionId)},
-                onUnload: {[weak self] in self?.callOnUnLoad(selectionId)},
                 onEmbeddedSizeChange: {[weak self] selectedPlacementName, widgetHeight in
                     self?.callOnEmbeddedSizeChange(selectionId,
                                                    selectedPlacementName: selectedPlacementName,
@@ -300,8 +298,6 @@ class RoktInternalImplementation {
                 layoutPluginViewStates: layoutPage.cacheProperties?.pluginViewStates,
                 layoutLoaders: placements,
                 config: roktConfig.getUXConfig(),
-                onLoad: {[weak self] in self?.callOnLoad(selectionId)},
-                onUnload: {[weak self] in self?.callOnUnLoad(selectionId)},
                 onEmbeddedSizeChange: {[weak self] selectedPlacementName, widgetHeight in
                     self?.callOnEmbeddedSizeChange(selectionId,
                                                    selectedPlacementName: selectedPlacementName,
@@ -393,8 +389,8 @@ class RoktInternalImplementation {
                                       execute: workItem)
     }
 
-    private func callOnRoktUXEvent(_ executeId: String,
-                                   uxEvent: RoktUXEvent) {
+    func callOnRoktUXEvent(_ executeId: String,
+                           uxEvent: RoktUXEvent) {
         if uxEvent is RoktUXEvent.FirstPositiveEngagement {
             callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
         } else if let event = uxEvent as? RoktUXEvent.OpenUrl {
@@ -414,6 +410,21 @@ class RoktInternalImplementation {
             callOnUnLoad(executeId)
             placements = nil
             _swiftUiExecuteLayout = nil
+        } else if (uxEvent as? RoktUXEvent.LayoutInteractive) != nil {
+            // Placement load bookkeeping — replaces the former onLoad view-lifecycle closure
+            // (the SDK-only loadLayout(pageModel:) overload no longer takes one). LayoutInteractive
+            // fires once per placement when it becomes interactable, keeping the loaded-placement
+            // count balanced against the unload events below.
+            callOnLoad(executeId)
+            callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
+        } else if (uxEvent as? RoktUXEvent.LayoutClosed) != nil
+                    || (uxEvent as? RoktUXEvent.LayoutCompleted) != nil {
+            // Placement unload bookkeeping — replaces the former onUnload view-lifecycle closure.
+            // Exactly one of LayoutClosed / LayoutCompleted fires per placement at dismissal
+            // (mirrors how LayoutFailure already drives callOnUnLoad above), so clearCallBacks
+            // still runs once the last placement is gone.
+            callOnRoktEvent(executeId, event: uxEvent.mapToRoktEvent)
+            callOnUnLoad(executeId)
         } else if let event = uxEvent as? RoktUXEvent.CartItemInstantPurchase {
             callOnRoktEvent(executeId, event: RoktEvent.CartItemInstantPurchaseInitiated(
                 identifier: event.layoutId,

--- a/Sources/Rokt_Widget/ViewModel/TimingsRequestProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/TimingsRequestProcessor.swift
@@ -88,6 +88,13 @@ class TimingsRequestProcessor {
         timingData.experiencesRequestEnd = RoktSDKDateHandler.currentDate()
     }
 
+    /// Records the experience JSON parse window reported by the UX helper.
+    func setExperienceJsonParseTimes(selectionId: String, start: Date, end: Date) {
+        let timingData = getOrCreateTimingData(selectionId: selectionId)
+        timingData.experienceJsonParseStart = start
+        timingData.experienceJsonParseEnd = end
+    }
+
     func setPlacementInteractiveTime(selectionId: String, _ time: Date? = RoktSDKDateHandler.currentDate()) {
         let timingData = getOrCreateTimingData(selectionId: selectionId)
         timingData.placementInteractive = time
@@ -120,6 +127,16 @@ class TimingsRequestProcessor {
         let timingsRequest = buildTimingsRequest(timingData: timingData)
         if isUniqueTimingsRequest(timingsRequest) {
             apiHelper.sendTimings(timingsRequest, sessionId: timingData.sessionId, selectionId: selectionId)
+
+            // Performance metrics (experiences request latency + experience JSON parse
+            // duration) go to the timings events endpoint. Shares the uniqueness gate
+            // above so both requests are sent exactly once per page instance.
+            let timingEventsRequest = buildTimingEventsRequest(timingData: timingData)
+            if !timingEventsRequest.timings.isEmpty {
+                apiHelper.sendTimingEvents(timingEventsRequest,
+                                           sessionId: timingData.sessionId,
+                                           selectionId: selectionId)
+            }
         }
     }
 
@@ -128,6 +145,8 @@ class TimingsRequestProcessor {
         let timingData = getOrCreateTimingData(selectionId: selectionId)
         timingData.experiencesRequestStart = nil
         timingData.experiencesRequestEnd = nil
+        timingData.experienceJsonParseStart = nil
+        timingData.experienceJsonParseEnd = nil
         timingData.selectionStart = nil
         timingData.selectionEnd = nil
         timingData.pageInit = nil
@@ -141,6 +160,29 @@ class TimingsRequestProcessor {
                               pluginId: timingData.pluginId,
                               pluginName: timingData.pluginName,
                               timings: buildTimingMetricArray(timingData))
+    }
+
+    private func buildTimingEventsRequest(timingData: TimingData) -> TimingEventsRequest {
+        var metrics = [TimingMetric]()
+
+        if let experiencesRequestStart = timingData.experiencesRequestStart {
+            metrics.append(TimingMetric(name: .experiencesRequestStart, value: experiencesRequestStart))
+        }
+        if let experiencesRequestEnd = timingData.experiencesRequestEnd {
+            metrics.append(TimingMetric(name: .experiencesRequestEnd, value: experiencesRequestEnd))
+        }
+        if let experienceJsonParseStart = timingData.experienceJsonParseStart {
+            metrics.append(TimingMetric(name: .experienceJsonParseStart, value: experienceJsonParseStart))
+        }
+        if let experienceJsonParseEnd = timingData.experienceJsonParseEnd {
+            metrics.append(TimingMetric(name: .experienceJsonParseEnd, value: experienceJsonParseEnd))
+        }
+
+        return TimingEventsRequest(pageId: timingData.pageId,
+                                   pageInstanceGuid: timingData.pageInstanceGuid,
+                                   pluginId: timingData.pluginId,
+                                   pluginName: timingData.pluginName,
+                                   timings: metrics)
     }
 
     private func isUniqueTimingsRequest(_ req: TimingsRequest) -> Bool {

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
@@ -320,6 +320,113 @@ class TestTimingsRequestProcessor: XCTestCase {
         XCTAssertEqual(RoktAPIHelperSpy.lastTimingsRequest?.pluginId, pluginId)
     }
 
+    // MARK: - Tests for timing events (performance metrics)
+
+    func testProcessTimingsRequest_SendsTimingEventsWithPerformanceMetrics() {
+        // Arrange
+        let parseStart = fixedDate!
+        let parseEnd = Date(timeIntervalSince1970: fixedDate.timeIntervalSince1970 + 1)
+        sut.setExperiencesRequestStartTime(selectionId: testSelectionId)
+        sut.setExperiencesRequestEndTime(selectionId: testSelectionId)
+        sut.setExperienceJsonParseTimes(selectionId: testSelectionId, start: parseStart, end: parseEnd)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert
+        XCTAssertEqual(RoktAPIHelperSpy.sendTimingEventsCallCount, 1)
+        let eventsRequest = RoktAPIHelperSpy.lastTimingEventsRequest!
+        XCTAssertEqual(eventsRequest.timings.count, 4)
+        XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experiencesRequestStart, value: fixedDate))
+        XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experiencesRequestEnd, value: fixedDate))
+        XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseStart, value: parseStart))
+        XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseEnd, value: parseEnd))
+        XCTAssertFalse(eventsRequest.isCached)
+        XCTAssertEqual(eventsRequest.expectedTti, 0)
+    }
+
+    func testProcessTimingsRequest_TimingEventsUseFunctionTimingNames() {
+        // Arrange
+        sut.setExperiencesRequestStartTime(selectionId: testSelectionId)
+        sut.setExperienceJsonParseTimes(selectionId: testSelectionId, start: fixedDate, end: fixedDate)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert - parse metrics serialize with the fn:<name>:start|end convention
+        let eventsRequest = RoktAPIHelperSpy.lastTimingEventsRequest!
+        let metricNames = eventsRequest.timings.map { $0.toDictionary()["name"] }
+        XCTAssertTrue(metricNames.contains("fn:experienceJsonParse:start"))
+        XCTAssertTrue(metricNames.contains("fn:experienceJsonParse:end"))
+    }
+
+    func testProcessTimingsRequest_CachedExperience_DoesNotSendTimingEvents() {
+        // Arrange - no experiencesRequestStart (cache hit scenario)
+        sut.setExperienceJsonParseTimes(selectionId: testSelectionId, start: fixedDate, end: fixedDate)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert
+        XCTAssertEqual(RoktAPIHelperSpy.sendTimingEventsCallCount, 0)
+        XCTAssertNil(RoktAPIHelperSpy.lastTimingEventsRequest)
+    }
+
+    func testProcessTimingsRequest_DuplicateRequest_DoesNotResendTimingEvents() {
+        // Arrange
+        sut.setExperiencesRequestStartTime(selectionId: testSelectionId)
+        sut.setExperienceJsonParseTimes(selectionId: testSelectionId, start: fixedDate, end: fixedDate)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert - shares the uniqueness gate with the timings request
+        XCTAssertEqual(RoktAPIHelperSpy.sendTimingEventsCallCount, 1)
+    }
+
+    func testProcessTimingsRequest_TimingEventsCarryPageAndPluginProperties() {
+        // Arrange
+        sut.setPageProperties(selectionId: testSelectionId, sessionId: "session1", pageId: "page1",
+                              pageInstanceGuid: "guid1")
+        sut.setPluginAttributes(selectionId: testSelectionId, pluginId: "plugin1", pluginName: "pluginName1")
+        sut.setExperiencesRequestStartTime(selectionId: testSelectionId)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert
+        let eventsRequest = RoktAPIHelperSpy.lastTimingEventsRequest!
+        XCTAssertEqual(eventsRequest.pageId, "page1")
+        XCTAssertEqual(eventsRequest.pageInstanceGuid, "guid1")
+        XCTAssertEqual(eventsRequest.pluginId, "plugin1")
+        XCTAssertEqual(eventsRequest.pluginName, "pluginName1")
+    }
+
+    func testSetExperienceJsonParseTimes_ResetWithPageTimings() {
+        // Arrange
+        sut.setExperienceJsonParseTimes(selectionId: testSelectionId, start: fixedDate, end: fixedDate)
+        sut.resetPageTimings(selectionId: testSelectionId)
+
+        sut.setExperiencesRequestStartTime(selectionId: testSelectionId)
+        sut.setPlacementInteractiveTime(selectionId: testSelectionId)
+
+        // Act
+        sut.processTimingsRequest(selectionId: testSelectionId)
+
+        // Assert - parse metrics are not included after reset
+        let eventsRequest = RoktAPIHelperSpy.lastTimingEventsRequest!
+        let hasParseMetric = eventsRequest.timings.contains {
+            $0.name == .experienceJsonParseStart || $0.name == .experienceJsonParseEnd
+        }
+        XCTAssertFalse(hasParseMetric)
+    }
+
     // MARK: - Tests for isUniqueTimingsRequest
 
     func testIsUniqueTimingsRequest_UniqueRequest() {
@@ -497,6 +604,8 @@ class RoktAPIHelperSpy: RoktAPIHelper {
     static var lastTimingsRequest: TimingsRequest?
     static var lastSessionId: String?
     static var lastSelectionId: String?
+    static var sendTimingEventsCallCount = 0
+    static var lastTimingEventsRequest: TimingEventsRequest?
 
     override static func sendTimings(_ timingsRequest: TimingsRequest, sessionId: String?, selectionId: String) {
         sendTimingsCallCount += 1
@@ -505,10 +614,19 @@ class RoktAPIHelperSpy: RoktAPIHelper {
         lastSelectionId = selectionId
     }
 
+    override static func sendTimingEvents(_ timingEventsRequest: TimingEventsRequest,
+                                          sessionId: String?,
+                                          selectionId: String) {
+        sendTimingEventsCallCount += 1
+        lastTimingEventsRequest = timingEventsRequest
+    }
+
     static func reset() {
         sendTimingsCallCount = 0
         lastTimingsRequest = nil
         lastSessionId = nil
         lastSelectionId = nil
+        sendTimingEventsCallCount = 0
+        lastTimingEventsRequest = nil
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
@@ -343,8 +343,7 @@ class TestTimingsRequestProcessor: XCTestCase {
         XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseStart, value: parseStart))
         XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseEnd, value: parseEnd))
 
-        // Minimal mobile payload: only timingMetrics (+ optional plugin attrs) is sent.
-        // WSDK-only / server-overwritten fields must NOT appear in the body.
+        // Body carries only timingMetrics (+ optional plugin attrs).
         let body = eventsRequest.toDictionary()
         XCTAssertNotNil(body[TimingEventsRequest.timingMetricsKey])
         XCTAssertNil(body["isCached"])

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestTimingRequestProcessor.swift
@@ -342,8 +342,14 @@ class TestTimingsRequestProcessor: XCTestCase {
         XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experiencesRequestEnd, value: fixedDate))
         XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseStart, value: parseStart))
         XCTAssertTrue(containsTimingMetric(eventsRequest.timings, name: .experienceJsonParseEnd, value: parseEnd))
-        XCTAssertFalse(eventsRequest.isCached)
-        XCTAssertEqual(eventsRequest.expectedTti, 0)
+
+        // Minimal mobile payload: only timingMetrics (+ optional plugin attrs) is sent.
+        // WSDK-only / server-overwritten fields must NOT appear in the body.
+        let body = eventsRequest.toDictionary()
+        XCTAssertNotNil(body[TimingEventsRequest.timingMetricsKey])
+        XCTAssertNil(body["isCached"])
+        XCTAssertNil(body["expectedTti"])
+        XCTAssertNil(body["eventTime"])
     }
 
     func testProcessTimingsRequest_TimingEventsUseFunctionTimingNames() {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -148,6 +148,43 @@ class TestRokt: XCTestCase {
         )
     }
 
+    func testProcessLayoutPageExecutePayload_recordsExperienceJsonParseTimes() {
+        // Arrange
+        let roktInternalImplementation = RoktInternalImplementation()
+        let timingsProcessor = TimingsRequestProcessor(apiHelper: RoktAPIHelperSpy.self)
+        roktInternalImplementation.processedTimingsRequests = timingsProcessor
+        RoktAPIHelperSpy.reset()
+        let selectionId = UUID().uuidString
+        let response = """
+            {
+              "sessionId": "test-session-id",
+              "placementContext": {
+                "roktTagId": "123",
+                "pageInstanceGuid": "test-guid",
+                "token": "test-token"
+              },
+              "placements": [],
+              "plugins": [],
+              "token": ""
+            }
+            """
+
+        // Act - parse times are recorded even when the response has no renderable layouts
+        _ = roktInternalImplementation.processLayoutPageExecutePayload(
+            response, selectionId: selectionId, viewName: "test", attributes: [:]
+        )
+
+        // Assert - the parse window flows into the timing events request
+        timingsProcessor.setExperiencesRequestStartTime(selectionId: selectionId)
+        timingsProcessor.setPlacementInteractiveTime(selectionId: selectionId)
+        timingsProcessor.processTimingsRequest(selectionId: selectionId)
+        let eventsRequest = RoktAPIHelperSpy.lastTimingEventsRequest
+        XCTAssertNotNil(eventsRequest)
+        XCTAssertTrue(eventsRequest!.timings.contains { $0.name == .experienceJsonParseStart })
+        XCTAssertTrue(eventsRequest!.timings.contains { $0.name == .experienceJsonParseEnd })
+        RoktAPIHelperSpy.reset()
+    }
+
     // MARK: - setSessionId Tests
 
     func test_setSessionId_updatesSessionManager() {

--- a/Tests/Rokt_WidgetTests/TestRoktUXEventPlacementCount.swift
+++ b/Tests/Rokt_WidgetTests/TestRoktUXEventPlacementCount.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Rokt_Widget
+@testable internal import RoktUXHelper
+
+/// The SDK-only `loadLayout(pageModel:)` overload no longer takes `onLoad`/`onUnload`
+/// view-lifecycle closures. The loaded-placement count that drives `clearCallBacks`
+/// (state-bag teardown) is now derived from the RoktUXEvent lifecycle stream in
+/// `callOnRoktUXEvent`. These tests pin that wiring:
+///   - load   ← `LayoutInteractive`            (increments once per placement)
+///   - unload ← `LayoutClosed` / `LayoutCompleted` (decrements once per placement)
+/// so the count stays balanced and the state bag is removed exactly when the last
+/// placement goes (the `StateBagManager` removes the bag when the count hits 0).
+final class TestRoktUXEventPlacementCount: XCTestCase {
+
+    private let executeId = "test-execute-id"
+
+    /// Seeds a fresh implementation with a state bag whose `loadedPlacements` is 0
+    /// (the default for a newly-created `ExecuteStateBag`).
+    private func makeImplementation() -> (RoktInternalImplementation, ExecuteStateBag) {
+        let impl = RoktInternalImplementation()
+        let bag = ExecuteStateBag(uxHelper: nil, onRoktEvent: nil)
+        impl.stateManager.addState(id: executeId, state: bag)
+        return (impl, bag)
+    }
+
+    func test_layoutInteractive_increasesLoadedPlacements() {
+        let (impl, bag) = makeImplementation()
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutInteractive(layoutId: "l1"))
+
+        XCTAssertEqual(bag.loadedPlacements, 1)
+    }
+
+    func test_layoutClosed_afterInteractive_decrementsAndTearsDown() {
+        let (impl, _) = makeImplementation()
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutInteractive(layoutId: "l1"))
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutClosed(layoutId: "l1"))
+
+        // Count returned to 0 → the state bag is removed (clearCallBacks fired).
+        XCTAssertNil(impl.stateManager.getState(id: executeId))
+    }
+
+    func test_layoutCompleted_afterInteractive_decrementsAndTearsDown() {
+        let (impl, _) = makeImplementation()
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutInteractive(layoutId: "l1"))
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutCompleted(layoutId: "l1"))
+
+        XCTAssertNil(impl.stateManager.getState(id: executeId))
+    }
+
+    /// Two placements under one execute: the count must reach 0 only after BOTH close.
+    func test_multiPlacement_countStaysBalanced() {
+        let (impl, bag) = makeImplementation()
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutInteractive(layoutId: "l1"))
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutInteractive(layoutId: "l2"))
+        XCTAssertEqual(bag.loadedPlacements, 2)
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutClosed(layoutId: "l1"))
+        XCTAssertEqual(impl.stateManager.getState(id: executeId)?.loadedPlacements, 1)
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutCompleted(layoutId: "l2"))
+        XCTAssertNil(impl.stateManager.getState(id: executeId))
+    }
+
+    /// LayoutReady is forwarded to the partner but must NOT count as a load — otherwise
+    /// the count would double (Ready + Interactive both fire per placement) and never reach 0.
+    func test_layoutReady_doesNotAffectPlacementCount() {
+        let (impl, bag) = makeImplementation()
+
+        impl.callOnRoktUXEvent(executeId, uxEvent: RoktUXEvent.LayoutReady(layoutId: "l1"))
+
+        XCTAssertEqual(bag.loadedPlacements, 0)
+        XCTAssertNotNil(impl.stateManager.getState(id: executeId))
+    }
+}

--- a/Tests/Rokt_WidgetTests/TestRoktUXEventPlacementCount.swift
+++ b/Tests/Rokt_WidgetTests/TestRoktUXEventPlacementCount.swift
@@ -2,20 +2,12 @@ import XCTest
 @testable import Rokt_Widget
 @testable internal import RoktUXHelper
 
-/// The SDK-only `loadLayout(pageModel:)` overload no longer takes `onLoad`/`onUnload`
-/// view-lifecycle closures. The loaded-placement count that drives `clearCallBacks`
-/// (state-bag teardown) is now derived from the RoktUXEvent lifecycle stream in
-/// `callOnRoktUXEvent`. These tests pin that wiring:
-///   - load   ← `LayoutInteractive`            (increments once per placement)
-///   - unload ← `LayoutClosed` / `LayoutCompleted` (decrements once per placement)
-/// so the count stays balanced and the state bag is removed exactly when the last
-/// placement goes (the `StateBagManager` removes the bag when the count hits 0).
+/// The loaded-placement count that gates `clearCallBacks` is derived from the RoktUXEvent
+/// lifecycle (LayoutInteractive loads; LayoutClosed/LayoutCompleted unload). These pin the balance.
 final class TestRoktUXEventPlacementCount: XCTestCase {
 
     private let executeId = "test-execute-id"
 
-    /// Seeds a fresh implementation with a state bag whose `loadedPlacements` is 0
-    /// (the default for a newly-created `ExecuteStateBag`).
     private func makeImplementation() -> (RoktInternalImplementation, ExecuteStateBag) {
         let impl = RoktInternalImplementation()
         let bag = ExecuteStateBag(uxHelper: nil, onRoktEvent: nil)


### PR DESCRIPTION
## What

Adds first-class performance instrumentation for the two most expensive steps of rendering a Rokt placement on iOS, and removes a redundant second parse of the experiences response.

- **Single parse** — the experiences JSON is parsed once by RoktUXHelper (`RoktUX.parseExperience`); the resulting page model is rendered via the new `loadLayout(pageModel:)` overload, so the SDK no longer decodes the same response a second time.
- **Performance metrics** — experiences-API latency (`experiencesRequestStart` / `experiencesRequestEnd`) and JSON-parse duration (`fn:experienceJsonParse:start` / `end`) are reported to `POST /v1/timings/events` at placement-interactive, alongside the existing `/v1/timings` send (unchanged). Cache hits are excluded.
- **Minimal payload** — the events body carries only `timingMetrics` (plus optional plugin attributes). Fields that are web-SDK-only or set server-side (`isCached`, `expectedTti`, `eventTime`) are no longer sent; session / page / SDK metadata travels via the existing request headers.
- **Lifecycle via events** — the SDK-only `loadLayout(pageModel:)` overload takes no `onLoad` / `onUnload` closures. Placement load/unload bookkeeping (which gates `clearCallBacks`) is now driven by the `RoktUXEvent` stream: `LayoutInteractive` → load, `LayoutClosed` / `LayoutCompleted` → unload (`LayoutFailure` already handled).

## Dependency

Requires **RoktUXHelper 0.12.0** (published) — pinned in `Package.swift` (`from: "0.12.0"`) and `Rokt-Widget.podspec` (`>= 0.12.0`).

## Testing

Verified with `xcodebuild test` on the iOS Simulator against the published 0.12.0:
- Timings processor — minimal body, non-cached gate, dedupe, `fn:` metric names.
- Placement-count balance driven purely by lifecycle events (`LayoutInteractive` / `Closed` / `Completed`); `LayoutReady` does not double-count.
- Event mapping / forwarding unchanged; no forward-payment regression.
<img width="606" height="425" alt="Screenshot 2026-06-12 at 1 20 19 pm" src="https://github.com/user-attachments/assets/957ce7bc-4944-4b66-aabe-d5ba2c68358b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
