### PR TITLE
fix: keep in-app browser open for internal links on the last offer

### DIFF
--- a/Example/Tests/ValidLayoutOverlayTests.swift
+++ b/Example/Tests/ValidLayoutOverlayTests.swift
@@ -253,6 +253,38 @@ final class ValidLayoutOverlayTests: QuickSpec {
                         .toEventually(equal(roundedDate),
                                       timeout: .seconds(5))
                 }
+
+                // An internally-opened link presents Safari on top of the overlay. The completion
+                // (which on the last/only offer closes the placement) must be deferred until the
+                // user dismisses Safari, otherwise closing the placement would tear down the Safari
+                // controller it presents and dismiss it immediately.
+                it("internal link defers completion until Safari is dismissed") {
+                    expect(UIApplication.topViewController())
+                        .toEventually(beAnInstanceOf(RoktUXSwiftUIViewController.self), timeout: .seconds(19))
+                    guard let overlay = UIApplication.topViewController() else {
+                        fail("overlay not presented")
+                        return
+                    }
+                    let linkHandler = LinkHandler()
+                    let url = URL(string: "https://www.rokt.com")!
+                    var completionFired = false
+                    linkHandler.linkHandler(url: url, type: .internally(sessionId: nil), completionHandler: {
+                        completionFired = true
+                    })
+
+                    // Safari is presented and stays presented while the completion is deferred.
+                    expect(overlay.presentedViewController)
+                        .toEventually(beAnInstanceOf(SFSafariViewController.self), timeout: .seconds(5))
+                    expect(completionFired).to(beFalse())
+
+                    // When the user closes Safari the deferred completion runs.
+                    guard let safari = overlay.presentedViewController as? SFSafariViewController else {
+                        fail("Safari not presented")
+                        return
+                    }
+                    linkHandler.safariViewControllerDidFinish(safari)
+                    expect(completionFired).toEventually(beTrue(), timeout: .seconds(5))
+                }
             }
         }
     }

--- a/Sources/Rokt_Widget/Util/LinkHandler.swift
+++ b/Sources/Rokt_Widget/Util/LinkHandler.swift
@@ -2,12 +2,14 @@ import Foundation
 import SafariServices
 internal import RoktUXHelper
 
-class LinkHandler {
+class LinkHandler: NSObject {
     private static let urlDiagnosticCode = "[URL]"
 
     private var completionHandler: (() -> Void)?
 
-    init() {}
+    override init() {
+        super.init()
+    }
 
     private func openURL(url: URL, type: RoktUXOpenURLType) {
         func openExternalLink(_ url: URL) {
@@ -29,9 +31,8 @@ class LinkHandler {
             }
             let safariVC = SFSafariViewController(url: url)
             safariVC.modalPresentationStyle = .overFullScreen
-            UIApplication.topViewController()?.present(safariVC, animated: true, completion: { [weak self] in
-                self?.completionHandler?()
-            })
+            safariVC.delegate = self
+            UIApplication.topViewController()?.present(safariVC, animated: true)
         case .externally,
                 .passthrough:
             completionHandler?()
@@ -59,4 +60,16 @@ class LinkHandler {
         openURL(url: url, type: type)
     }
 
+}
+
+extension LinkHandler: SFSafariViewControllerDelegate {
+    // For internally-opened links the completion (offer progression / close) must run only
+    // once the in-app browser is actually dismissed. Firing it while Safari is still
+    // presented would, on the last/only offer, close the placement and tear down the
+    // Safari controller that the placement presents.
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        let handler = completionHandler
+        completionHandler = nil
+        handler?()
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

When a positive-CTA link is configured to open **internally** (in-app `SFSafariViewController`), tapping it on the **last/only offer** caused the in-app browser to appear and then immediately dismiss itself within about a second. Earlier offers were unaffected.

Root cause: the in-app browser is presented on top of the placement overlay (the overlay is its presenter). The link completion — which advances/closes the offer — was fired as soon as Safari finished presenting. On the last/only offer that completion closes the placement by calling `dismiss()` on the overlay. Because `dismiss()` dismisses whatever a controller is currently presenting, and the overlay was presenting Safari, UIKit dismissed **Safari** instead of the overlay. On non-last offers the completion only transitions to the next offer (no `dismiss()`), which is why the issue was specific to the last/only offer.

Fixes [(issue)]

## What Has Changed

- `LinkHandler` now becomes the `SFSafariViewControllerDelegate` and defers the link completion until the in-app browser is actually dismissed by the user (`safariViewControllerDidFinish`), instead of firing it the moment Safari finishes presenting.
- `LinkHandler` now inherits from `NSObject` (required to conform to `SFSafariViewControllerDelegate`).
- Added a regression test asserting that, for an internally-opened link, Safari stays presented and the completion only fires after the browser is dismissed.

## How Has This Been Tested

- Added/ran a unit test (`ValidLayoutOverlayTests` → "internal link defers completion until Safari is dismissed") on the iOS Simulator that drives the real `LinkHandler` against a presented placement overlay and verifies the deferred-completion behaviour.
- Manually traced and verified on the simulator that the in-app browser now stays open on the last/only offer and the placement closes cleanly only after the browser is dismissed.

## Notes

Behaviour change is limited to internally-opened links: the completion now runs on browser dismissal rather than on browser presentation, which also matches the intent of the close callback. External/passthrough link handling is unchanged.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.