### PR TITLE
refactor: convert TxnSessionManager to an actor

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -1,7 +1,7 @@
 // periphery:ignore:all - v2 session store; token-refresh/session-id members are consumed by the upcoming v2 offers/events path
 import Foundation
 
-internal final class TxnSessionManager {
+internal actor TxnSessionManager {
     // Persistence keys for the v2 path, separate from the legacy SessionManager's `rokt.*` keys.
     private enum Keys {
         static let tagId = "ROKT_TXN_TAG_ID"
@@ -11,13 +11,14 @@ internal final class TxnSessionManager {
     }
 
     private let clock: () -> Date
-    private let lock = NSLock()
 
     // nil disables persistence (in-memory only), preserving the lightweight test setup.
     private let roktTagId: String?
     private let store: TxnSessionStore?
 
-    private(set) var boundTagId: String?
+    // Immutable, so it is read synchronously outside the actor in resolveTxnSessionManager.
+    nonisolated let boundTagId: String?
+
     private var sessionId: String?
     private var token: String?
     private var expiresAt: Date?
@@ -42,29 +43,21 @@ internal final class TxnSessionManager {
     }
 
     var currentSessionId: String? {
-        lock.lock()
-        defer { lock.unlock() }
-        return sessionId
+        sessionId
     }
 
     var isExpired: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return isExpiredLocked
+        hasExpired
     }
 
     // nil when there is no token or it has expired; the server then mints a
     // fresh session rather than returning 401.
     var authorizationHeader: String? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let token, !isExpiredLocked else { return nil }
+        guard let token, !hasExpired else { return nil }
         return "Bearer \(token)"
     }
 
     func update(sessionId: String, sessionToken: TxnSessionToken) {
-        lock.lock()
-        defer { lock.unlock() }
         self.sessionId = sessionId
         token = sessionToken.token
         expiresAt = sessionToken.expiresAtDate
@@ -73,16 +66,12 @@ internal final class TxnSessionManager {
 
     // Token-only refresh for offers/events responses, keeping the session id.
     func update(sessionToken: TxnSessionToken) {
-        lock.lock()
-        defer { lock.unlock() }
         token = sessionToken.token
         expiresAt = sessionToken.expiresAtDate
         persist(includeSessionId: false)
     }
 
     func clear() {
-        lock.lock()
-        defer { lock.unlock() }
         sessionId = nil
         token = nil
         expiresAt = nil
@@ -93,7 +82,7 @@ internal final class TxnSessionManager {
         store.removeValue(forKey: Keys.expiresAt)
     }
 
-    private var isExpiredLocked: Bool {
+    private var hasExpired: Bool {
         guard let expiresAt else { return true }
         return clock() >= expiresAt
     }
@@ -112,7 +101,7 @@ internal final class TxnSessionManager {
             .map { Date(timeIntervalSince1970: $0/1000) }
         // Drop a persisted-but-expired token so we never start with stale state;
         // an expired JWT is dead server-side and a fresh session is minted at init.
-        if isExpiredLocked {
+        if hasExpired {
             clear()
         }
     }

--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -50,7 +50,7 @@ internal struct TxnEventService {
         guard !events.isEmpty else { return }
         guard let client else { throw TxnEventError.invalidBaseURL }
 
-        let authToken = sessionManager.authorizationHeader
+        let authToken = await sessionManager.authorizationHeader
 
         var attempt = 0
         while true {
@@ -71,7 +71,7 @@ internal struct TxnEventService {
                 if let data,
                    let decoded = try? JSONDecoder().decode(TxnEventsResponse.self, from: data),
                    let sessionToken = decoded.sessionToken {
-                    sessionManager.update(sessionToken: sessionToken)
+                    await sessionManager.update(sessionToken: sessionToken)
                 }
                 return
             } catch let error where isRetryable(error: error) && attempt < maxRetries {

--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -56,10 +56,11 @@ internal struct TxnInitService {
 
         httpClient.updateTimeout(timeout: requestTimeout)
 
+        let authToken = await sessionManager.authorizationHeader
         let client = V2SessionsInitClient(
             baseURL: baseURL,
             accountId: accountId,
-            authToken: sessionManager.authorizationHeader,
+            authToken: authToken,
             sdkVersion: sdkVersion,
             httpClient: httpClient
         )
@@ -87,7 +88,7 @@ internal struct TxnInitService {
                 }
 
                 let decoded = try JSONDecoder().decode(TxnInitResponse.self, from: data)
-                sessionManager.update(sessionId: decoded.sessionId, sessionToken: decoded.sessionToken)
+                await sessionManager.update(sessionId: decoded.sessionId, sessionToken: decoded.sessionToken)
                 return InitResult(response: decoded, featureFlags: decoded.featureFlags.toInitFeatureFlags())
             } catch let error where isRetryable(error: error) && attempt < maxRetries {
                 try await sleep(backoffDelay(attempt: attempt))

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -950,18 +950,6 @@ class RoktInternalImplementation {
         )
     }
 
-    // Reuse the manager for the same tag so the minted token survives across calls;
-    // a new tag triggers a fresh manager, which clears any stored session not bound to it.
-    private func resolveTxnSessionManager(roktTagId: String) -> TxnSessionManager {
-        if let existing = txnSessionManager, existing.boundTagId == roktTagId {
-            return existing
-        }
-        let manager = TxnSessionManager(roktTagId: roktTagId)
-        txnSessionManager = manager
-        return manager
-    }
-
-
     private static func statusCode(from error: Error) -> Int? {
         if case TxnInitService.TxnInitError.unexpectedStatusCode(let code) = error {
             return code

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -950,6 +950,18 @@ class RoktInternalImplementation {
         )
     }
 
+    // Reuse the manager for the same tag so the minted token survives across calls;
+    // a new tag triggers a fresh manager, which clears any stored session not bound to it.
+    private func resolveTxnSessionManager(roktTagId: String) -> TxnSessionManager {
+        if let existing = txnSessionManager, existing.boundTagId == roktTagId {
+            return existing
+        }
+        let manager = TxnSessionManager(roktTagId: roktTagId)
+        txnSessionManager = manager
+        return manager
+    }
+
+
     private static func statusCode(from error: Error) -> Int? {
         if case TxnInitService.TxnInitError.unexpectedStatusCode(let code) = error {
             return code

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -23,58 +23,78 @@ final class TestTxnSessionManager: XCTestCase {
         return TxnSessionToken(token: value, expiresAt: expiryMs)
     }
 
-    func test_initialState_hasNoSession() {
-        XCTAssertNil(manager.currentSessionId)
-        XCTAssertNil(manager.authorizationHeader)
-        XCTAssertTrue(manager.isExpired)
+    func test_initialState_hasNoSession() async {
+        let sessionId = await manager.currentSessionId
+        let header = await manager.authorizationHeader
+        let isExpired = await manager.isExpired
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertTrue(isExpired)
     }
 
-    func test_update_storesSessionIdAndAuthorizationHeader() {
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
-        XCTAssertEqual(manager.currentSessionId, "sid")
-        XCTAssertEqual(manager.authorizationHeader, "Bearer jwt")
-        XCTAssertFalse(manager.isExpired)
+    func test_update_storesSessionIdAndAuthorizationHeader() async {
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
+        let sessionId = await manager.currentSessionId
+        let header = await manager.authorizationHeader
+        let isExpired = await manager.isExpired
+        XCTAssertEqual(sessionId, "sid")
+        XCTAssertEqual(header, "Bearer jwt")
+        XCTAssertFalse(isExpired)
     }
 
-    func test_expiredToken_dropsAuthorizationHeader_butRetainsSessionId() {
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
+    func test_expiredToken_dropsAuthorizationHeader_butRetainsSessionId() async {
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
         now = now.addingTimeInterval(61)
-        XCTAssertNil(manager.authorizationHeader)
-        XCTAssertTrue(manager.isExpired)
-        XCTAssertEqual(manager.currentSessionId, "sid")
+        let header = await manager.authorizationHeader
+        let isExpired = await manager.isExpired
+        let sessionId = await manager.currentSessionId
+        XCTAssertNil(header)
+        XCTAssertTrue(isExpired)
+        XCTAssertEqual(sessionId, "sid")
     }
 
-    func test_expiryBoundary_isExpiredAtExactExpiry() {
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
+    func test_expiryBoundary_isExpiredAtExactExpiry() async {
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
         now = now.addingTimeInterval(60)
-        XCTAssertTrue(manager.isExpired)
-        XCTAssertNil(manager.authorizationHeader)
+        let isExpired = await manager.isExpired
+        let header = await manager.authorizationHeader
+        XCTAssertTrue(isExpired)
+        XCTAssertNil(header)
     }
 
-    func test_tokenOnlyUpdate_keepsSessionId_andRefreshesToken() {
-        manager.update(sessionId: "sid", sessionToken: token("old", expiresInSeconds: 10))
-        manager.update(sessionToken: token("new", expiresInSeconds: 1800))
-        XCTAssertEqual(manager.currentSessionId, "sid")
-        XCTAssertEqual(manager.authorizationHeader, "Bearer new")
-        XCTAssertFalse(manager.isExpired)
+    func test_tokenOnlyUpdate_keepsSessionId_andRefreshesToken() async {
+        await manager.update(sessionId: "sid", sessionToken: token("old", expiresInSeconds: 10))
+        await manager.update(sessionToken: token("new", expiresInSeconds: 1800))
+        let sessionId = await manager.currentSessionId
+        let header = await manager.authorizationHeader
+        let isExpired = await manager.isExpired
+        XCTAssertEqual(sessionId, "sid")
+        XCTAssertEqual(header, "Bearer new")
+        XCTAssertFalse(isExpired)
     }
 
-    func test_refresh_extendsExpiryOnAnExpiredSession() {
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
+    func test_refresh_extendsExpiryOnAnExpiredSession() async {
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
         now = now.addingTimeInterval(61)
-        XCTAssertTrue(manager.isExpired)
+        let expiredBeforeRefresh = await manager.isExpired
+        XCTAssertTrue(expiredBeforeRefresh)
 
-        manager.update(sessionToken: token("jwt2", expiresInSeconds: 1800))
-        XCTAssertFalse(manager.isExpired)
-        XCTAssertEqual(manager.authorizationHeader, "Bearer jwt2")
+        await manager.update(sessionToken: token("jwt2", expiresInSeconds: 1800))
+        let isExpired = await manager.isExpired
+        let header = await manager.authorizationHeader
+        XCTAssertFalse(isExpired)
+        XCTAssertEqual(header, "Bearer jwt2")
     }
 
-    func test_clear_resetsAllState() {
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
-        manager.clear()
-        XCTAssertNil(manager.currentSessionId)
-        XCTAssertNil(manager.authorizationHeader)
-        XCTAssertTrue(manager.isExpired)
+    func test_clear_resetsAllState() async {
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
+        await manager.clear()
+        let sessionId = await manager.currentSessionId
+        let header = await manager.authorizationHeader
+        let isExpired = await manager.isExpired
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertTrue(isExpired)
     }
 
     // MARK: - Persistence
@@ -92,86 +112,100 @@ final class TestTxnSessionManager: XCTestCase {
         TxnSessionManager(roktTagId: tagId, store: store, clock: { self.now })
     }
 
-    func test_persistence_restoresValidSessionForSameTagId() {
+    func test_persistence_restoresValidSessionForSameTagId() async {
         let store = InMemoryStore()
-        persistentManager(tagId: "tag-1", store: store)
+        await persistentManager(tagId: "tag-1", store: store)
             .update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
 
         let restored = persistentManager(tagId: "tag-1", store: store)
 
-        XCTAssertEqual(restored.currentSessionId, "sid")
-        XCTAssertEqual(restored.authorizationHeader, "Bearer jwt")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "sid")
+        XCTAssertEqual(header, "Bearer jwt")
         XCTAssertEqual(restored.boundTagId, "tag-1")
     }
 
-    func test_persistence_clearsWhenTagIdDiffers() {
+    func test_persistence_clearsWhenTagIdDiffers() async {
         let store = InMemoryStore()
-        persistentManager(tagId: "tag-1", store: store)
+        await persistentManager(tagId: "tag-1", store: store)
             .update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
 
         let other = persistentManager(tagId: "tag-2", store: store)
 
-        XCTAssertNil(other.currentSessionId)
-        XCTAssertNil(other.authorizationHeader)
+        let sessionId = await other.currentSessionId
+        let header = await other.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
     }
 
-    func test_persistence_switchingTagIdWipesPreviousAccountSession() {
+    func test_persistence_switchingTagIdWipesPreviousAccountSession() async {
         let store = InMemoryStore()
-        persistentManager(tagId: "tag-1", store: store)
+        await persistentManager(tagId: "tag-1", store: store)
             .update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
 
         _ = persistentManager(tagId: "tag-2", store: store)
 
         // Verify the data was wiped, not just skipped on restore.
         let backToTag1 = persistentManager(tagId: "tag-1", store: store)
-        XCTAssertNil(backToTag1.currentSessionId)
-        XCTAssertNil(backToTag1.authorizationHeader)
+        let sessionId = await backToTag1.currentSessionId
+        let header = await backToTag1.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
     }
 
-    func test_persistence_dropsExpiredTokenOnLoad() {
+    func test_persistence_dropsExpiredTokenOnLoad() async {
         let store = InMemoryStore()
-        persistentManager(tagId: "tag-1", store: store)
+        await persistentManager(tagId: "tag-1", store: store)
             .update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 60))
         now = now.addingTimeInterval(61)
 
         let restored = persistentManager(tagId: "tag-1", store: store)
 
-        XCTAssertNil(restored.currentSessionId)
-        XCTAssertNil(restored.authorizationHeader)
-        XCTAssertTrue(restored.isExpired)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        let isExpired = await restored.isExpired
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertTrue(isExpired)
     }
 
-    func test_persistence_tokenOnlyRefreshDoesNotLoseSessionIdAcrossLoads() {
+    func test_persistence_tokenOnlyRefreshDoesNotLoseSessionIdAcrossLoads() async {
         let store = InMemoryStore()
         let manager = persistentManager(tagId: "tag-1", store: store)
-        manager.update(sessionId: "sid", sessionToken: token("old", expiresInSeconds: 60))
-        manager.update(sessionToken: token("new", expiresInSeconds: 1800))
+        await manager.update(sessionId: "sid", sessionToken: token("old", expiresInSeconds: 60))
+        await manager.update(sessionToken: token("new", expiresInSeconds: 1800))
 
         let restored = persistentManager(tagId: "tag-1", store: store)
 
-        XCTAssertEqual(restored.currentSessionId, "sid")
-        XCTAssertEqual(restored.authorizationHeader, "Bearer new")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "sid")
+        XCTAssertEqual(header, "Bearer new")
     }
 
-    func test_persistence_clearRemovesPersistedSession() {
+    func test_persistence_clearRemovesPersistedSession() async {
         let store = InMemoryStore()
         let manager = persistentManager(tagId: "tag-1", store: store)
-        manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
+        await manager.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
 
-        manager.clear()
+        await manager.clear()
         let restored = persistentManager(tagId: "tag-1", store: store)
 
-        XCTAssertNil(restored.currentSessionId)
-        XCTAssertNil(restored.authorizationHeader)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
     }
 
-    func test_inMemoryManager_doesNotPersist() {
+    func test_inMemoryManager_doesNotPersist() async {
         // The clock-only initializer is in-memory; nothing should leak to the store.
         let store = InMemoryStore()
         let inMemory = TxnSessionManager(clock: { self.now })
-        inMemory.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
+        await inMemory.update(sessionId: "sid", sessionToken: token("jwt", expiresInSeconds: 1800))
 
         let persistent = persistentManager(tagId: "tag-1", store: store)
-        XCTAssertNil(persistent.currentSessionId)
+        let sessionId = await persistent.currentSessionId
+        XCTAssertNil(sessionId)
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -39,9 +39,9 @@ final class TestTxnEventService: XCTestCase {
         )
     }
 
-    private func storeValidToken(_ token: String = "stored-jwt") {
+    private func storeValidToken(_ token: String = "stored-jwt") async {
         let expiryMs = Int64(now.addingTimeInterval(1800).timeIntervalSince1970 * 1000)
-        sessionManager.update(sessionId: "session-1", sessionToken: TxnSessionToken(token: token, expiresAt: expiryMs))
+        await sessionManager.update(sessionId: "session-1", sessionToken: TxnSessionToken(token: token, expiresAt: expiryMs))
     }
 
     private func rotatedResponse(token: String = "rotated-jwt") -> Data {
@@ -61,17 +61,18 @@ final class TestTxnEventService: XCTestCase {
     }
 
     func test_send_success_rotatesSessionToken() async throws {
-        storeValidToken()
+        await storeValidToken()
         httpClient.results = [.success(status: 202, data: rotatedResponse())]
 
         try await makeService().send(events: sampleEvents())
 
-        XCTAssertEqual(sessionManager.authorizationHeader, "Bearer rotated-jwt")
+        let header = await sessionManager.authorizationHeader
+        XCTAssertEqual(header, "Bearer rotated-jwt")
         XCTAssertEqual(httpClient.callCount, 1)
     }
 
     func test_send_withValidToken_attachesAuthorizationAndDeviceHeaders() async throws {
-        storeValidToken()
+        await storeValidToken()
         httpClient.results = [.success(status: 202, data: rotatedResponse())]
 
         try await makeService().send(events: sampleEvents())
@@ -90,12 +91,13 @@ final class TestTxnEventService: XCTestCase {
     }
 
     func test_send_responseWithoutSessionToken_leavesTokenUnchanged() async throws {
-        storeValidToken("keep-jwt")
+        await storeValidToken("keep-jwt")
         httpClient.results = [.success(status: 202, data: Data(#"{ "event_ids": ["event-1"] }"#.utf8))]
 
         try await makeService().send(events: sampleEvents())
 
-        XCTAssertEqual(sessionManager.authorizationHeader, "Bearer keep-jwt")
+        let header = await sessionManager.authorizationHeader
+        XCTAssertEqual(header, "Bearer keep-jwt")
     }
 
     func test_send_retriesOnTransient5xx_thenSucceeds() async throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -57,10 +57,12 @@ final class TestTxnInitService: XCTestCase {
         httpClient.results = [.success(data: successJSON())]
         let result = try await makeService().initSession()
 
+        let storedSessionId = await sessionManager.currentSessionId
+        let storedHeader = await sessionManager.authorizationHeader
         XCTAssertEqual(result.response.sessionId, "sess-123")
         XCTAssertEqual(result.response.sessionToken.token, "minted-jwt")
-        XCTAssertEqual(sessionManager.currentSessionId, "sess-123")
-        XCTAssertEqual(sessionManager.authorizationHeader, "Bearer minted-jwt")
+        XCTAssertEqual(storedSessionId, "sess-123")
+        XCTAssertEqual(storedHeader, "Bearer minted-jwt")
         XCTAssertTrue(result.featureFlags.isEnabled(.roktTrackingStatus))
         XCTAssertTrue(result.featureFlags.isEnabled(.minimumPostPurchaseSchema))
         XCTAssertEqual(httpClient.capturedHeaders.count, 1)
@@ -68,7 +70,10 @@ final class TestTxnInitService: XCTestCase {
 
     func test_initSession_withValidStoredToken_sendsAuthorizationHeader() async throws {
         let expiryMs = Int64(now.addingTimeInterval(1800).timeIntervalSince1970 * 1000)
-        sessionManager.update(sessionId: "existing", sessionToken: TxnSessionToken(token: "stored-jwt", expiresAt: expiryMs))
+        await sessionManager.update(
+            sessionId: "existing",
+            sessionToken: TxnSessionToken(token: "stored-jwt", expiresAt: expiryMs)
+        )
         httpClient.results = [.success(data: successJSON())]
 
         _ = try await makeService().initSession()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

`TxnSessionManager` holds the v2 init session state (session id, bearer token, expiry) and is read/written from concurrent async contexts. It previously guarded that state with a manual `NSLock`. This PR converts it to a Swift `actor` so the compiler enforces serialized access, removing the hand-rolled locking and the class of bugs that come with it.

Stacked on top of the v2-init wiring PR.

Fixes [(issue)]

## What Has Changed

- Converted `TxnSessionManager` from a `final class` + `NSLock` to an `internal actor`.
- Removed all manual `lock()/unlock()` calls; mutable state is now actor-isolated.
- `boundTagId` is `nonisolated let` so it stays synchronously readable.
- Renamed the private `isExpiredLocked` helper to `hasExpired` (locking no longer relevant).
- `TxnInitService` now `await`s the actor-isolated `authorizationHeader` and `update(...)`.
- Updated `TxnSessionManager` / `TxnInitService` unit tests to async.

## How Has This Been Tested

- Updated and ran the `TxnSessionManager` and `TxnInitService` unit test suites.
- Verified the v2 init flow still mints/persists a session and that the bearer  token round-trips through the actor.

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
