### PR TITLE
pact: bring iOS consumer to parity with Android (blocking gate + contract content)

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,5 +1,8 @@
 name: Pact Consumer
 
+# Generates the consumer pact on every PR, publishes it to the broker on
+# same-repo PR pushes and main, then runs a blocking can-i-deploy check.
+
 on:
   pull_request:
   push:
@@ -7,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # paths-filter lists changed files via the PR files API
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,7 +24,7 @@ jobs:
       contract: ${{ steps.filter.outputs.contract }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           # paths-filter needs history to diff against the previous commit on push.
@@ -32,9 +36,10 @@ jobs:
         with:
           filters: |
             contract:
-              - 'Sources/Rokt_Widget/Networking/TxnOffersClient.swift'
+              - 'Sources/Rokt_Widget/Networking/OffersClient.swift'
               - 'Sources/Rokt_Widget/Networking/TxnEventsClient.swift'
               - 'Sources/Rokt_Widget/Networking/TxnInitClient.swift'
+              - 'Sources/Rokt_Widget/Models/SelectResponse.swift'
               - 'Tests/ContractTests/**'
               - 'Package.swift'
               - '.github/workflows/pact-consumer.yml'
@@ -44,7 +49,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -137,14 +142,12 @@ jobs:
               --build-url "${BUILD_URL}"
 
   can-i-deploy:
-    name: Can I Deploy (advisory)
+    name: Can I Deploy
     needs: [publish]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Advisory — never fails the job. Forward-looking pacts: the SDK doesn't consume
-    # V2 yet and no deploy environment is wired up, so `--to-environment stage` is a
-    # deliberate no-op (`stage` is a placeholder). When the SDK consumes V2, make it
-    # blocking against the environment a released SDK calls (likely production).
+    # Blocking: fail the PR when the published contract is not verified as
+    # deployable to the production environment.
     environment: pact-publish
     steps:
       - name: Check provider verification
@@ -154,10 +157,10 @@ jobs:
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           # renovate: datasource=docker depName=pactfoundation/pact-cli
           PACT_CLI_IMAGE="pactfoundation/pact-cli:1.5.0.4@sha256:4708c3d61157bff90082a483e4ff70541eb66f951eb3e218ea3e80a557abd170"
-          if docker run --rm \
+          docker run --rm \
             -e PACT_BROKER_BASE_URL \
             -e PACT_BROKER_USERNAME \
             -e PACT_BROKER_PASSWORD \
@@ -165,8 +168,4 @@ jobs:
             broker can-i-deploy \
               --pacticipant rokt-sdk-ios \
               --version "${GITHUB_SHA}" \
-              --to-environment stage; then
-            echo "can-i-deploy: deployable."
-          else
-            echo "::warning::can-i-deploy is advisory and non-blocking: these are forward-looking V2 contracts the SDK does not consume yet, so there is no stage deployment to verify against."
-          fi
+              --to-environment production

--- a/Tests/ContractTests/OffersClientPactSpec.swift
+++ b/Tests/ContractTests/OffersClientPactSpec.swift
@@ -150,4 +150,100 @@ class OffersClientPactSpec: XCTestCase {
 
         wait(for: [expectation], timeout: 35)
     }
+
+    func test_offersNoPageDetection_returnsSessionWithoutPlugins() {
+        Self.mockService
+            .uponReceiving("a v2 sessions offers request from rokt-sdk-ios for a non-configured page")
+            .given(ProviderState(description: "no page detection on offers request", params: [:]))
+            .withRequest(
+                method: .POST,
+                path: "/v2/sessions/offers",
+                headers: [
+                    "rokt-account-id": Matcher.SomethingLike("account-456"),
+                    "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
+                    "x-request-id": Matcher.SomethingLike("request-id-123"),
+                    "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
+                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    "Content-Type": "application/json"
+                ],
+                body: [
+                    "page": [
+                        "page_identifier": Matcher.SomethingLike("checkout-page")
+                    ],
+                    "privacy_control": [
+                        "no_functional": Matcher.SomethingLike(false),
+                        "no_targeting": Matcher.SomethingLike(false),
+                        "do_not_share_or_sell": Matcher.SomethingLike(false)
+                    ],
+                    "channel": [
+                        "type": "msdk",
+                        "sdk_version": Matcher.SomethingLike("5.2.2"),
+                        "rokt_platform_type": "iOS"
+                    ],
+                    "attributes": [
+                        "standalone": Matcher.SomethingLike("notdefined"),
+                        "customer.locale": Matcher.SomethingLike("en-US")
+                    ]
+                ]
+            )
+            // No-detection shape: the request is identical to the happy path
+            // (detection is a server-only outcome), but the provider returns only
+            // the session and token, with page_context carrying is_page_detected:
+            // false. No page_id/page_type/page_instance_guid and no plugins are
+            // returned, so they are intentionally absent from this contract.
+            // PactSwift cannot assert a key is absent; omitting plugins is the
+            // parity equivalent of Android's assertNull(response.plugins).
+            .willRespondWith(
+                status: 200,
+                headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
+                body: [
+                    "session_id": Matcher.SomethingLike("session-123"),
+                    "session_token": [
+                        "token": Matcher.SomethingLike("rotated-session-token"),
+                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
+                    ],
+                    "page_context": [
+                        "is_page_detected": false
+                    ]
+                ]
+            )
+
+        let expectation = expectation(description: "v2 offers no-detection request completes")
+
+        Self.mockService.run(timeout: 30) { baseURL, done in
+            Task {
+                defer { done() }
+                do {
+                    let url = try XCTUnwrap(URL(string: baseURL))
+                    let client = OffersClient(
+                        baseURL: url,
+                        accountId: "account-456",
+                        authToken: "Bearer session-token-abc",
+                        sdkVersion: "5.2.2",
+                        pageInstanceGuid: "page-instance-guid-123"
+                    )
+                    let input = OffersInput(
+                        requestId: "request-id-123",
+                        pageIdentifier: "checkout-page",
+                        attributes: [
+                            "standalone": "notdefined",
+                            "customer.locale": "en-US"
+                        ],
+                        privacyControl: SelectPrivacyControl(
+                            noFunctional: false,
+                            noTargeting: false,
+                            doNotShareOrSell: false
+                        )
+                    )
+                    let (_, httpResponse) = try await client.fetchOffers(input: input)
+                    XCTAssertEqual(httpResponse?.statusCode, 200)
+                } catch {
+                    XCTFail("OffersClient request failed: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 35)
+    }
 }

--- a/Tests/ContractTests/TxnEventsClientPactSpec.swift
+++ b/Tests/ContractTests/TxnEventsClientPactSpec.swift
@@ -50,7 +50,10 @@ class TxnEventsClientPactSpec: XCTestCase {
                     // the API rejects other forms, so the example uses a valid one.
                     "events": Matcher.EachLike([
                         "event_type": Matcher.SomethingLike("impression"),
-                        "instance_id": Matcher.SomethingLike("00000000-0000-0000-0000-000000000001"),
+                        "instance_id": Matcher.RegexLike(
+                            "00000000-0000-0000-0000-000000000001",
+                            term: #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"#
+                        ),
                         "timestamp": Matcher.SomethingLike(1_774_474_053_000),
                         "data": [
                             "source_message_id": Matcher.SomethingLike("source-message-001")

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -28,9 +28,10 @@ class TxnInitClientPactSpec: XCTestCase {
             .withRequest(
                 method: .POST,
                 path: "/v2/sessions/init",
+                // Cold init: no Authorization — the client has no session token yet,
+                // so the server mints one. x-request-id is always sent.
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
-                    "Authorization": Matcher.RegexLike("Bearer session-token-abc", term: #".+"#),
                     "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),
                     "Content-Type": "application/json"
                 ],
@@ -52,10 +53,11 @@ class TxnInitClientPactSpec: XCTestCase {
                         "expires_at": Matcher.SomethingLike(1_774_474_053_000)
                     ],
                     "feature_flags": [
-                        "rokt-tracking-status": Matcher.SomethingLike(true),
-                        "client-timeout-ms": Matcher.SomethingLike(30_000),
-                        "ios-sdk-log-font-happy-path": Matcher.SomethingLike(true),
-                        "ios-sdk-use-font-register-with-url": Matcher.SomethingLike(false),
+                        // Provider returns these four verbatim — pin exact (not type) match.
+                        "rokt-tracking-status": true,
+                        "client-timeout-ms": 30_000,
+                        "ios-sdk-log-font-happy-path": true,
+                        "ios-sdk-use-font-register-with-url": false,
                         "mobile-sdk-use-bounding-box": Matcher.SomethingLike(false),
                         "mobile-sdk-use-partner-events": Matcher.SomethingLike(false),
                         "mobile-sdk-use-open-url-from-rokt": Matcher.SomethingLike(false),
@@ -80,7 +82,6 @@ class TxnInitClientPactSpec: XCTestCase {
                     let client = TxnInitClient(
                         baseURL: url,
                         accountId: "account-456",
-                        authToken: "Bearer session-token-abc",
                         sdkVersion: "5.2.2"
                     )
                     let (_, httpResponse) = try await client.initSession(


### PR DESCRIPTION
## What

Bring the iOS Pact Consumer flow **and** contract content to parity with the Android consumer (`sdk-android-source`), and flip `can-i-deploy` from advisory to **blocking**.

### Commit 1 — flow parity + blocking gate (`ci(pact)`)
- `can-i-deploy` now **fails the PR** when the published contract isn't verified deployable to `production` (was advisory against a `stage` placeholder that doesn't exist in the broker, so it always took the warning branch). `set -euo pipefail`, dropped the warning-swallow wrapper, job renamed `Can I Deploy`.
- Fix stale path filter `TxnOffersClient.swift` → `OffersClient.swift`; watch the offers request models (`SelectResponse.swift`); add `pull-requests: read`; bump `actions/checkout` to v6.0.3.

This commit doesn't change the published pact, so it verified **green** (`Computer says yes \o/`) — confirming the blocking gate works end-to-end.

### Commit 2 — contract-content parity (`test(pact)`)
- **offers**: add the `no page detection` interaction (session + token, `is_page_detected:false`, no plugins).
- **init**: model a cold init — drop the `Authorization` assertion and invoke the client without a token (the server mints the session); keep `x-request-id`, which the iOS client always sends.
- **init**: exact-match the four feature flags the provider returns verbatim.
- **events**: assert `instance_id` is a canonical UUID (regex) rather than any string.

Each change was validated against the `transactions` provider stub and verifies green.

## Why `Can I Deploy` is red right now (expected)

Commit 2 changes the published pact, so the gate reports:
> There is no verified pact between this version of rokt-sdk-ios and the version of transactions-api currently in production.

That's the blocking gate doing its job — the new contract hasn't been provider-verified yet. **No provider code change is needed** (all changes verify green against the current stub). It recovers to green once a `transactions` **master** build runs `pact:verify` (verifies the new contract — no branch filter, runs on every build) and `pact:record-deployment` (records the prod deployment — master/hotfix only).

## Notes
- Stacks on #208 (base `feat/v2-offers-network`). Draft until the gate recovers green after provider re-verification.
- Once reliably green, add `Can I Deploy` to required status checks (branch protection) so it blocks merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
