### PR TITLE
fix(offers): address v2 offers wire-model review feedback

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme Rokt-Widget \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -178,7 +178,7 @@ jobs:
 
           xcodebuild test \
             -scheme "$SCHEME" \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -derivedDataPath "$DERIVED" \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -207,7 +207,7 @@ jobs:
           xcodebuild test \
             -project Example/rokt.xcodeproj \
             -scheme rokt-Example-MOCK \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
@@ -257,7 +257,7 @@ jobs:
 
       - name: Build Example App
         run: |
-          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
+          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
 
       - name: Run Periphery Scan
         run: periphery scan --format github-actions

--- a/Sources/Rokt_Widget/Models/TxnSelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/TxnSelectResponse.swift
@@ -210,14 +210,65 @@ internal struct TxnSelectLayoutVariant: Decodable, Equatable {
 internal struct TxnSelectOffer: Decodable, Equatable {
     let campaignId: String?
     let creative: TxnSelectCreative?
-    // Catalog items (shoppable ads) are kept on the wire model but deferred in
-    // the mapper; surfacing them is a follow-up PR.
-    let catalogItems: [TxnJSONValue]?
+    // Shoppable-ad catalog items; surfacing them to the render models is
+    // deferred to the mapper in a follow-up.
+    let catalogItems: [TxnSelectCatalogItem]?
 
     enum CodingKeys: String, CodingKey {
         case campaignId = "campaign_id"
         case creative
         case catalogItems = "catalog_items"
+    }
+}
+
+/// A shoppable catalog item on an offer. Only the fields the render model
+/// consumes are declared; the lenient decoder skips anything else on the wire.
+/// The `token` is echoed back on purchase events.
+internal struct TxnSelectCatalogItem: Decodable, Equatable {
+    let catalogItemId: String?
+    let instanceGuid: String?
+    let cartItemId: String?
+    let title: String?
+    let description: String?
+    let price: Double?
+    let originalPrice: Double?
+    let priceFormatted: String?
+    let originalPriceFormatted: String?
+    let currency: String?
+    let url: String?
+    let urlBehavior: String?
+    let signalType: String?
+    let minItemCount: Int?
+    let maxItemCount: Int?
+    let preSelectedQuantity: Int?
+    let providerData: String?
+    let linkedProductId: String?
+    let quantityMustBeSynchronized: Bool?
+    let images: [String: TxnSelectImage]?
+    let token: String?
+
+    enum CodingKeys: String, CodingKey {
+        case catalogItemId = "catalog_item_id"
+        case instanceGuid = "instance_guid"
+        case cartItemId = "cart_item_id"
+        case title
+        case description
+        case price
+        case originalPrice = "original_price"
+        case priceFormatted = "price_formatted"
+        case originalPriceFormatted = "original_price_formatted"
+        case currency
+        case url
+        case urlBehavior = "url_behavior"
+        case signalType = "signal_type"
+        case minItemCount = "min_item_count"
+        case maxItemCount = "max_item_count"
+        case preSelectedQuantity = "pre_selected_quantity"
+        case providerData = "provider_data"
+        case linkedProductId = "linked_product_id"
+        case quantityMustBeSynchronized = "quantity_must_be_synchronized"
+        case images
+        case token
     }
 }
 
@@ -317,42 +368,5 @@ internal struct TxnSelectRealTimeEvent: Decodable, Equatable {
     enum CodingKeys: String, CodingKey {
         case eventType = "event_type"
         case payload
-    }
-}
-
-/// Opaque JSON value for `catalog_items`, kept un-shaped on purpose: surfacing
-/// shoppable ads is deferred to the mapper in a follow-up. Decoded so the
-/// payload round-trips and is retained on the wire model, but not interpreted here.
-internal enum TxnJSONValue: Decodable, Equatable {
-    case null
-    case bool(Bool)
-    case int(Int)
-    case double(Double)
-    case string(String)
-    case array([TxnJSONValue])
-    case object([String: TxnJSONValue])
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if container.decodeNil() {
-            self = .null
-        } else if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
-        } else if let value = try? container.decode(Int.self) {
-            self = .int(value)
-        } else if let value = try? container.decode(Double.self) {
-            self = .double(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else if let value = try? container.decode([TxnJSONValue].self) {
-            self = .array(value)
-        } else if let value = try? container.decode([String: TxnJSONValue].self) {
-            self = .object(value)
-        } else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Unsupported JSON value"
-            )
-        }
     }
 }

