### PR TITLE
fix(spm): raise swift-tools-version to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// Note: 5.5 is the minimum that supports .iOS(.v15) in PackageDescription.
 
 import PackageDescription
 


### PR DESCRIPTION
## Problem

SwiftPM consumers of `Rokt-Widget` on the 4.x line can't resolve the package under Xcode 16.x:

```
/Package.swift:8: error: 'v15' is unavailable
note: 'v15' was introduced in PackageDescription 5.5
xcodebuild: error: Could not resolve package dependencies (exit code 74)
```

## Root cause

4.16.5 raised the iOS deployment platform to `.iOS(.v15)` but left `Package.swift` at `// swift-tools-version:5.3`. `SupportedPlatform.IOSVersion.v15` was only introduced in PackageDescription 5.5, so the manifest (compiled with `-package-description-version 5.3.0`) is invalid and SwiftPM refuses it.

| Version | platform | tools-version | state |
|---|---|---|---|
| 4.16.4 | `.v12` | 5.3 | ✅ last good |
| 4.16.5 | `.v15` | 5.3 | ❌ first broken |

Because SwiftPM resolves the highest tag in `>= 4.15.0, < 5.0.0`, every consumer pinned to 4.x picks up the broken 4.16.5.

## Fix

Bump the manifest header `5.3 → 5.5` (the minimum that supports `.iOS(.v15)`). **Manifest-only — one line.**

### Scope note
This PR deliberately contains *only* the `Package.swift` tools-version change. The version bump, the binary URL/checksum, `CHANGELOG.md`, `Rokt-Widget.podspec` and `README.md` are all owned by the `release-draft` workflow (in `sdk-ios-source`) and are applied automatically at release time — so they are intentionally not touched here.

The `swift-tools-version` / `platforms` lines are *not* generated by `release-draft` (it only `sed`s the download URL + checksum), so this fix is persisted in this repo and will not regress on the next release.

## Verification

`swift package dump-package` evaluates cleanly — platform `ios 15.0`, `toolsVersion 5.5.0` (previously errored with `'v15' is unavailable`).

## Discovered via

React Native SDK iOS CI (Build & Test iOS) — unrelated to the change under test there; reproduces for any SwiftPM consumer on 4.x under Xcode 16.4. Once a release carrying this fix is published, that check passes with no RN-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)