### PR TITLE
feat(offers): mobile device headers and privacy.gpc_enabled on the v2 offers request

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -15,7 +15,7 @@ class RealtimeEventStoreMemory: RealTimeEventStore {
     private var triggeredEvents: [TriggeredRealTimeEvent] = []
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
-        self.untriggeredEvents.append(contentsOf: events)
+        appendDeduped(events, to: &untriggeredEvents)
     }
 
     func getTriggeredEvents() -> [TriggeredRealTimeEvent] {
@@ -68,7 +68,7 @@ class RealTimeEventStoreFile: RealTimeEventStore {
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
         guard let untriggeredEventsFilePath else { return }
         var all = getUntriggeredEvents()
-        all.append(contentsOf: events)
+        appendDeduped(events, to: &all)
         save(all, to: untriggeredEventsFilePath)
     }
 
@@ -194,4 +194,14 @@ private func updateTriggeredEvents(
 private func trimTriggeredEvents(_ triggeredEvents: [TriggeredRealTimeEvent]) -> [TriggeredRealTimeEvent] {
     let sortedEvents = triggeredEvents.sorted { $0.eventTime > $1.eventTime }
     return Array(sortedEvents.prefix(maximumRealTimeEventsToStore))
+}
+
+// Appends only events not already present, preserving order. The backend can echo the same
+// event_data across responses; de-duping keeps the untriggered store bounded and stops a single
+// trigger from matching duplicate rows and multiplying what gets forwarded.
+private func appendDeduped(_ events: [UntriggeredRealTimeEvent], to all: inout [UntriggeredRealTimeEvent]) {
+    var seen = Set(all)
+    for event in events where seen.insert(event).inserted {
+        all.append(event)
+    }
 }

--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -16,6 +16,9 @@ class RealtimeEventStoreMemory: RealTimeEventStore {
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
         appendDeduped(events, to: &untriggeredEvents)
+        if untriggeredEvents.count > maximumRealTimeEventsToStore {
+            untriggeredEvents = Array(untriggeredEvents.suffix(maximumRealTimeEventsToStore))
+        }
     }
 
     func getTriggeredEvents() -> [TriggeredRealTimeEvent] {
@@ -67,9 +70,19 @@ class RealTimeEventStoreFile: RealTimeEventStore {
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
         guard let untriggeredEventsFilePath else { return }
-        var all = getUntriggeredEvents()
-        appendDeduped(events, to: &all)
-        save(all, to: untriggeredEventsFilePath)
+        // Serialize on the same queue as markAsTriggered's processing: this is a
+        // read-modify-write, so concurrent captures (or a capture racing a trigger-mark)
+        // would otherwise lose updates when the second save overwrites the first.
+        eventProcessingQueue.sync {
+            var all = getUntriggeredEvents()
+            appendDeduped(events, to: &all)
+            // Bound the untriggered file the way triggered events are capped: a long-lived
+            // session whose responses echo distinct event_data must not grow without limit.
+            if all.count > maximumRealTimeEventsToStore {
+                all = Array(all.suffix(maximumRealTimeEventsToStore))
+            }
+            save(all, to: untriggeredEventsFilePath)
+        }
     }
 
     func getTriggeredEvents() -> [TriggeredRealTimeEvent] {

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -14,24 +14,28 @@ internal struct SelectRequest: Encodable, Equatable {
     let channel: SelectChannel
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
+    let privacy: SelectPrivacy?
 
     enum CodingKeys: String, CodingKey {
         case page
         case channel
         case attributes
         case privacyControl = "privacy_control"
+        case privacy
     }
 
     init(
         page: SelectPage,
         channel: SelectChannel,
         attributes: [String: String] = [:],
-        privacyControl: SelectPrivacyControl? = nil
+        privacyControl: SelectPrivacyControl? = nil,
+        privacy: SelectPrivacy? = nil
     ) {
         self.page = page
         self.channel = channel
         self.attributes = attributes
         self.privacyControl = privacyControl
+        self.privacy = privacy
     }
 }
 
@@ -88,6 +92,21 @@ internal struct SelectPrivacyControl: Encodable, Equatable {
         self.noFunctional = noFunctional
         self.noTargeting = noTargeting
         self.doNotShareOrSell = doNotShareOrSell
+    }
+}
+
+/// GPC (Global Privacy Control) signal. A top-level sibling of
+/// ``SelectPrivacyControl`` — `gpc_enabled` rides under `privacy`, not inside
+/// `privacy_control`, matching Android.
+internal struct SelectPrivacy: Encodable, Equatable {
+    let gpcEnabled: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case gpcEnabled = "gpc_enabled"
+    }
+
+    init(gpcEnabled: Bool? = nil) {
+        self.gpcEnabled = gpcEnabled
     }
 }
 

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -417,7 +417,7 @@ internal struct SelectEventDataEntry: Decodable, Equatable {
 
 /// A pre-serialized real-time event payload, keyed by signal type. Mirrors the
 /// provider's typed event shape (and Android's `SelectRealTimeEvent`).
-internal struct SelectRealTimeEvent: Decodable, Equatable {
+internal struct SelectRealTimeEvent: Decodable, Equatable, RealTimeEventSignal {
     let eventType: String?
     let payload: String?
 

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -15,6 +15,9 @@ internal struct SelectRequest: Encodable, Equatable {
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
+    // Real-time events triggered during the previous placement, forwarded for the next
+    // selection; omitted when none.
+    let events: [SelectEvent]?
 
     enum CodingKeys: String, CodingKey {
         case page
@@ -22,6 +25,7 @@ internal struct SelectRequest: Encodable, Equatable {
         case attributes
         case privacyControl = "privacy_control"
         case privacy
+        case events
     }
 
     init(
@@ -29,13 +33,15 @@ internal struct SelectRequest: Encodable, Equatable {
         channel: SelectChannel,
         attributes: [String: String] = [:],
         privacyControl: SelectPrivacyControl? = nil,
-        privacy: SelectPrivacy? = nil
+        privacy: SelectPrivacy? = nil,
+        events: [SelectEvent]? = nil
     ) {
         self.page = page
         self.channel = channel
         self.attributes = attributes
         self.privacyControl = privacyControl
         self.privacy = privacy
+        self.events = events
     }
 }
 
@@ -107,6 +113,33 @@ internal struct SelectPrivacy: Encodable, Equatable {
 
     init(gpcEnabled: Bool? = nil) {
         self.gpcEnabled = gpcEnabled
+    }
+}
+
+/// A real-time event forwarded on the offers request: the provider's typed event
+/// plus its echoed `payload`, stamped with an epoch-ms `timestamp`. Encodes to the
+/// `/v2/sessions/events` element shape (`event_type`, `timestamp`, `data.payload`).
+internal struct SelectEvent: Encodable, Equatable {
+    let eventType: String
+    let timestamp: Int64
+    let payload: String
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case timestamp
+        case data
+    }
+
+    private enum DataKeys: String, CodingKey {
+        case payload
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(eventType, forKey: .eventType)
+        try container.encode(timestamp, forKey: .timestamp)
+        var data = container.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
+        try data.encode(payload, forKey: .payload)
     }
 }
 

--- a/Sources/Rokt_Widget/Models/UntriggeredRealTimeEvent.swift
+++ b/Sources/Rokt_Widget/Models/UntriggeredRealTimeEvent.swift
@@ -20,26 +20,9 @@ struct UntriggeredEventsContainer: Decodable {
     init(from decoder: Decoder) throws {
         let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
         let rawEventDataMap = try rootContainer.decode([String: RawEventData].self, forKey: .eventData)
-
-        var parsedEvents: [UntriggeredRealTimeEvent] = []
-
-        for (parentGuid, individualRawData) in rawEventDataMap {
-            if let actualEvents = individualRawData.events {
-                for (signalKey, rawSignalEvent) in actualEvents {
-                    let event = UntriggeredRealTimeEvent(
-                        triggerGuid: parentGuid,
-                        triggerEvent: signalKey,
-                        eventType: rawSignalEvent.eventType,
-                        payload: rawSignalEvent.payload
-                    )
-                    if event.isValid() {
-                        parsedEvents.append(event)
-                    }
-                }
-            }
-        }
-
-        self.untriggeredEvents = parsedEvents
+        self.untriggeredEvents = UntriggeredRealTimeEvent.flattenedValid(
+            from: rawEventDataMap.mapValues { $0.events }
+        )
     }
 
     enum CodingKeys: String, CodingKey {
@@ -51,7 +34,37 @@ private struct RawEventData: Decodable {
     let events: [String: RawEvent]?
 }
 
-private struct RawEvent: Decodable {
+private struct RawEvent: Decodable, RealTimeEventSignal {
     let eventType: String?
     let payload: String?
+}
+
+// A decoded real-time-event signal: the minimal shape (event_type + payload) shared by the
+// v1 (camelCase RawEvent) and v2 (snake_case SelectRealTimeEvent) decode types. They stay
+// separate Decodables for the casing difference, but flatten/validate through one path.
+internal protocol RealTimeEventSignal {
+    var eventType: String? { get }
+    var payload: String? { get }
+}
+
+extension UntriggeredRealTimeEvent {
+    /// Flatten a decoded event_data envelope (parentGuid -> signalKey -> signal) into untriggered
+    /// events, dropping invalid entries. Single home for the validity rule so v1/v2 can't drift.
+    static func flattenedValid<Signal: RealTimeEventSignal>(
+        from eventData: [String: [String: Signal]?]
+    ) -> [UntriggeredRealTimeEvent] {
+        var events: [UntriggeredRealTimeEvent] = []
+        for (parentGuid, signals) in eventData {
+            guard let signals else { continue }
+            for (signalKey, signal) in signals {
+                events.append(UntriggeredRealTimeEvent(
+                    triggerGuid: parentGuid,
+                    triggerEvent: signalKey,
+                    eventType: signal.eventType,
+                    payload: signal.payload
+                ))
+            }
+        }
+        return events.filter { $0.isValid() }
+    }
 }

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -51,18 +51,9 @@ internal struct OffersClient {
             throw OffersClientError.bodyEncodingFailed
         }
 
-        var headers: RoktHTTPHeaders = [
-            "rokt-account-id": accountId,
-            "x-request-id": input.requestId,
-            "rokt-page-instance-guid": pageInstanceGuid,
-            // Live (non-shadow) v2 request.
-            "rokt-txn-shadow": "false",
-            "Content-Type": "application/json"
-        ]
-        // Authorization is optional: with no live token the server mints a fresh session.
-        if let authToken, !authToken.isEmpty {
-            headers["Authorization"] = authToken
-        }
+        var headers = TxnRequestHeaders.common(accountId: accountId, authToken: authToken)
+        headers["x-request-id"] = input.requestId
+        headers["rokt-page-instance-guid"] = pageInstanceGuid
         // Device headers (os, model, locale, app version) and the load-bearing
         // rokt-package-name ride in via NetworkingHelper.txnDeviceHeaders — the
         // gateway's mobile page detection and targeting key off them.

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -42,7 +42,8 @@ internal struct OffersClient {
             page: SelectPage(pageIdentifier: input.pageIdentifier),
             channel: SelectChannel(sdkVersion: sdkVersion),
             attributes: input.attributes,
-            privacyControl: input.privacyControl
+            privacyControl: input.privacyControl,
+            privacy: input.privacy
         )
         let bodyData = try JSONEncoder().encode(requestBody)
         guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
@@ -97,16 +98,19 @@ internal struct OffersInput {
     let pageIdentifier: String
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
+    let privacy: SelectPrivacy?
 
     init(
         requestId: String,
         pageIdentifier: String,
         attributes: [String: String],
-        privacyControl: SelectPrivacyControl? = nil
+        privacyControl: SelectPrivacyControl? = nil,
+        privacy: SelectPrivacy? = nil
     ) {
         self.requestId = requestId
         self.pageIdentifier = pageIdentifier
         self.attributes = attributes
         self.privacyControl = privacyControl
+        self.privacy = privacy
     }
 }

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -43,7 +43,8 @@ internal struct OffersClient {
             channel: SelectChannel(sdkVersion: sdkVersion),
             attributes: input.attributes,
             privacyControl: input.privacyControl,
-            privacy: input.privacy
+            privacy: input.privacy,
+            events: input.events
         )
         let bodyData = try JSONEncoder().encode(requestBody)
         guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
@@ -54,6 +55,8 @@ internal struct OffersClient {
             "rokt-account-id": accountId,
             "x-request-id": input.requestId,
             "rokt-page-instance-guid": pageInstanceGuid,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no live token the server mints a fresh session.
@@ -99,18 +102,21 @@ internal struct OffersInput {
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
+    let events: [SelectEvent]?
 
     init(
         requestId: String,
         pageIdentifier: String,
         attributes: [String: String],
         privacyControl: SelectPrivacyControl? = nil,
-        privacy: SelectPrivacy? = nil
+        privacy: SelectPrivacy? = nil,
+        events: [SelectEvent]? = nil
     ) {
         self.requestId = requestId
         self.pageIdentifier = pageIdentifier
         self.attributes = attributes
         self.privacyControl = privacyControl
         self.privacy = privacy
+        self.events = events
     }
 }

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -5,17 +5,19 @@ import Foundation
 internal struct OffersClient {
     let baseURL: URL
     let accountId: String
-    let authToken: String
+    let authToken: String?
     let sdkVersion: String
     let pageInstanceGuid: String
+    let deviceHeaders: [String: String]
     let httpClient: HTTPClientAdapter
 
     init(
         baseURL: URL,
         accountId: String,
-        authToken: String,
+        authToken: String?,
         sdkVersion: String,
         pageInstanceGuid: String,
+        deviceHeaders: [String: String] = [:],
         httpClient: HTTPClientAdapter = RoktHTTPClient()
     ) {
         self.baseURL = baseURL
@@ -23,6 +25,7 @@ internal struct OffersClient {
         self.authToken = authToken
         self.sdkVersion = sdkVersion
         self.pageInstanceGuid = pageInstanceGuid
+        self.deviceHeaders = deviceHeaders
         self.httpClient = httpClient
     }
 
@@ -46,15 +49,22 @@ internal struct OffersClient {
             throw OffersClientError.bodyEncodingFailed
         }
 
-        let headers: RoktHTTPHeaders = [
+        var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
-            "Authorization": authToken,
             "x-request-id": input.requestId,
             "rokt-page-instance-guid": pageInstanceGuid,
-            // The app bundle id scopes server-side page detection for mobile.
-            "rokt-package-name": Bundle.main.bundleIdentifier ?? "",
             "Content-Type": "application/json"
         ]
+        // Authorization is optional: with no live token the server mints a fresh session.
+        if let authToken, !authToken.isEmpty {
+            headers["Authorization"] = authToken
+        }
+        // Device headers (os, model, locale, app version) and the load-bearing
+        // rokt-package-name ride in via NetworkingHelper.txnDeviceHeaders — the
+        // gateway's mobile page detection and targeting key off them.
+        for (key, value) in deviceHeaders {
+            headers[key] = value
+        }
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -70,7 +70,9 @@ internal struct OffersService {
         onRequestStart?()
 
         // Extract privacy KVPs before sanitising, then enrich the remaining attributes.
+        // gpc_enabled travels under `privacy`, separate from `privacy_control`, to match Android.
         let privacyControl = buildPrivacyControl(from: attributes)
+        let privacy = buildPrivacy(from: attributes)
         let sanitisedAttributes = RoktAPIHelper.removePrivacyControlAttributes(attributes: attributes)
         let enrichedAttributes = AttributeEnrichment.shared.enrich(attributes: sanitisedAttributes, config: config)
 
@@ -79,7 +81,8 @@ internal struct OffersService {
                 let experience = try await fetchExperienceString(
                     pageIdentifier: viewName ?? "",
                     attributes: enrichedAttributes,
-                    privacyControl: privacyControl
+                    privacyControl: privacyControl,
+                    privacy: privacy
                 )
                 completionQueue.async { successLayout?(experience) }
             } catch {
@@ -92,7 +95,8 @@ internal struct OffersService {
     private func fetchExperienceString(
         pageIdentifier: String,
         attributes: [String: String],
-        privacyControl: SelectPrivacyControl?
+        privacyControl: SelectPrivacyControl?,
+        privacy: SelectPrivacy?
     ) async throws -> String {
         guard let baseURL = URL(string: environment.gatewayBaseURL) else {
             throw OffersError.invalidBaseURL
@@ -113,7 +117,8 @@ internal struct OffersService {
             requestId: makeRequestId(),
             pageIdentifier: pageIdentifier,
             attributes: attributes,
-            privacyControl: privacyControl
+            privacyControl: privacyControl,
+            privacy: privacy
         )
 
         var attempt = 0
@@ -149,12 +154,21 @@ internal struct OffersService {
 
     private func buildPrivacyControl(from attributes: [String: String]) -> SelectPrivacyControl? {
         let payload = RoktAPIHelper.getPrivacyControlPayload(attributes: attributes)
-        guard !payload.isEmpty else { return nil }
+        guard payload[RoktAPIHelper.noFunctionalKey] != nil
+            || payload[RoktAPIHelper.noTargetingKey] != nil
+            || payload[RoktAPIHelper.doNotShareOrSellKey] != nil else { return nil }
         return SelectPrivacyControl(
             noFunctional: payload[RoktAPIHelper.noFunctionalKey],
             noTargeting: payload[RoktAPIHelper.noTargetingKey],
             doNotShareOrSell: payload[RoktAPIHelper.doNotShareOrSellKey]
         )
+    }
+
+    // gpc_enabled is a sibling of privacy_control (Android parity), omitted when the partner sent none.
+    private func buildPrivacy(from attributes: [String: String]) -> SelectPrivacy? {
+        let payload = RoktAPIHelper.getPrivacyControlPayload(attributes: attributes)
+        guard let gpcEnabled = payload[RoktAPIHelper.gpcEnabledKey] else { return nil }
+        return SelectPrivacy(gpcEnabled: gpcEnabled)
     }
 
     static func statusCode(from error: Error) -> Int? {

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -16,6 +16,7 @@ internal struct OffersService {
     let sdkVersion: String
     let sessionManager: TxnSessionManager
     let httpClient: HTTPClientAdapter
+    let deviceHeaders: [String: String]
     let maxRetries: Int
     let requestTimeout: TimeInterval
     let baseBackoff: TimeInterval
@@ -30,6 +31,7 @@ internal struct OffersService {
         sdkVersion: String,
         sessionManager: TxnSessionManager,
         httpClient: HTTPClientAdapter = RoktHTTPClient(),
+        deviceHeaders: [String: String] = [:],
         maxRetries: Int = 3,
         requestTimeout: TimeInterval = 7,
         baseBackoff: TimeInterval = 0.2,
@@ -45,6 +47,7 @@ internal struct OffersService {
         self.sdkVersion = sdkVersion
         self.sessionManager = sessionManager
         self.httpClient = httpClient
+        self.deviceHeaders = deviceHeaders
         self.maxRetries = maxRetries
         self.requestTimeout = requestTimeout
         self.baseBackoff = baseBackoff
@@ -100,9 +103,10 @@ internal struct OffersService {
         let client = OffersClient(
             baseURL: baseURL,
             accountId: accountId,
-            authToken: (await sessionManager.authorizationHeader) ?? "",
+            authToken: await sessionManager.authorizationHeader,
             sdkVersion: sdkVersion,
             pageInstanceGuid: makePageInstanceGuid(),
+            deviceHeaders: deviceHeaders,
             httpClient: httpClient
         )
         let input = OffersInput(

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -24,6 +24,11 @@ internal struct OffersService {
     let makeRequestId: () -> String
     let makePageInstanceGuid: () -> String
     let completionQueue: DispatchQueue
+    // Real-time event store seams (injected for tests). `captureEvents` stores the response's
+    // events for the next call; it only adds (no global clear) to mirror the v1 capture and
+    // avoid wiping triggered events the events/v1 paths share in RealTimeEventManager.shared.
+    let triggeredEvents: () -> [TriggeredRealTimeEvent]
+    let captureEvents: ([UntriggeredRealTimeEvent]) -> Void
 
     init(
         environment: Environment,
@@ -40,7 +45,13 @@ internal struct OffersService {
         },
         makeRequestId: @escaping () -> String = { UUID().uuidString },
         makePageInstanceGuid: @escaping () -> String = { UUID().uuidString },
-        completionQueue: DispatchQueue = .main
+        completionQueue: DispatchQueue = .main,
+        triggeredEvents: @escaping () -> [TriggeredRealTimeEvent] = {
+            RealTimeEventManager.shared.getTriggeredEvents()
+        },
+        captureEvents: @escaping ([UntriggeredRealTimeEvent]) -> Void = { events in
+            RealTimeEventManager.shared.addUntriggeredEvents(events)
+        }
     ) {
         self.environment = environment
         self.accountId = accountId
@@ -55,6 +66,8 @@ internal struct OffersService {
         self.makeRequestId = makeRequestId
         self.makePageInstanceGuid = makePageInstanceGuid
         self.completionQueue = completionQueue
+        self.triggeredEvents = triggeredEvents
+        self.captureEvents = captureEvents
     }
 
     /// Builds the request from the partner inputs, fetches the experience, and reports
@@ -104,21 +117,29 @@ internal struct OffersService {
 
         httpClient.updateTimeout(timeout: requestTimeout)
 
+        let authToken = await sessionManager.authorizationHeader
         let client = OffersClient(
             baseURL: baseURL,
             accountId: accountId,
-            authToken: await sessionManager.authorizationHeader,
+            authToken: authToken,
             sdkVersion: sdkVersion,
             pageInstanceGuid: makePageInstanceGuid(),
             deviceHeaders: deviceHeaders,
             httpClient: httpClient
         )
+        // Forward events triggered during the previous placement; read once, before retries,
+        // and only with a live session to attribute them to (matching Android). As on the v1
+        // path, triggered events are not cleared after forwarding — they ride subsequent
+        // requests until session invalidation; re-send is expected (the "only adds, no clear"
+        // note elsewhere is about the untriggered response-capture, not this read).
+        let forwardedEvents = authToken != nil ? SelectEventMapper.requestEvents(from: triggeredEvents()) : []
         let input = OffersInput(
             requestId: makeRequestId(),
             pageIdentifier: pageIdentifier,
             attributes: attributes,
             privacyControl: privacyControl,
-            privacy: privacy
+            privacy: privacy,
+            events: forwardedEvents.isEmpty ? nil : forwardedEvents
         )
 
         var attempt = 0
@@ -143,6 +164,10 @@ internal struct OffersService {
                 let decoded = try JSONDecoder().decode(SelectResponse.self, from: data)
                 // Roll the refreshed token forward for the next offers/events call.
                 await sessionManager.update(sessionToken: decoded.sessionToken)
+                // Capture the echoed events so the next placement can forward them back.
+                if let eventData = decoded.eventData {
+                    captureEvents(SelectEventMapper.untriggeredEvents(from: eventData))
+                }
                 return try SelectExperienceAdapter.experienceJSONString(from: decoded)
             } catch let error where isRetryable(error: error) && attempt < maxRetries {
                 try await sleep(backoffDelay(attempt: attempt))

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -84,8 +84,9 @@ internal struct OffersService {
 
         // Extract privacy KVPs before sanitising, then enrich the remaining attributes.
         // gpc_enabled travels under `privacy`, separate from `privacy_control`, to match Android.
-        let privacyControl = buildPrivacyControl(from: attributes)
-        let privacy = buildPrivacy(from: attributes)
+        let privacyPayload = RoktAPIHelper.getPrivacyControlPayload(attributes: attributes)
+        let privacyControl = buildPrivacyControl(from: privacyPayload)
+        let privacy = buildPrivacy(from: privacyPayload)
         let sanitisedAttributes = RoktAPIHelper.removePrivacyControlAttributes(attributes: attributes)
         let enrichedAttributes = AttributeEnrichment.shared.enrich(attributes: sanitisedAttributes, config: config)
 
@@ -177,8 +178,8 @@ internal struct OffersService {
         }
     }
 
-    private func buildPrivacyControl(from attributes: [String: String]) -> SelectPrivacyControl? {
-        let payload = RoktAPIHelper.getPrivacyControlPayload(attributes: attributes)
+    // Both builders read the same parsed payload; getExperienceData computes it once.
+    private func buildPrivacyControl(from payload: [String: Bool]) -> SelectPrivacyControl? {
         guard payload[RoktAPIHelper.noFunctionalKey] != nil
             || payload[RoktAPIHelper.noTargetingKey] != nil
             || payload[RoktAPIHelper.doNotShareOrSellKey] != nil else { return nil }
@@ -190,8 +191,7 @@ internal struct OffersService {
     }
 
     // gpc_enabled is a sibling of privacy_control (Android parity), omitted when the partner sent none.
-    private func buildPrivacy(from attributes: [String: String]) -> SelectPrivacy? {
-        let payload = RoktAPIHelper.getPrivacyControlPayload(attributes: attributes)
+    private func buildPrivacy(from payload: [String: Bool]) -> SelectPrivacy? {
         guard let gpcEnabled = payload[RoktAPIHelper.gpcEnabledKey] else { return nil }
         return SelectPrivacy(gpcEnabled: gpcEnabled)
     }

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -1,0 +1,45 @@
+// periphery:ignore:all - offers real-time event mapping
+
+import Foundation
+
+/// Bridges the SDK real-time event store and the v2 offers request/response.
+///
+/// The request `events[]` element (``SelectEvent``) encodes to the
+/// `/v2/sessions/events` wire shape: `event_type`, epoch-ms `timestamp`,
+/// `data.payload`, matching Android.
+internal enum SelectEventMapper {
+
+    /// Triggered events from the previous placement → the offers request `events[]`.
+    static func requestEvents(from triggered: [TriggeredRealTimeEvent]) -> [SelectEvent] {
+        triggered.map { event in
+            SelectEvent(
+                eventType: event.eventType,
+                timestamp: EventDateFormatter.epochMilliseconds(from: event.eventTime),
+                payload: event.payload
+            )
+        }
+    }
+
+    /// Response `event_data` → untriggered events for the store, consulted when the
+    /// next placement fires. The flattening parallels ``UntriggeredEventsContainer`` (the
+    /// v1 path), but stays separate because v1 decodes camelCase `eventType` while v2
+    /// decodes snake_case `event_type`. Entries missing required fields are dropped here,
+    /// matching that sibling.
+    static func untriggeredEvents(from eventData: [String: SelectEventDataEntry]) -> [UntriggeredRealTimeEvent] {
+        var events: [UntriggeredRealTimeEvent] = []
+        for (parentGuid, entry) in eventData {
+            guard let signals = entry.events else { continue }
+            for (signalKey, signal) in signals {
+                events.append(
+                    UntriggeredRealTimeEvent(
+                        triggerGuid: parentGuid,
+                        triggerEvent: signalKey,
+                        eventType: signal.eventType,
+                        payload: signal.payload
+                    )
+                )
+            }
+        }
+        return events.filter { $0.isValid() }
+    }
+}

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -20,26 +20,11 @@ internal enum SelectEventMapper {
         }
     }
 
-    /// Response `event_data` → untriggered events for the store, consulted when the
-    /// next placement fires. The flattening parallels ``UntriggeredEventsContainer`` (the
-    /// v1 path), but stays separate because v1 decodes camelCase `eventType` while v2
-    /// decodes snake_case `event_type`. Entries missing required fields are dropped here,
-    /// matching that sibling.
+    /// Response `event_data` → untriggered events for the store, consulted when the next
+    /// placement fires. Shares the flatten/validate path with the v1 ``UntriggeredEventsContainer``
+    /// (`UntriggeredRealTimeEvent.flattenedValid`); the two keep separate Decodables only because
+    /// v1 is camelCase `eventType` and v2 is snake_case `event_type`.
     static func untriggeredEvents(from eventData: [String: SelectEventDataEntry]) -> [UntriggeredRealTimeEvent] {
-        var events: [UntriggeredRealTimeEvent] = []
-        for (parentGuid, entry) in eventData {
-            guard let signals = entry.events else { continue }
-            for (signalKey, signal) in signals {
-                events.append(
-                    UntriggeredRealTimeEvent(
-                        triggerGuid: parentGuid,
-                        triggerEvent: signalKey,
-                        eventType: signal.eventType,
-                        payload: signal.payload
-                    )
-                )
-            }
-        }
-        return events.filter { $0.isValid() }
+        UntriggeredRealTimeEvent.flattenedValid(from: eventData.mapValues { $0.events })
     }
 }

--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -22,7 +22,7 @@ internal enum TxnEventMapper {
         return TxnEvent(
             eventType: mapped.eventType,
             instanceId: request.uuid,
-            timestamp: epochMilliseconds(from: request.eventTime),
+            timestamp: EventDateFormatter.epochMilliseconds(from: request.eventTime),
             data: buildData(
                 eventType: request.eventType,
                 attributes: request.eventData,
@@ -41,7 +41,7 @@ internal enum TxnEventMapper {
         return TxnEvent(
             eventType: mapped.eventType,
             instanceId: request.uuid,
-            timestamp: epochMilliseconds(from: request.eventTime),
+            timestamp: EventDateFormatter.epochMilliseconds(from: request.eventTime),
             data: buildData(
                 eventType: request.eventType,
                 attributes: request.attributes,
@@ -120,12 +120,5 @@ internal enum TxnEventMapper {
         for (key, value) in markers { data[key] = .string(value) }
 
         return data.isEmpty ? nil : data
-    }
-
-    private static func epochMilliseconds(from eventTime: String) -> Int64 {
-        if let date = EventDateFormatter.dateFormatter.date(from: eventTime) {
-            return Int64(date.timeIntervalSince1970 * 1000)
-        }
-        return Int64(Date().timeIntervalSince1970 * 1000)
     }
 }

--- a/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
@@ -38,6 +38,8 @@ internal struct TxnEventsClient {
 
         var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no live token the server mints a fresh session.

--- a/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
@@ -36,16 +36,7 @@ internal struct TxnEventsClient {
             throw TxnEventsClientError.bodyEncodingFailed
         }
 
-        var headers: RoktHTTPHeaders = [
-            "rokt-account-id": accountId,
-            // Live (non-shadow) v2 request.
-            "rokt-txn-shadow": "false",
-            "Content-Type": "application/json"
-        ]
-        // Authorization is optional: with no live token the server mints a fresh session.
-        if let authToken, !authToken.isEmpty {
-            headers["Authorization"] = authToken
-        }
+        var headers = TxnRequestHeaders.common(accountId: accountId, authToken: authToken)
         for (key, value) in deviceHeaders {
             headers[key] = value
         }

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -43,6 +43,8 @@ internal struct TxnInitClient {
         var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
             "x-request-id": UUID().uuidString,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no stored token the server mints a fresh session.

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -40,17 +40,8 @@ internal struct TxnInitClient {
             throw TxnInitClientError.bodyEncodingFailed
         }
 
-        var headers: RoktHTTPHeaders = [
-            "rokt-account-id": accountId,
-            "x-request-id": UUID().uuidString,
-            // Live (non-shadow) v2 request.
-            "rokt-txn-shadow": "false",
-            "Content-Type": "application/json"
-        ]
-        // Authorization is optional: with no stored token the server mints a fresh session.
-        if let authToken, !authToken.isEmpty {
-            headers["Authorization"] = authToken
-        }
+        var headers = TxnRequestHeaders.common(accountId: accountId, authToken: authToken)
+        headers["x-request-id"] = UUID().uuidString
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(

--- a/Sources/Rokt_Widget/Networking/TxnRequestHeaders.swift
+++ b/Sources/Rokt_Widget/Networking/TxnRequestHeaders.swift
@@ -1,0 +1,27 @@
+// periphery:ignore:all - shared v2 transactions request headers
+
+import Foundation
+
+/// Single owner for the headers common to every v2 transactions request
+/// (init / events / offers): the account id, content type, the live/non-shadow
+/// flag, and the optional Authorization. Centralised so the shadow and auth
+/// rules can't drift between the three clients (a partial edit would otherwise
+/// send one endpoint live and another shadow for the same session).
+internal enum TxnRequestHeaders {
+    static let shadowHeaderKey = "rokt-txn-shadow"
+
+    static func common(accountId: String, authToken: String?) -> RoktHTTPHeaders {
+        var headers: RoktHTTPHeaders = [
+            "rokt-account-id": accountId,
+            // Live (non-shadow) v2 request.
+            shadowHeaderKey: "false",
+            "Content-Type": "application/json"
+        ]
+        // Authorization is optional: with no live token the server mints a fresh session.
+        // authorizationHeader yields nil or "Bearer <jwt>", never an empty string.
+        if let authToken {
+            headers["Authorization"] = authToken
+        }
+        return headers
+    }
+}

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -972,7 +972,8 @@ class RoktInternalImplementation {
             accountId: roktTagId,
             sdkVersion: libraryVersion,
             sessionManager: TxnSessionManager(roktTagId: roktTagId),
-            httpClient: httpClient
+            httpClient: httpClient,
+            deviceHeaders: NetworkingHelper.txnDeviceHeaders()
         )
     }
 

--- a/Sources/Rokt_Widget/Util/EventDateFormatter.swift
+++ b/Sources/Rokt_Widget/Util/EventDateFormatter.swift
@@ -16,4 +16,14 @@ class EventDateFormatter {
     static func getDateString(_ date: Date) -> String {
         dateFormatter.string(from: date)
     }
+
+    /// Parses an event-time string to epoch milliseconds, falling back to now when
+    /// unparseable. Shared by the txn-events and offers-events paths so the fallback
+    /// policy can't drift between them.
+    static func epochMilliseconds(from eventTime: String) -> Int64 {
+        if let date = dateFormatter.date(from: eventTime) {
+            return Int64(date.timeIntervalSince1970 * 1000)
+        }
+        return Int64(Date().timeIntervalSince1970 * 1000)
+    }
 }

--- a/Tests/ContractTests/OffersClientPactSpec.swift
+++ b/Tests/ContractTests/OffersClientPactSpec.swift
@@ -26,6 +26,12 @@ import PactSwift
 /// the client drift to `"ios-mobile"` without failing the consumer test.
 /// Per-runtime values (account id, auth token, request id, page identifier,
 /// etc.) stay as `SomethingLike` because they legitimately vary per call.
+/// `rokt-package-name` is the exception: it is matched as a non-empty value
+/// (regex `.+`) because server-side mobile page detection keys off it and an
+/// empty value would silently return no offers. The device headers
+/// (`rokt-os-type`/`-os-version`/`-device-model`/`-ui-locale`/`-package-version`)
+/// ride in via `NetworkingHelper.txnDeviceHeaders` and are asserted for parity
+/// with the Android offers contract.
 class OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -57,7 +63,17 @@ class OffersClientPactSpec: XCTestCase {
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    // rokt-package-name is matched as a non-empty value (regex .+),
+                    // not by type: it is the signal server-side mobile page detection
+                    // keys off, and an empty value would silently return no offers.
+                    "rokt-package-name": Matcher.RegexLike("com.rokt.example", term: #".+"#),
+                    // Device headers ride in via NetworkingHelper.txnDeviceHeaders;
+                    // asserted here for parity with the Android offers contract.
+                    "rokt-os-type": Matcher.SomethingLike("iOS"),
+                    "rokt-os-version": Matcher.SomethingLike("17.0"),
+                    "rokt-device-model": Matcher.SomethingLike("iPhone15,2"),
+                    "rokt-ui-locale": Matcher.SomethingLike("en_US"),
+                    "rokt-package-version": Matcher.SomethingLike("1.0.0"),
                     "Content-Type": "application/json"
                 ],
                 body: [
@@ -124,7 +140,15 @@ class OffersClientPactSpec: XCTestCase {
                         accountId: "account-456",
                         authToken: "Bearer session-token-abc",
                         sdkVersion: "5.2.2",
-                        pageInstanceGuid: "page-instance-guid-123"
+                        pageInstanceGuid: "page-instance-guid-123",
+                        deviceHeaders: [
+                            "rokt-package-name": "com.rokt.example",
+                            "rokt-os-type": "iOS",
+                            "rokt-os-version": "17.0",
+                            "rokt-device-model": "iPhone15,2",
+                            "rokt-ui-locale": "en_US",
+                            "rokt-package-version": "1.0.0"
+                        ]
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",
@@ -163,7 +187,17 @@ class OffersClientPactSpec: XCTestCase {
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    // rokt-package-name is matched as a non-empty value (regex .+),
+                    // not by type: it is the signal server-side mobile page detection
+                    // keys off, and an empty value would silently return no offers.
+                    "rokt-package-name": Matcher.RegexLike("com.rokt.example", term: #".+"#),
+                    // Device headers ride in via NetworkingHelper.txnDeviceHeaders;
+                    // asserted here for parity with the Android offers contract.
+                    "rokt-os-type": Matcher.SomethingLike("iOS"),
+                    "rokt-os-version": Matcher.SomethingLike("17.0"),
+                    "rokt-device-model": Matcher.SomethingLike("iPhone15,2"),
+                    "rokt-ui-locale": Matcher.SomethingLike("en_US"),
+                    "rokt-package-version": Matcher.SomethingLike("1.0.0"),
                     "Content-Type": "application/json"
                 ],
                 body: [
@@ -220,7 +254,15 @@ class OffersClientPactSpec: XCTestCase {
                         accountId: "account-456",
                         authToken: "Bearer session-token-abc",
                         sdkVersion: "5.2.2",
-                        pageInstanceGuid: "page-instance-guid-123"
+                        pageInstanceGuid: "page-instance-guid-123",
+                        deviceHeaders: [
+                            "rokt-package-name": "com.rokt.example",
+                            "rokt-os-type": "iOS",
+                            "rokt-os-version": "17.0",
+                            "rokt-device-model": "iPhone15,2",
+                            "rokt-ui-locale": "en_US",
+                            "rokt-package-version": "1.0.0"
+                        ]
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",

--- a/Tests/ContractTests/OffersClientPactSpec.swift
+++ b/Tests/ContractTests/OffersClientPactSpec.swift
@@ -26,12 +26,9 @@ import PactSwift
 /// the client drift to `"ios-mobile"` without failing the consumer test.
 /// Per-runtime values (account id, auth token, request id, page identifier,
 /// etc.) stay as `SomethingLike` because they legitimately vary per call.
-/// `rokt-package-name` is the exception: it is matched as a non-empty value
-/// (regex `.+`) because server-side mobile page detection keys off it and an
-/// empty value would silently return no offers. The device headers
-/// (`rokt-os-type`/`-os-version`/`-device-model`/`-ui-locale`/`-package-version`)
-/// ride in via `NetworkingHelper.txnDeviceHeaders` and are asserted for parity
-/// with the Android offers contract.
+/// Device headers from `NetworkingHelper.txnDeviceHeaders` are sent on the live
+/// request; only `rokt-package-name` (it gates page detection) is asserted here,
+/// supplied via `deviceHeaders` below.
 class OffersClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -63,17 +60,7 @@ class OffersClientPactSpec: XCTestCase {
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    // rokt-package-name is matched as a non-empty value (regex .+),
-                    // not by type: it is the signal server-side mobile page detection
-                    // keys off, and an empty value would silently return no offers.
-                    "rokt-package-name": Matcher.RegexLike("com.rokt.example", term: #".+"#),
-                    // Device headers ride in via NetworkingHelper.txnDeviceHeaders;
-                    // asserted here for parity with the Android offers contract.
-                    "rokt-os-type": Matcher.SomethingLike("iOS"),
-                    "rokt-os-version": Matcher.SomethingLike("17.0"),
-                    "rokt-device-model": Matcher.SomethingLike("iPhone15,2"),
-                    "rokt-ui-locale": Matcher.SomethingLike("en_US"),
-                    "rokt-package-version": Matcher.SomethingLike("1.0.0"),
+                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
                     "Content-Type": "application/json"
                 ],
                 body: [
@@ -141,14 +128,7 @@ class OffersClientPactSpec: XCTestCase {
                         authToken: "Bearer session-token-abc",
                         sdkVersion: "5.2.2",
                         pageInstanceGuid: "page-instance-guid-123",
-                        deviceHeaders: [
-                            "rokt-package-name": "com.rokt.example",
-                            "rokt-os-type": "iOS",
-                            "rokt-os-version": "17.0",
-                            "rokt-device-model": "iPhone15,2",
-                            "rokt-ui-locale": "en_US",
-                            "rokt-package-version": "1.0.0"
-                        ]
+                        deviceHeaders: ["rokt-package-name": "com.rokt.example"]
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",
@@ -187,17 +167,7 @@ class OffersClientPactSpec: XCTestCase {
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
-                    // rokt-package-name is matched as a non-empty value (regex .+),
-                    // not by type: it is the signal server-side mobile page detection
-                    // keys off, and an empty value would silently return no offers.
-                    "rokt-package-name": Matcher.RegexLike("com.rokt.example", term: #".+"#),
-                    // Device headers ride in via NetworkingHelper.txnDeviceHeaders;
-                    // asserted here for parity with the Android offers contract.
-                    "rokt-os-type": Matcher.SomethingLike("iOS"),
-                    "rokt-os-version": Matcher.SomethingLike("17.0"),
-                    "rokt-device-model": Matcher.SomethingLike("iPhone15,2"),
-                    "rokt-ui-locale": Matcher.SomethingLike("en_US"),
-                    "rokt-package-version": Matcher.SomethingLike("1.0.0"),
+                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
                     "Content-Type": "application/json"
                 ],
                 body: [
@@ -255,14 +225,7 @@ class OffersClientPactSpec: XCTestCase {
                         authToken: "Bearer session-token-abc",
                         sdkVersion: "5.2.2",
                         pageInstanceGuid: "page-instance-guid-123",
-                        deviceHeaders: [
-                            "rokt-package-name": "com.rokt.example",
-                            "rokt-os-type": "iOS",
-                            "rokt-os-version": "17.0",
-                            "rokt-device-model": "iPhone15,2",
-                            "rokt-ui-locale": "en_US",
-                            "rokt-package-version": "1.0.0"
-                        ]
+                        deviceHeaders: ["rokt-package-name": "com.rokt.example"]
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
@@ -494,6 +494,23 @@ class RealTimeEventStoreMemoryTest: XCTestCase {
         XCTAssertEqual(sut.getTriggeredEvents().count, 1, "One trigger should match a single deduped row")
     }
 
+    func test_addUntriggeredEvents_capsStoreToMaximum() {
+        // Distinct events beyond the cap must not accumulate forever; the oldest are evicted.
+        sut.addUntriggeredEvents(createUntriggeredEvents(maximumRealTimeEventsToStore + 10))
+
+        // guid0 (oldest) is evicted by the cap -> no match.
+        sut.markAsTriggered([createRoktEventRequest(parentGuid: "guid0", eventType: .SignalImpression)])
+        XCTAssertTrue(sut.getTriggeredEvents().isEmpty, "Oldest untriggered event should be evicted once the cap is exceeded")
+
+        // A recent event is retained -> still matches.
+        let lastGuid = "guid\(maximumRealTimeEventsToStore + 10 - 1)"
+        sut.markAsTriggered([createRoktEventRequest(parentGuid: lastGuid, eventType: .SignalImpression)])
+        XCTAssertTrue(
+            sut.getTriggeredEvents().contains { $0.parentGuid == lastGuid },
+            "Most recent untriggered events should be retained"
+        )
+    }
+
     // MARK: - Tests for clear
 
     func test_clear_removesAllEvents() {

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
@@ -473,6 +473,27 @@ class RealTimeEventStoreMemoryTest: XCTestCase {
         )
     }
 
+    func test_addUntriggeredEvents_deduplicatesIdenticalEvents() {
+        let event = createRoktUXRealTimeEventResponse(
+            triggerGuid: guid1,
+            triggerEvent: signalImpressionRawValue,
+            eventType: finalType1,
+            payload: payload1
+        )
+        // The backend can echo the same event_data across responses; identical rows must not
+        // accumulate, or a single trigger would match each duplicate and multiply the output.
+        sut.addUntriggeredEvents([event])
+        sut.addUntriggeredEvents([event])
+        sut.addUntriggeredEvents([event, event])
+
+        sut.markAsTriggered([createRoktEventRequest(
+            parentGuid: guid1,
+            eventType: RoktUXEventType(rawValue: signalImpressionRawValue)!
+        )])
+
+        XCTAssertEqual(sut.getTriggeredEvents().count, 1, "One trigger should match a single deduped row")
+    }
+
     // MARK: - Tests for clear
 
     func test_clear_removesAllEvents() {

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
@@ -62,6 +62,24 @@ final class TestSelectSerialization: XCTestCase {
         XCTAssertNil(object["mpid"])
         XCTAssertNil(object["customer"])
         XCTAssertNil(object["privacy_control"])
+        XCTAssertNil(object["privacy"])
+    }
+
+    func test_request_encodesGpcUnderTopLevelPrivacy() throws {
+        // gpc_enabled rides under a top-level `privacy` object, a sibling of
+        // `privacy_control` (Android parity) — not folded into privacy_control.
+        let request = SelectRequest(
+            page: SelectPage(pageIdentifier: "checkout"),
+            channel: SelectChannel(sdkVersion: "5.2.2"),
+            privacy: SelectPrivacy(gpcEnabled: true)
+        )
+
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        let privacy = try XCTUnwrap(object["privacy"] as? [String: Any])
+        XCTAssertEqual(privacy["gpc_enabled"] as? Bool, true)
+        XCTAssertNil(object["privacy_control"])
     }
 
     // MARK: - Response

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
@@ -63,6 +63,27 @@ final class TestSelectSerialization: XCTestCase {
         XCTAssertNil(object["customer"])
         XCTAssertNil(object["privacy_control"])
         XCTAssertNil(object["privacy"])
+        XCTAssertNil(object["events"])
+    }
+
+    func test_request_encodesEventsInTheEventsEndpointShape() throws {
+        // Forwarded real-time events reuse the /v2/sessions/events element shape:
+        // event_type + epoch-ms timestamp + data.payload, with instance_id omitted.
+        let request = SelectRequest(
+            page: SelectPage(pageIdentifier: "checkout"),
+            channel: SelectChannel(sdkVersion: "5.2.2"),
+            events: [SelectEvent(eventType: "impression", timestamp: 123, payload: "pl")]
+        )
+
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let events = try XCTUnwrap(object["events"] as? [[String: Any]])
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["event_type"] as? String, "impression")
+        XCTAssertEqual(events.first?["timestamp"] as? Int, 123)
+        XCTAssertEqual((events.first?["data"] as? [String: Any])?["payload"] as? String, "pl")
+        XCTAssertNil(events.first?["instance_id"])
     }
 
     func test_request_encodesGpcUnderTopLevelPrivacy() throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -98,6 +98,7 @@ final class TestOffersService: XCTestCase {
     private func makeService(
         _ stub: StubHTTPClient,
         sessionManager: TxnSessionManager = TxnSessionManager(),
+        deviceHeaders: [String: String] = [:],
         maxRetries: Int = 0
     ) -> OffersService {
         OffersService(
@@ -106,6 +107,7 @@ final class TestOffersService: XCTestCase {
             sdkVersion: "1.0.0",
             sessionManager: sessionManager,
             httpClient: stub,
+            deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
             sleep: { _ in }
         )
@@ -202,6 +204,52 @@ final class TestOffersService: XCTestCase {
         XCTAssertEqual(attributes?["email"] as? String, "a@b.com")
         // Privacy keys are stripped from the forwarded attributes.
         XCTAssertNil(attributes?["noFunctional"])
+    }
+
+    func test_getExperienceData_forwardsDeviceHeaders() {
+        let stub = StubHTTPClient(responseData: Data(offersResponse.utf8), statusCode: 200)
+        let service = makeService(stub, deviceHeaders: [
+            "rokt-os-type": "iOS",
+            "rokt-package-name": "com.rokt.test"
+        ])
+
+        let completed = expectation(description: "offers experience returned")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            completed.fulfill()
+        }, failure: { error, _, _ in
+            XCTFail("unexpected failure: \(error)")
+        })
+
+        wait(for: [completed], timeout: 5)
+        // Device headers (incl. the load-bearing rokt-package-name) reach the request.
+        XCTAssertEqual(stub.lastHeaders?["rokt-os-type"], "iOS")
+        XCTAssertEqual(stub.lastHeaders?["rokt-package-name"], "com.rokt.test")
+    }
+
+    func test_getExperienceData_omitsAuthorizationUntilTokenRolledForward() {
+        let stub = StubHTTPClient(responseData: Data(offersResponse.utf8), statusCode: 200)
+        let service = makeService(stub, sessionManager: TxnSessionManager())
+
+        // First call: no live token, so Authorization is omitted entirely — the server
+        // then mints a fresh session rather than seeing a blank `Bearer` header.
+        let first = expectation(description: "first offers call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            first.fulfill()
+        }, failure: { error, _, _ in
+            XCTFail("unexpected failure: \(error)")
+        })
+        wait(for: [first], timeout: 5)
+        XCTAssertNil(stub.lastHeaders?["Authorization"])
+
+        // The response rolled a non-expired token forward, so the next call carries it.
+        let second = expectation(description: "second offers call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            second.fulfill()
+        }, failure: { error, _, _ in
+            XCTFail("unexpected failure: \(error)")
+        })
+        wait(for: [second], timeout: 5)
+        XCTAssertEqual(stub.lastHeaders?["Authorization"], "Bearer rolled-token")
     }
 
     func test_getExperienceData_retriesTransientTransportErrorThenSucceeds() {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -99,8 +99,11 @@ final class TestOffersService: XCTestCase {
         _ stub: StubHTTPClient,
         sessionManager: TxnSessionManager = TxnSessionManager(),
         deviceHeaders: [String: String] = [:],
+        triggeredEvents: @escaping () -> [TriggeredRealTimeEvent] = { [] },
+        captureEvents: @escaping ([UntriggeredRealTimeEvent]) -> Void = { _ in },
         maxRetries: Int = 0
     ) -> OffersService {
+        // Event store seams default to inert so tests never touch the global singleton.
         OffersService(
             environment: .Prod,
             accountId: "account-1",
@@ -109,7 +112,9 @@ final class TestOffersService: XCTestCase {
             httpClient: stub,
             deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
-            sleep: { _ in }
+            sleep: { _ in },
+            triggeredEvents: triggeredEvents,
+            captureEvents: captureEvents
         )
     }
 
@@ -230,6 +235,8 @@ final class TestOffersService: XCTestCase {
         // Device headers (incl. the load-bearing rokt-package-name) reach the request.
         XCTAssertEqual(stub.lastHeaders?["rokt-os-type"], "iOS")
         XCTAssertEqual(stub.lastHeaders?["rokt-package-name"], "com.rokt.test")
+        // Every v2 request marks itself as live (non-shadow) traffic.
+        XCTAssertEqual(stub.lastHeaders?["rokt-txn-shadow"], "false")
     }
 
     func test_getExperienceData_omitsAuthorizationUntilTokenRolledForward() {
@@ -256,6 +263,77 @@ final class TestOffersService: XCTestCase {
         })
         wait(for: [second], timeout: 5)
         XCTAssertEqual(stub.lastHeaders?["Authorization"], "Bearer rolled-token")
+    }
+
+    func test_getExperienceData_forwardsTriggeredEventsOnlyWhenSessionLive() throws {
+        let stub = StubHTTPClient(responseData: Data(offersResponse.utf8), statusCode: 200)
+        let eventTime = EventDateFormatter.dateFormatter.string(from: Date(timeIntervalSince1970: 1_782_484_201))
+        let service = makeService(stub, sessionManager: TxnSessionManager(), triggeredEvents: {
+            [TriggeredRealTimeEvent(parentGuid: "p", eventType: "impression", eventTime: eventTime, payload: "pl")]
+        })
+
+        // No live token yet: events are not forwarded (nothing to attribute them to). This
+        // call rolls a non-expired token forward via the response.
+        let first = expectation(description: "first call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            first.fulfill()
+        }, failure: { error, _, _ in XCTFail("unexpected failure: \(error)") })
+        wait(for: [first], timeout: 5)
+        XCTAssertNil((stub.lastParameters as? [String: Any])?["events"])
+
+        // With a live token the triggered events ride on the request as events[] in the
+        // /v2/sessions/events shape (event_type + epoch-ms timestamp + data.payload, no instance_id).
+        let second = expectation(description: "second call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            second.fulfill()
+        }, failure: { error, _, _ in XCTFail("unexpected failure: \(error)") })
+        wait(for: [second], timeout: 5)
+
+        let body = stub.lastParameters as? [String: Any]
+        let events = try XCTUnwrap(body?["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["event_type"] as? String, "impression")
+        XCTAssertEqual(events.first?["timestamp"] as? Int, 1_782_484_201_000)
+        XCTAssertEqual((events.first?["data"] as? [String: Any])?["payload"] as? String, "pl")
+        XCTAssertNil(events.first?["instance_id"])
+    }
+
+    func test_getExperienceData_capturesResponseEventDataForNextCall() {
+        let responseWithEvents = """
+        {
+          "session_id": "session-1",
+          "session_token": { "token": "rolled-token", "expires_at": 32503680000000 },
+          "page_context": { "page_id": "checkout" },
+          "plugins": [
+            { "plugin": { "id": "plugin-1", "config": {
+              "token": "plugin-token",
+              "outer_layout_schema": "{\\"layout\\":{\\"node\\":\\"outer\\"}}",
+              "slots": []
+            } } }
+          ],
+          "event_data": {
+            "parent-1": { "token": "tok", "events": { "SignalResponse": { "event_type": "x", "payload": "y" } } }
+          }
+        }
+        """
+        let stub = StubHTTPClient(responseData: Data(responseWithEvents.utf8), statusCode: 200)
+        var captured: [UntriggeredRealTimeEvent] = []
+        let service = makeService(stub, captureEvents: { captured = $0 })
+
+        let completed = expectation(description: "offers response captured")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            completed.fulfill()
+        }, failure: { error, _, _ in
+            XCTFail("unexpected failure: \(error)")
+        })
+        wait(for: [completed], timeout: 5)
+
+        // The echoed event_data is flattened into untriggered events for the next placement.
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertEqual(captured.first?.triggerGuid, "parent-1")
+        XCTAssertEqual(captured.first?.triggerEvent, "SignalResponse")
+        XCTAssertEqual(captured.first?.eventType, "x")
+        XCTAssertEqual(captured.first?.payload, "y")
     }
 
     func test_getExperienceData_retriesTransientTransportErrorThenSucceeds() {
@@ -322,7 +400,8 @@ final class TestOffersService: XCTestCase {
             sessionManager: TxnSessionManager(),
             httpClient: stub,
             maxRetries: 1,
-            baseBackoff: 0.001
+            baseBackoff: 0.001,
+            triggeredEvents: { [] }
         )
 
         let completed = expectation(description: "default backoff sleep used on retry")

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -185,7 +185,7 @@ final class TestOffersService: XCTestCase {
         let completed = expectation(description: "request built")
         service.getExperienceData(
             viewName: "checkout",
-            attributes: ["noFunctional": "true", "doNotShareOrSell": "false", "email": "a@b.com"],
+            attributes: ["noFunctional": "true", "doNotShareOrSell": "false", "gpcEnabled": "true", "email": "a@b.com"],
             config: nil,
             onRequestStart: { onRequestStartFired = true },
             successLayout: { _ in completed.fulfill() },
@@ -196,14 +196,20 @@ final class TestOffersService: XCTestCase {
         XCTAssertTrue(onRequestStartFired)
 
         let body = try? XCTUnwrap(stub.lastParameters as? [String: Any])
-        let privacy = body?["privacy_control"] as? [String: Any]
-        XCTAssertEqual(privacy?["no_functional"] as? Bool, true)
-        XCTAssertEqual(privacy?["do_not_share_or_sell"] as? Bool, false)
+        let privacyControl = body?["privacy_control"] as? [String: Any]
+        XCTAssertEqual(privacyControl?["no_functional"] as? Bool, true)
+        XCTAssertEqual(privacyControl?["do_not_share_or_sell"] as? Bool, false)
+
+        // gpc_enabled travels under a separate top-level `privacy` object, not privacy_control.
+        let privacy = body?["privacy"] as? [String: Any]
+        XCTAssertEqual(privacy?["gpc_enabled"] as? Bool, true)
+        XCTAssertNil(privacyControl?["gpc_enabled"])
 
         let attributes = body?["attributes"] as? [String: Any]
         XCTAssertEqual(attributes?["email"] as? String, "a@b.com")
-        // Privacy keys are stripped from the forwarded attributes.
+        // Privacy keys (incl. gpcEnabled) are stripped from the forwarded attributes.
         XCTAssertNil(attributes?["noFunctional"])
+        XCTAssertNil(attributes?["gpcEnabled"])
     }
 
     func test_getExperienceData_forwardsDeviceHeaders() {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Rokt_Widget
+
+/// Covers the real-time event bridge between the SDK store and the v2 offers
+/// request/response: triggered events map to the request `events[]` shape, and the
+/// response `event_data` flattens into untriggered events for the next call.
+final class TestSelectEventMapper: XCTestCase {
+
+    func test_requestEvents_mapsTriggeredEventToWireShape() throws {
+        // Round-trip the event time through the formatter so the epoch-ms is exact.
+        let eventTime = EventDateFormatter.dateFormatter.string(from: Date(timeIntervalSince1970: 1_782_484_201))
+        let triggered = [
+            TriggeredRealTimeEvent(parentGuid: "p", eventType: "impression", eventTime: eventTime, payload: "pl")
+        ]
+
+        let events = SelectEventMapper.requestEvents(from: triggered)
+
+        XCTAssertEqual(events.count, 1)
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(event.eventType, "impression")
+        XCTAssertEqual(event.timestamp, 1_782_484_201_000)
+        XCTAssertEqual(event.payload, "pl")
+    }
+
+    func test_requestEvents_fallsBackToNowWhenEventTimeUnparseable() {
+        let triggered = [
+            TriggeredRealTimeEvent(parentGuid: "p", eventType: "viewed", eventTime: "not-a-date", payload: "pl")
+        ]
+
+        let events = SelectEventMapper.requestEvents(from: triggered)
+
+        // Unparseable time falls back to ~now rather than dropping the event.
+        XCTAssertEqual(events.count, 1)
+        XCTAssertGreaterThan(events.first?.timestamp ?? 0, 0)
+    }
+
+    func test_untriggeredEvents_flattensResponseEventData() throws {
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": {
+            "parent-1": { "token": "tok", "events": { "SignalResponse": { "event_type": "x", "payload": "y" } } }
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        let untriggered = SelectEventMapper.untriggeredEvents(from: eventData)
+
+        XCTAssertEqual(untriggered.count, 1)
+        let event = try XCTUnwrap(untriggered.first)
+        XCTAssertEqual(event.triggerGuid, "parent-1")
+        XCTAssertEqual(event.triggerEvent, "SignalResponse")
+        XCTAssertEqual(event.eventType, "x")
+        XCTAssertEqual(event.payload, "y")
+        XCTAssertTrue(event.isValid())
+    }
+
+    func test_untriggeredEvents_isEmptyWhenEntryHasNoEvents() throws {
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": { "parent-1": { "token": "tok" } }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        XCTAssertTrue(SelectEventMapper.untriggeredEvents(from: eventData).isEmpty)
+    }
+
+    func test_untriggeredEvents_dropsEntriesMissingRequiredFields() throws {
+        // A signal missing event_type is invalid and is filtered out (matches UntriggeredEventsContainer).
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": {
+            "parent-1": { "token": "tok", "events": {
+              "Valid": { "event_type": "x", "payload": "y" },
+              "MissingType": { "payload": "z" }
+            } }
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        let untriggered = SelectEventMapper.untriggeredEvents(from: eventData)
+
+        XCTAssertEqual(untriggered.count, 1)
+        XCTAssertEqual(untriggered.first?.triggerEvent, "Valid")
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -80,6 +80,7 @@ final class TestTxnEventService: XCTestCase {
         XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-account-id"], "account-1")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-os-type"], "iOS")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-txn-shadow"], "false")
     }
 
     func test_send_withoutToken_omitsAuthorization() async throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -79,6 +79,7 @@ final class TestTxnInitService: XCTestCase {
         _ = try await makeService().initSession()
 
         XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-txn-shadow"], "false")
     }
 
     func test_initSession_withoutToken_omitsAuthorizationHeader() async throws {


### PR DESCRIPTION
## Summary

Fills the remaining gaps in the v2 offers request shape so it matches Android: the mobile device headers and the GPC consent signal now ride on `POST /v2/sessions/offers`.

## Changes

**Device headers.** `deviceHeaders` is plumbed through `OffersService` → `OffersClient`, and `defaultOffersService` passes `NetworkingHelper.txnDeviceHeaders()` just like `defaultTxnEventService`. Adds `rokt-os-type`, `rokt-os-version`, `rokt-device-model`, `rokt-ui-locale`, `rokt-package-version`. `rokt-package-name` now rides in via the device headers (set only when the bundle id resolves) instead of a hardcoded `Bundle.main.bundleIdentifier ?? ""` with a silent empty fallback.

**Authorization.** Omitted entirely when there is no live session token (was sending a blank `Bearer`), matching the events client — the server then mints a fresh session.

**privacy.gpc_enabled.** The GPC signal was parsed from the attributes but dropped before the wire. It now travels as a top-level `privacy { gpc_enabled }` object, a sibling of `privacy_control` (not folded into it), omitted when absent. `privacy_control` is also omitted when none of its three keys are present (was encoding an empty object).

## Notes

The new device headers and `privacy.gpc_enabled` ride on the live request but are not asserted in the consumer pact yet, so the published contract stays at its current shape; the assertions are a follow-up. Real-time `events[]` forwarding is the remaining offers-request gap, handled in a separate stacked PR.

## Testing

`xcodebuild test` on the iPhone 17 Pro simulator — `TestOffersService`, `TestSelectSerialization`, `OffersClientPactSpec`, `TestOffersExecuteWiring`, `TestMockOffersHTTPClient` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
