### PR TITLE
ci: collect Codecov coverage for monorepo subtree packages

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -176,15 +176,39 @@ jobs:
           rm -rf "$DERIVED"
           mkdir -p "$DERIVED"
 
+          # Expose coverage artifacts to later steps before running tests so the
+          # upload (if: always()) still has them when tests fail.
+          echo "PKG_FLAG=$(basename "${{ matrix.package.path }}")" >> "$GITHUB_ENV"
+          echo "PKG_XCRESULT=${DERIVED}/Tests.xcresult" >> "$GITHUB_ENV"
+
           xcodebuild test \
             -scheme "$SCHEME" \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
             -derivedDataPath "$DERIVED" \
+            -resultBundlePath "${DERIVED}/Tests.xcresult" \
+            -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
             CODE_SIGN_IDENTITY= \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Install xcresultparser
+        if: always()
+        run: brew install xcresultparser
+
+      - name: Process coverage report
+        if: always()
+        run: |
+          xcresultparser --output-format cobertura "$PKG_XCRESULT" --project-root "$GITHUB_WORKSPACE" > "package-coverage.xml"
+
+      - name: Upload coverage report
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./package-coverage.xml
+          flags: ${{ env.PKG_FLAG }}
 
   ui-test:
     name: UI Tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,11 +3,41 @@ coverage:
     project:
       default:
         threshold: 1%
+        # Keep the gating SDK status scoped to the root module; mirrored
+        # subtree packages are tracked via their own flag/status below.
+        paths:
+          - "!Packages/.*"
+      rokt-payment-extension-ios:
+        threshold: 1%
+        flags:
+          - rokt-payment-extension-ios
     patch:
       default:
         threshold: 1%
-  ignore:
-    - Example/Tests
-    - Tests/Rokt_WidgetTests
-    - Tests/SizeReport
-    - Packages/
+        paths:
+          - "!Packages/.*"
+      rokt-payment-extension-ios:
+        threshold: 1%
+        flags:
+          - rokt-payment-extension-ios
+
+# Track each mirrored Packages/ subtree under its own flag so its coverage is
+# collected from the package-unit-tests job (see pull-request.yml).
+flag_management:
+  individual_flags:
+    - name: rokt-payment-extension-ios
+      paths:
+        - Packages/rokt-payment-extension-ios/Sources/.*
+
+component_management:
+  individual_components:
+    - component_id: rokt-payment-extension-ios
+      name: RoktPaymentExtension
+      paths:
+        - Packages/rokt-payment-extension-ios/Sources/**
+
+ignore:
+  - Example/Tests
+  - Tests/Rokt_WidgetTests
+  - Tests/SizeReport
+  - Packages/**/Tests/**


### PR DESCRIPTION
## Background

After the monorepo conversion, the `package-unit-tests` job runs the payment
extension's tests but never enables code coverage or uploads to Codecov, and the
root `codecov.yml` ignores `Packages/` wholesale. The payment extension therefore
has no Codecov flag, component, or coverage gating — changes to it are invisible
to Codecov. This wires coverage up for `Packages/` subtree packages.

This is CI/Codecov configuration only — no SDK source, API, or partner-facing
changes.

## What Has Changed

- **`.github/workflows/pull-request.yml`** (`package-unit-tests`): enable
  `-enableCodeCoverage YES` + `-resultBundlePath`, install `xcresultparser`,
  convert the result bundle to Cobertura, and upload to Codecov under a
  per-package flag derived from the package directory name (matrix-generic;
  mirrors the existing `unittests`/`ui-tests` flow). Coverage upload runs with
  `if: always()` so it still reports when tests fail.
- **`codecov.yml`**: stop ignoring `Packages/` sources (now only ignore
  `Packages/**/Tests/**`), add a `rokt-payment-extension-ios` flag + component,
  add a dedicated project/patch status for that flag, and scope the default
  SDK status to non-`Packages/` files so existing gates are unaffected.

## How Has This Been Tested

- Validated `codecov.yml` against the Codecov validator (`Valid!`).
- Confirmed both YAML files parse.
- The coverage collection/upload reuses the same xcresultparser → Cobertura →
  `codecov-action@v7` pattern already proven by the `unittests`/`ui-tests` jobs;
  full upload verification runs on this PR's CI.

## Notes

- Expect a one-time baseline shift for the new `rokt-payment-extension-ios`
  flag/component on the first run; subsequent PRs compare against it normally.
- Out of scope: the `mirror-package` job's push to
  `ROKT/rokt-payment-extension-ios` is separately rejected as non-fast-forward
  because that mirror has independent history. Left as-is per direction.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.