--- a/Sources/Rokt_Widget/Models/TxnSelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/TxnSelectResponse.swift
@@ -305,13 +305,24 @@ internal struct TxnSelectIcon: Decodable, Equatable {
 /// Token lookup for a trackable entity, echoed back on `/v2/sessions/events`.
 internal struct TxnSelectEventDataEntry: Decodable, Equatable {
     let token: String
-    let events: [String: TxnJSONValue]?
+    let events: [String: TxnSelectRealTimeEvent]?
 }
 
-/// Opaque JSON value used for fields whose inner shape is deferred
-/// (`catalog_items`, per-entity `events`). Mirrors Android's use of
-/// `JsonObject`/`JsonElement`: decoded so the payload round-trips and is
-/// retained on the wire model, but not interpreted here.
+/// A pre-serialized real-time event payload, keyed by signal type. Mirrors the
+/// provider's typed event shape (and Android's `SelectRealTimeEvent`).
+internal struct TxnSelectRealTimeEvent: Decodable, Equatable {
+    let eventType: String?
+    let payload: String?
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case payload
+    }
+}
+
+/// Opaque JSON value for `catalog_items`, kept un-shaped on purpose: surfacing
+/// shoppable ads is deferred to the mapper in a follow-up. Decoded so the
+/// payload round-trips and is retained on the wire model, but not interpreted here.
 internal enum TxnJSONValue: Decodable, Equatable {
     case null
     case bool(Bool)

--- a/Tests/Rokt_WidgetTests/Resource/txn_offers.json
+++ b/Tests/Rokt_WidgetTests/Resource/txn_offers.json
@@ -43,20 +43,20 @@
                   "response_options_map": {
                     "positive": {
                       "id": "mock-response-option-positive",
-                      "action": "url",
+                      "action": "Url",
                       "instance_guid": "mock-response-option-instance-1",
                       "token": "mock-response-option-token",
-                      "signal_type": "signal-response",
+                      "signal_type": "SignalResponse",
                       "short_label": "Yes please",
                       "is_positive": true,
                       "url": "https://example.com/accept"
                     },
                     "negative": {
                       "id": "mock-response-option-negative",
-                      "action": "noFunc",
+                      "action": "CaptureOnly",
                       "instance_guid": "mock-response-option-instance-2",
                       "token": "mock-response-option-token-2",
-                      "signal_type": "signal-response",
+                      "signal_type": "SignalResponse",
                       "short_label": "No thanks",
                       "is_positive": false
                     }
@@ -71,7 +71,13 @@
   ],
   "event_data": {
     "mock-creative-instance-1": {
-      "token": "mock-event-token"
+      "token": "mock-event-token",
+      "events": {
+        "SignalResponse": {
+          "event_type": "SignalResponse",
+          "payload": "{\"metadata\":[]}"
+        }
+      }
     }
   }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnOffersFixture.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnOffersFixture.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Rokt_Widget
+
+/// Guards the bundled mock offers fixture (`txn_offers.json`): proves it decodes
+/// into `TxnSelectResponse` and that its response-option `action` / `signal_type`
+/// values are ones the renderer recognizes. Mirrors Android's `TxnOffersFixtureTest`
+/// — the same fixture seeds the offline mock offers path, so an unrecognized
+/// action (or a fixture that fails to decode) silently breaks that path.
+final class TestTxnOffersFixture: XCTestCase {
+
+    // Values the renderer's `Action` / `RoktUXSignalType` enums recognize; the
+    // mapper later coerces anything outside them to `.unknown`.
+    private let recognizedActions: Set<String> = ["Url", "CaptureOnly", "ExternalPaymentTrigger"]
+    private let recognizedSignalTypes: Set<String> = ["SignalResponse", "SignalGatedResponse"]
+
+    private func loadFixture() throws -> TxnSelectResponse {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: "txn_offers", withExtension: "json"),
+            "txn_offers.json missing from the test bundle"
+        )
+        return try JSONDecoder().decode(TxnSelectResponse.self, from: Data(contentsOf: url))
+    }
+
+    private func responseOptions(_ response: TxnSelectResponse) -> [TxnSelectResponseOption] {
+        (response.plugins ?? [])
+            .compactMap { $0.plugin?.config?.slots }
+            .flatMap { $0 }
+            .compactMap { $0.offer?.creative?.responseOptionsMap?.values }
+            .flatMap { Array($0) }
+    }
+
+    func test_fixtureDecodesIntoSelectResponse() throws {
+        let response = try loadFixture()
+
+        XCTAssertFalse(response.sessionId.isEmpty)
+        XCTAssertFalse(response.sessionToken.token.isEmpty)
+
+        let config = try XCTUnwrap(response.plugins?.first?.plugin?.config)
+        XCTAssertFalse(config.slots.isEmpty)
+        // DCUI schemas stay as pre-serialized strings.
+        XCTAssertFalse(try XCTUnwrap(config.outerLayoutSchema).isEmpty)
+
+        let slot = try XCTUnwrap(config.slots.first)
+        XCTAssertFalse(try XCTUnwrap(slot.layoutVariant?.layoutVariantSchema).isEmpty)
+        XCTAssertNotNil(slot.offer?.creative)
+    }
+
+    func test_fixtureResponseOptionsUseRecognizedActionAndSignalType() throws {
+        let options = responseOptions(try loadFixture())
+
+        XCTAssertFalse(options.isEmpty)
+        for option in options {
+            XCTAssertTrue(
+                recognizedActions.contains(try XCTUnwrap(option.action)),
+                "Unrecognized action: \(option.action ?? "nil")"
+            )
+            XCTAssertTrue(
+                recognizedSignalTypes.contains(try XCTUnwrap(option.signalType)),
+                "Unrecognized signal_type: \(option.signalType ?? "nil")"
+            )
+        }
+    }
+
+    func test_fixtureEventDataDecodesTypedRealTimeEvents() throws {
+        let response = try loadFixture()
+
+        let entry = try XCTUnwrap(response.eventData?["mock-creative-instance-1"])
+        XCTAssertFalse(entry.token.isEmpty)
+
+        let event = try XCTUnwrap(entry.events?["SignalResponse"])
+        XCTAssertEqual(event.eventType, "SignalResponse")
+        XCTAssertNotNil(event.payload)
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnSelectSerialization.swift
@@ -169,29 +169,9 @@ final class TestTxnSelectSerialization: XCTestCase {
         XCTAssertEqual(response.sessionId, "session-123")
     }
 
-    func test_response_decodesCatalogItemsButKeepsThemDeferred() throws {
-        // catalog_items is retained on the wire model (shoppable ads) but the
-        // mapper surfacing them is a later PR.
-        let payload = """
-        {
-          "session_id": "session-123",
-          "session_token": { "token": "t", "expires_at": 1 },
-          "plugins": [
-            { "plugin": { "config": { "slots": [
-              { "offer": { "campaign_id": "c1", "catalog_items": [ { "id": "cat-1" } ] } }
-            ] } } }
-          ]
-        }
-        """
-
-        let response = try decode(payload)
-        let offer = try XCTUnwrap(response.plugins?.first?.plugin?.config?.slots.first?.offer)
-        XCTAssertEqual(offer.campaignId, "c1")
-        XCTAssertNotNil(offer.catalogItems)
-    }
-
-    func test_response_catalogItemsRoundTripEveryJSONValueKind() throws {
-        // catalog_items stays opaque, so its decode must round-trip every JSON kind.
+    func test_response_decodesTypedCatalogItems() throws {
+        // catalog_items decodes into the typed model (mapping to render models is
+        // still deferred to the mapper). Unknown wire keys are tolerated.
         let payload = """
         {
           "session_id": "session-123",
@@ -201,11 +181,14 @@ final class TestTxnSelectSerialization: XCTestCase {
               { "offer": { "campaign_id": "c1", "catalog_items": [
                 {
                   "catalog_item_id": "cat-1",
-                  "min_item_count": 1,
+                  "title": "Sample item",
                   "price": 9.99,
+                  "currency": "USD",
+                  "min_item_count": 1,
                   "quantity_must_be_synchronized": true,
-                  "images": ["light", "dark"],
-                  "provider_data": null
+                  "images": { "hero": { "light": "light.png", "dark": "dark.png" } },
+                  "token": "catalog-token",
+                  "unexpected_field": "ignored"
                 }
               ] } }
             ] } } }
@@ -214,17 +197,16 @@ final class TestTxnSelectSerialization: XCTestCase {
         """
 
         let response = try decode(payload)
-        let items = try XCTUnwrap(
-            response.plugins?.first?.plugin?.config?.slots.first?.offer?.catalogItems
+        let item = try XCTUnwrap(
+            response.plugins?.first?.plugin?.config?.slots.first?.offer?.catalogItems?.first
         )
-        XCTAssertEqual(items.count, 1)
-        XCTAssertEqual(items.first, .object([
-            "catalog_item_id": .string("cat-1"),
-            "min_item_count": .int(1),
-            "price": .double(9.99),
-            "quantity_must_be_synchronized": .bool(true),
-            "images": .array([.string("light"), .string("dark")]),
-            "provider_data": .null
-        ]))
+        XCTAssertEqual(item.catalogItemId, "cat-1")
+        XCTAssertEqual(item.title, "Sample item")
+        XCTAssertEqual(item.price, 9.99)
+        XCTAssertEqual(item.currency, "USD")
+        XCTAssertEqual(item.minItemCount, 1)
+        XCTAssertEqual(item.quantityMustBeSynchronized, true)
+        XCTAssertEqual(item.images?["hero"]?.light, "light.png")
+        XCTAssertEqual(item.token, "catalog-token")
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnSelectSerialization.swift
@@ -189,4 +189,42 @@ final class TestTxnSelectSerialization: XCTestCase {
         XCTAssertEqual(offer.campaignId, "c1")
         XCTAssertNotNil(offer.catalogItems)
     }
+
+    func test_response_catalogItemsRoundTripEveryJSONValueKind() throws {
+        // catalog_items stays opaque, so its decode must round-trip every JSON kind.
+        let payload = """
+        {
+          "session_id": "session-123",
+          "session_token": { "token": "t", "expires_at": 1 },
+          "plugins": [
+            { "plugin": { "config": { "slots": [
+              { "offer": { "campaign_id": "c1", "catalog_items": [
+                {
+                  "catalog_item_id": "cat-1",
+                  "min_item_count": 1,
+                  "price": 9.99,
+                  "quantity_must_be_synchronized": true,
+                  "images": ["light", "dark"],
+                  "provider_data": null
+                }
+              ] } }
+            ] } } }
+          ]
+        }
+        """
+
+        let response = try decode(payload)
+        let items = try XCTUnwrap(
+            response.plugins?.first?.plugin?.config?.slots.first?.offer?.catalogItems
+        )
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first, .object([
+            "catalog_item_id": .string("cat-1"),
+            "min_item_count": .int(1),
+            "price": .double(9.99),
+            "quantity_must_be_synchronized": .bool(true),
+            "images": .array([.string("light"), .string("dark")]),
+            "provider_data": .null
+        ]))
+    }
 }


### PR DESCRIPTION
## What

Addresses the review feedback on the v2 offers wire model from #208, plus full `catalog_items` typing. Stacks on `feat/v2-offers-network`.

## Changes

- **`events` is now typed** (#5 — "is this an unknown type?"). `event_data[].events` was an opaque JSON map; it's now `TxnSelectRealTimeEvent { event_type, payload }`, matching the v2 offers response contract and the Android `SelectRealTimeEvent` shape.
- **`catalog_items` is now typed too.** Replaced the opaque per-item JSON value with a typed `TxnSelectCatalogItem` mirroring Android's `SelectCatalogItem`, which removes the opaque `TxnJSONValue` entirely. Mapping the items into the render models stays deferred to the mapper.
- **Fixture action / signal values corrected** (#2 — "is this a valid action?"). `noFunc`, lowercase `url`, and `signal-response` aren't values the renderer recognizes (`Action` = `Url`/`CaptureOnly`/`ExternalPaymentTrigger`; `RoktUXSignalType` = `SignalResponse`/`SignalGatedResponse`) — they'd fall back to `.unknown`. Updated to `Url` (positive), `CaptureOnly` (decline), and `SignalResponse`.
- **Fixture is now used** (#1 — "is this used somewhere?"). Moved `txn_offers.json` into the SPM test target and added `TestTxnOffersFixture`, which decodes it and asserts every response option carries a recognized action / signal type — mirroring the Android offers fixture test, and seeding the offline mock offers path.

On the two nullability threads (#3, #4): **no code change.** The optional fields map to `omitempty` value types on the wire (absent-when-empty, never `null`); the genuinely-guaranteed fields (`session_id`, `session_token`, `event_data[].token`) already fail early as required decodes. Reasoning is in the thread replies.

## CI

Also bumps the PR-test simulator from `iPhone 16 Pro` → `iPhone 17 Pro` in `pull-request.yml`. The `macos-latest-xlarge` image (Xcode 26.3) no longer ships an iPhone 16 Pro, so `xcodebuild` was failing at destination resolution before any test ran. This aligns with `pact-consumer.yml`, which already targets iPhone 17 Pro. It's a repo-wide infra fix kept as its own commit, so it can be split into a standalone PR if preferred.

## Verification

`TestTxnOffersFixture` + `TestTxnSelectSerialization` pass on the iOS simulator (iPhone 17 Pro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)