### PR TITLE
feat(offers): forward real-time events on the v2 offers request

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -15,7 +15,7 @@ class RealtimeEventStoreMemory: RealTimeEventStore {
     private var triggeredEvents: [TriggeredRealTimeEvent] = []
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
-        self.untriggeredEvents.append(contentsOf: events)
+        appendDeduped(events, to: &untriggeredEvents)
     }
 
     func getTriggeredEvents() -> [TriggeredRealTimeEvent] {
@@ -68,7 +68,7 @@ class RealTimeEventStoreFile: RealTimeEventStore {
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
         guard let untriggeredEventsFilePath else { return }
         var all = getUntriggeredEvents()
-        all.append(contentsOf: events)
+        appendDeduped(events, to: &all)
         save(all, to: untriggeredEventsFilePath)
     }
 
@@ -194,4 +194,14 @@ private func updateTriggeredEvents(
 private func trimTriggeredEvents(_ triggeredEvents: [TriggeredRealTimeEvent]) -> [TriggeredRealTimeEvent] {
     let sortedEvents = triggeredEvents.sorted { $0.eventTime > $1.eventTime }
     return Array(sortedEvents.prefix(maximumRealTimeEventsToStore))
+}
+
+// Appends only events not already present, preserving order. The backend can echo the same
+// event_data across responses; de-duping keeps the untriggered store bounded and stops a single
+// trigger from matching duplicate rows and multiplying what gets forwarded.
+private func appendDeduped(_ events: [UntriggeredRealTimeEvent], to all: inout [UntriggeredRealTimeEvent]) {
+    var seen = Set(all)
+    for event in events where seen.insert(event).inserted {
+        all.append(event)
+    }
 }

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -16,8 +16,8 @@ internal struct SelectRequest: Encodable, Equatable {
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
     // Real-time events triggered during the previous placement, forwarded for the next
-    // selection. Reuses TxnEvent (the /v2/sessions/events element); omitted when none.
-    let events: [TxnEvent]?
+    // selection; omitted when none.
+    let events: [SelectEvent]?
 
     enum CodingKeys: String, CodingKey {
         case page
@@ -34,7 +34,7 @@ internal struct SelectRequest: Encodable, Equatable {
         attributes: [String: String] = [:],
         privacyControl: SelectPrivacyControl? = nil,
         privacy: SelectPrivacy? = nil,
-        events: [TxnEvent]? = nil
+        events: [SelectEvent]? = nil
     ) {
         self.page = page
         self.channel = channel
@@ -113,6 +113,33 @@ internal struct SelectPrivacy: Encodable, Equatable {
 
     init(gpcEnabled: Bool? = nil) {
         self.gpcEnabled = gpcEnabled
+    }
+}
+
+/// A real-time event forwarded on the offers request: the provider's typed event
+/// plus its echoed `payload`, stamped with an epoch-ms `timestamp`. Encodes to the
+/// `/v2/sessions/events` element shape (`event_type`, `timestamp`, `data.payload`).
+internal struct SelectEvent: Encodable, Equatable {
+    let eventType: String
+    let timestamp: Int64
+    let payload: String
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case timestamp
+        case data
+    }
+
+    private enum DataKeys: String, CodingKey {
+        case payload
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(eventType, forKey: .eventType)
+        try container.encode(timestamp, forKey: .timestamp)
+        var data = container.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
+        try data.encode(payload, forKey: .payload)
     }
 }
 

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -15,6 +15,9 @@ internal struct SelectRequest: Encodable, Equatable {
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
+    // Real-time events triggered during the previous placement, forwarded for the next
+    // selection. Reuses TxnEvent (the /v2/sessions/events element); omitted when none.
+    let events: [TxnEvent]?
 
     enum CodingKeys: String, CodingKey {
         case page
@@ -22,6 +25,7 @@ internal struct SelectRequest: Encodable, Equatable {
         case attributes
         case privacyControl = "privacy_control"
         case privacy
+        case events
     }
 
     init(
@@ -29,13 +33,15 @@ internal struct SelectRequest: Encodable, Equatable {
         channel: SelectChannel,
         attributes: [String: String] = [:],
         privacyControl: SelectPrivacyControl? = nil,
-        privacy: SelectPrivacy? = nil
+        privacy: SelectPrivacy? = nil,
+        events: [TxnEvent]? = nil
     ) {
         self.page = page
         self.channel = channel
         self.attributes = attributes
         self.privacyControl = privacyControl
         self.privacy = privacy
+        self.events = events
     }
 }
 

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -55,6 +55,8 @@ internal struct OffersClient {
             "rokt-account-id": accountId,
             "x-request-id": input.requestId,
             "rokt-page-instance-guid": pageInstanceGuid,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no live token the server mints a fresh session.

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -43,7 +43,8 @@ internal struct OffersClient {
             channel: SelectChannel(sdkVersion: sdkVersion),
             attributes: input.attributes,
             privacyControl: input.privacyControl,
-            privacy: input.privacy
+            privacy: input.privacy,
+            events: input.events
         )
         let bodyData = try JSONEncoder().encode(requestBody)
         guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
@@ -99,18 +100,21 @@ internal struct OffersInput {
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
+    let events: [TxnEvent]?
 
     init(
         requestId: String,
         pageIdentifier: String,
         attributes: [String: String],
         privacyControl: SelectPrivacyControl? = nil,
-        privacy: SelectPrivacy? = nil
+        privacy: SelectPrivacy? = nil,
+        events: [TxnEvent]? = nil
     ) {
         self.requestId = requestId
         self.pageIdentifier = pageIdentifier
         self.attributes = attributes
         self.privacyControl = privacyControl
         self.privacy = privacy
+        self.events = events
     }
 }

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -100,7 +100,7 @@ internal struct OffersInput {
     let attributes: [String: String]
     let privacyControl: SelectPrivacyControl?
     let privacy: SelectPrivacy?
-    let events: [TxnEvent]?
+    let events: [SelectEvent]?
 
     init(
         requestId: String,
@@ -108,7 +108,7 @@ internal struct OffersInput {
         attributes: [String: String],
         privacyControl: SelectPrivacyControl? = nil,
         privacy: SelectPrivacy? = nil,
-        events: [TxnEvent]? = nil
+        events: [SelectEvent]? = nil
     ) {
         self.requestId = requestId
         self.pageIdentifier = pageIdentifier

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -127,8 +127,11 @@ internal struct OffersService {
             deviceHeaders: deviceHeaders,
             httpClient: httpClient
         )
-        // Forward events triggered during the previous placement; read once, before retries.
-        // Only with a live session to attribute them to, matching Android.
+        // Forward events triggered during the previous placement; read once, before retries,
+        // and only with a live session to attribute them to (matching Android). As on the v1
+        // path, triggered events are not cleared after forwarding — they ride subsequent
+        // requests until session invalidation; re-send is expected (the "only adds, no clear"
+        // note elsewhere is about the untriggered response-capture, not this read).
         let forwardedEvents = authToken != nil ? SelectEventMapper.requestEvents(from: triggeredEvents()) : []
         let input = OffersInput(
             requestId: makeRequestId(),

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -24,6 +24,11 @@ internal struct OffersService {
     let makeRequestId: () -> String
     let makePageInstanceGuid: () -> String
     let completionQueue: DispatchQueue
+    // Real-time event store seams (injected for tests). `captureEvents` stores the response's
+    // events for the next call; it only adds (no global clear) to mirror the v1 capture and
+    // avoid wiping triggered events the events/v1 paths share in RealTimeEventManager.shared.
+    let triggeredEvents: () -> [TriggeredRealTimeEvent]
+    let captureEvents: ([UntriggeredRealTimeEvent]) -> Void
 
     init(
         environment: Environment,
@@ -40,7 +45,13 @@ internal struct OffersService {
         },
         makeRequestId: @escaping () -> String = { UUID().uuidString },
         makePageInstanceGuid: @escaping () -> String = { UUID().uuidString },
-        completionQueue: DispatchQueue = .main
+        completionQueue: DispatchQueue = .main,
+        triggeredEvents: @escaping () -> [TriggeredRealTimeEvent] = {
+            RealTimeEventManager.shared.getTriggeredEvents()
+        },
+        captureEvents: @escaping ([UntriggeredRealTimeEvent]) -> Void = { events in
+            RealTimeEventManager.shared.addUntriggeredEvents(events)
+        }
     ) {
         self.environment = environment
         self.accountId = accountId
@@ -55,6 +66,8 @@ internal struct OffersService {
         self.makeRequestId = makeRequestId
         self.makePageInstanceGuid = makePageInstanceGuid
         self.completionQueue = completionQueue
+        self.triggeredEvents = triggeredEvents
+        self.captureEvents = captureEvents
     }
 
     /// Builds the request from the partner inputs, fetches the experience, and reports
@@ -104,21 +117,26 @@ internal struct OffersService {
 
         httpClient.updateTimeout(timeout: requestTimeout)
 
+        let authToken = await sessionManager.authorizationHeader
         let client = OffersClient(
             baseURL: baseURL,
             accountId: accountId,
-            authToken: await sessionManager.authorizationHeader,
+            authToken: authToken,
             sdkVersion: sdkVersion,
             pageInstanceGuid: makePageInstanceGuid(),
             deviceHeaders: deviceHeaders,
             httpClient: httpClient
         )
+        // Forward events triggered during the previous placement; read once, before retries.
+        // Only with a live session to attribute them to, matching Android.
+        let forwardedEvents = authToken != nil ? SelectEventMapper.requestEvents(from: triggeredEvents()) : []
         let input = OffersInput(
             requestId: makeRequestId(),
             pageIdentifier: pageIdentifier,
             attributes: attributes,
             privacyControl: privacyControl,
-            privacy: privacy
+            privacy: privacy,
+            events: forwardedEvents.isEmpty ? nil : forwardedEvents
         )
 
         var attempt = 0
@@ -143,6 +161,10 @@ internal struct OffersService {
                 let decoded = try JSONDecoder().decode(SelectResponse.self, from: data)
                 // Roll the refreshed token forward for the next offers/events call.
                 await sessionManager.update(sessionToken: decoded.sessionToken)
+                // Capture the echoed events so the next placement can forward them back.
+                if let eventData = decoded.eventData {
+                    captureEvents(SelectEventMapper.untriggeredEvents(from: eventData))
+                }
                 return try SelectExperienceAdapter.experienceJSONString(from: decoded)
             } catch let error where isRetryable(error: error) && attempt < maxRetries {
                 try await sleep(backoffDelay(attempt: attempt))

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -4,19 +4,18 @@ import Foundation
 
 /// Bridges the SDK real-time event store and the v2 offers request/response.
 ///
-/// The request `events[]` element reuses ``TxnEvent`` (the `/v2/sessions/events`
-/// wire shape: `event_type`, epoch-ms `timestamp`, `data.payload`), matching
-/// Android; `instance_id` is omitted for forwarded events.
+/// The request `events[]` element (``SelectEvent``) encodes to the
+/// `/v2/sessions/events` wire shape: `event_type`, epoch-ms `timestamp`,
+/// `data.payload`, matching Android.
 internal enum SelectEventMapper {
 
     /// Triggered events from the previous placement → the offers request `events[]`.
-    static func requestEvents(from triggered: [TriggeredRealTimeEvent]) -> [TxnEvent] {
+    static func requestEvents(from triggered: [TriggeredRealTimeEvent]) -> [SelectEvent] {
         triggered.map { event in
-            TxnEvent(
+            SelectEvent(
                 eventType: event.eventType,
-                instanceId: nil,
                 timestamp: epochMilliseconds(from: event.eventTime),
-                data: ["payload": .string(event.payload)]
+                payload: event.payload
             )
         }
     }

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -1,0 +1,51 @@
+// periphery:ignore:all - offers real-time event mapping
+
+import Foundation
+
+/// Bridges the SDK real-time event store and the v2 offers request/response.
+///
+/// The request `events[]` element reuses ``TxnEvent`` (the `/v2/sessions/events`
+/// wire shape: `event_type`, epoch-ms `timestamp`, `data.payload`), matching
+/// Android; `instance_id` is omitted for forwarded events.
+internal enum SelectEventMapper {
+
+    /// Triggered events from the previous placement → the offers request `events[]`.
+    static func requestEvents(from triggered: [TriggeredRealTimeEvent]) -> [TxnEvent] {
+        triggered.map { event in
+            TxnEvent(
+                eventType: event.eventType,
+                instanceId: nil,
+                timestamp: epochMilliseconds(from: event.eventTime),
+                data: ["payload": .string(event.payload)]
+            )
+        }
+    }
+
+    /// Response `event_data` → untriggered events for the store, consulted when the
+    /// next placement fires (mirrors ``UntriggeredEventsContainer``'s flattening).
+    static func untriggeredEvents(from eventData: [String: SelectEventDataEntry]) -> [UntriggeredRealTimeEvent] {
+        var events: [UntriggeredRealTimeEvent] = []
+        for (parentGuid, entry) in eventData {
+            guard let signals = entry.events else { continue }
+            for (signalKey, signal) in signals {
+                events.append(
+                    UntriggeredRealTimeEvent(
+                        triggerGuid: parentGuid,
+                        triggerEvent: signalKey,
+                        eventType: signal.eventType,
+                        payload: signal.payload
+                    )
+                )
+            }
+        }
+        return events
+    }
+
+    // Mirrors TxnEventMapper: parse the stored ISO event time to epoch-ms, falling back to now.
+    private static func epochMilliseconds(from eventTime: String) -> Int64 {
+        if let date = EventDateFormatter.dateFormatter.date(from: eventTime) {
+            return Int64(date.timeIntervalSince1970 * 1000)
+        }
+        return Int64(Date().timeIntervalSince1970 * 1000)
+    }
+}

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -14,14 +14,17 @@ internal enum SelectEventMapper {
         triggered.map { event in
             SelectEvent(
                 eventType: event.eventType,
-                timestamp: epochMilliseconds(from: event.eventTime),
+                timestamp: EventDateFormatter.epochMilliseconds(from: event.eventTime),
                 payload: event.payload
             )
         }
     }
 
     /// Response `event_data` → untriggered events for the store, consulted when the
-    /// next placement fires (mirrors ``UntriggeredEventsContainer``'s flattening).
+    /// next placement fires. The flattening parallels ``UntriggeredEventsContainer`` (the
+    /// v1 path), but stays separate because v1 decodes camelCase `eventType` while v2
+    /// decodes snake_case `event_type`. Entries missing required fields are dropped here,
+    /// matching that sibling.
     static func untriggeredEvents(from eventData: [String: SelectEventDataEntry]) -> [UntriggeredRealTimeEvent] {
         var events: [UntriggeredRealTimeEvent] = []
         for (parentGuid, entry) in eventData {
@@ -37,14 +40,6 @@ internal enum SelectEventMapper {
                 )
             }
         }
-        return events
-    }
-
-    // Mirrors TxnEventMapper: parse the stored ISO event time to epoch-ms, falling back to now.
-    private static func epochMilliseconds(from eventTime: String) -> Int64 {
-        if let date = EventDateFormatter.dateFormatter.date(from: eventTime) {
-            return Int64(date.timeIntervalSince1970 * 1000)
-        }
-        return Int64(Date().timeIntervalSince1970 * 1000)
+        return events.filter { $0.isValid() }
     }
 }

--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -22,7 +22,7 @@ internal enum TxnEventMapper {
         return TxnEvent(
             eventType: mapped.eventType,
             instanceId: request.uuid,
-            timestamp: epochMilliseconds(from: request.eventTime),
+            timestamp: EventDateFormatter.epochMilliseconds(from: request.eventTime),
             data: buildData(
                 eventType: request.eventType,
                 attributes: request.eventData,
@@ -41,7 +41,7 @@ internal enum TxnEventMapper {
         return TxnEvent(
             eventType: mapped.eventType,
             instanceId: request.uuid,
-            timestamp: epochMilliseconds(from: request.eventTime),
+            timestamp: EventDateFormatter.epochMilliseconds(from: request.eventTime),
             data: buildData(
                 eventType: request.eventType,
                 attributes: request.attributes,
@@ -120,12 +120,5 @@ internal enum TxnEventMapper {
         for (key, value) in markers { data[key] = .string(value) }
 
         return data.isEmpty ? nil : data
-    }
-
-    private static func epochMilliseconds(from eventTime: String) -> Int64 {
-        if let date = EventDateFormatter.dateFormatter.date(from: eventTime) {
-            return Int64(date.timeIntervalSince1970 * 1000)
-        }
-        return Int64(Date().timeIntervalSince1970 * 1000)
     }
 }

--- a/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
@@ -38,6 +38,8 @@ internal struct TxnEventsClient {
 
         var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no live token the server mints a fresh session.

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -43,6 +43,8 @@ internal struct TxnInitClient {
         var headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
             "x-request-id": UUID().uuidString,
+            // Live (non-shadow) v2 request.
+            "rokt-txn-shadow": "false",
             "Content-Type": "application/json"
         ]
         // Authorization is optional: with no stored token the server mints a fresh session.

--- a/Sources/Rokt_Widget/Util/EventDateFormatter.swift
+++ b/Sources/Rokt_Widget/Util/EventDateFormatter.swift
@@ -16,4 +16,14 @@ class EventDateFormatter {
     static func getDateString(_ date: Date) -> String {
         dateFormatter.string(from: date)
     }
+
+    /// Parses an event-time string to epoch milliseconds, falling back to now when
+    /// unparseable. Shared by the txn-events and offers-events paths so the fallback
+    /// policy can't drift between them.
+    static func epochMilliseconds(from eventTime: String) -> Int64 {
+        if let date = dateFormatter.date(from: eventTime) {
+            return Int64(date.timeIntervalSince1970 * 1000)
+        }
+        return Int64(Date().timeIntervalSince1970 * 1000)
+    }
 }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreMemoryTest.swift
@@ -473,6 +473,27 @@ class RealTimeEventStoreMemoryTest: XCTestCase {
         )
     }
 
+    func test_addUntriggeredEvents_deduplicatesIdenticalEvents() {
+        let event = createRoktUXRealTimeEventResponse(
+            triggerGuid: guid1,
+            triggerEvent: signalImpressionRawValue,
+            eventType: finalType1,
+            payload: payload1
+        )
+        // The backend can echo the same event_data across responses; identical rows must not
+        // accumulate, or a single trigger would match each duplicate and multiply the output.
+        sut.addUntriggeredEvents([event])
+        sut.addUntriggeredEvents([event])
+        sut.addUntriggeredEvents([event, event])
+
+        sut.markAsTriggered([createRoktEventRequest(
+            parentGuid: guid1,
+            eventType: RoktUXEventType(rawValue: signalImpressionRawValue)!
+        )])
+
+        XCTAssertEqual(sut.getTriggeredEvents().count, 1, "One trigger should match a single deduped row")
+    }
+
     // MARK: - Tests for clear
 
     func test_clear_removesAllEvents() {

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
@@ -72,7 +72,7 @@ final class TestSelectSerialization: XCTestCase {
         let request = SelectRequest(
             page: SelectPage(pageIdentifier: "checkout"),
             channel: SelectChannel(sdkVersion: "5.2.2"),
-            events: [TxnEvent(eventType: "impression", instanceId: nil, timestamp: 123, data: ["payload": .string("pl")])]
+            events: [SelectEvent(eventType: "impression", timestamp: 123, payload: "pl")]
         )
 
         let encoded = try JSONEncoder().encode(request)

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestSelectSerialization.swift
@@ -63,6 +63,27 @@ final class TestSelectSerialization: XCTestCase {
         XCTAssertNil(object["customer"])
         XCTAssertNil(object["privacy_control"])
         XCTAssertNil(object["privacy"])
+        XCTAssertNil(object["events"])
+    }
+
+    func test_request_encodesEventsInTheEventsEndpointShape() throws {
+        // Forwarded real-time events reuse the /v2/sessions/events element shape:
+        // event_type + epoch-ms timestamp + data.payload, with instance_id omitted.
+        let request = SelectRequest(
+            page: SelectPage(pageIdentifier: "checkout"),
+            channel: SelectChannel(sdkVersion: "5.2.2"),
+            events: [TxnEvent(eventType: "impression", instanceId: nil, timestamp: 123, data: ["payload": .string("pl")])]
+        )
+
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let events = try XCTUnwrap(object["events"] as? [[String: Any]])
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["event_type"] as? String, "impression")
+        XCTAssertEqual(events.first?["timestamp"] as? Int, 123)
+        XCTAssertEqual((events.first?["data"] as? [String: Any])?["payload"] as? String, "pl")
+        XCTAssertNil(events.first?["instance_id"])
     }
 
     func test_request_encodesGpcUnderTopLevelPrivacy() throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -99,8 +99,11 @@ final class TestOffersService: XCTestCase {
         _ stub: StubHTTPClient,
         sessionManager: TxnSessionManager = TxnSessionManager(),
         deviceHeaders: [String: String] = [:],
+        triggeredEvents: @escaping () -> [TriggeredRealTimeEvent] = { [] },
+        captureEvents: @escaping ([UntriggeredRealTimeEvent]) -> Void = { _ in },
         maxRetries: Int = 0
     ) -> OffersService {
+        // Event store seams default to inert so tests never touch the global singleton.
         OffersService(
             environment: .Prod,
             accountId: "account-1",
@@ -109,7 +112,9 @@ final class TestOffersService: XCTestCase {
             httpClient: stub,
             deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
-            sleep: { _ in }
+            sleep: { _ in },
+            triggeredEvents: triggeredEvents,
+            captureEvents: captureEvents
         )
     }
 
@@ -258,6 +263,77 @@ final class TestOffersService: XCTestCase {
         XCTAssertEqual(stub.lastHeaders?["Authorization"], "Bearer rolled-token")
     }
 
+    func test_getExperienceData_forwardsTriggeredEventsOnlyWhenSessionLive() throws {
+        let stub = StubHTTPClient(responseData: Data(offersResponse.utf8), statusCode: 200)
+        let eventTime = EventDateFormatter.dateFormatter.string(from: Date(timeIntervalSince1970: 1_782_484_201))
+        let service = makeService(stub, sessionManager: TxnSessionManager(), triggeredEvents: {
+            [TriggeredRealTimeEvent(parentGuid: "p", eventType: "impression", eventTime: eventTime, payload: "pl")]
+        })
+
+        // No live token yet: events are not forwarded (nothing to attribute them to). This
+        // call rolls a non-expired token forward via the response.
+        let first = expectation(description: "first call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            first.fulfill()
+        }, failure: { error, _, _ in XCTFail("unexpected failure: \(error)") })
+        wait(for: [first], timeout: 5)
+        XCTAssertNil((stub.lastParameters as? [String: Any])?["events"])
+
+        // With a live token the triggered events ride on the request as events[] in the
+        // /v2/sessions/events shape (event_type + epoch-ms timestamp + data.payload, no instance_id).
+        let second = expectation(description: "second call")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            second.fulfill()
+        }, failure: { error, _, _ in XCTFail("unexpected failure: \(error)") })
+        wait(for: [second], timeout: 5)
+
+        let body = stub.lastParameters as? [String: Any]
+        let events = try XCTUnwrap(body?["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["event_type"] as? String, "impression")
+        XCTAssertEqual(events.first?["timestamp"] as? Int, 1_782_484_201_000)
+        XCTAssertEqual((events.first?["data"] as? [String: Any])?["payload"] as? String, "pl")
+        XCTAssertNil(events.first?["instance_id"])
+    }
+
+    func test_getExperienceData_capturesResponseEventDataForNextCall() {
+        let responseWithEvents = """
+        {
+          "session_id": "session-1",
+          "session_token": { "token": "rolled-token", "expires_at": 32503680000000 },
+          "page_context": { "page_id": "checkout" },
+          "plugins": [
+            { "plugin": { "id": "plugin-1", "config": {
+              "token": "plugin-token",
+              "outer_layout_schema": "{\\"layout\\":{\\"node\\":\\"outer\\"}}",
+              "slots": []
+            } } }
+          ],
+          "event_data": {
+            "parent-1": { "token": "tok", "events": { "SignalResponse": { "event_type": "x", "payload": "y" } } }
+          }
+        }
+        """
+        let stub = StubHTTPClient(responseData: Data(responseWithEvents.utf8), statusCode: 200)
+        var captured: [UntriggeredRealTimeEvent] = []
+        let service = makeService(stub, captureEvents: { captured = $0 })
+
+        let completed = expectation(description: "offers response captured")
+        service.getExperienceData(viewName: "checkout", attributes: [:], config: nil, successLayout: { _ in
+            completed.fulfill()
+        }, failure: { error, _, _ in
+            XCTFail("unexpected failure: \(error)")
+        })
+        wait(for: [completed], timeout: 5)
+
+        // The echoed event_data is flattened into untriggered events for the next placement.
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertEqual(captured.first?.triggerGuid, "parent-1")
+        XCTAssertEqual(captured.first?.triggerEvent, "SignalResponse")
+        XCTAssertEqual(captured.first?.eventType, "x")
+        XCTAssertEqual(captured.first?.payload, "y")
+    }
+
     func test_getExperienceData_retriesTransientTransportErrorThenSucceeds() {
         let timeout = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
         let stub = StubHTTPClient(sequence: [
@@ -322,7 +398,8 @@ final class TestOffersService: XCTestCase {
             sessionManager: TxnSessionManager(),
             httpClient: stub,
             maxRetries: 1,
-            baseBackoff: 0.001
+            baseBackoff: 0.001,
+            triggeredEvents: { [] }
         )
 
         let completed = expectation(description: "default backoff sleep used on retry")

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -235,6 +235,8 @@ final class TestOffersService: XCTestCase {
         // Device headers (incl. the load-bearing rokt-package-name) reach the request.
         XCTAssertEqual(stub.lastHeaders?["rokt-os-type"], "iOS")
         XCTAssertEqual(stub.lastHeaders?["rokt-package-name"], "com.rokt.test")
+        // Every v2 request marks itself as live (non-shadow) traffic.
+        XCTAssertEqual(stub.lastHeaders?["rokt-txn-shadow"], "false")
     }
 
     func test_getExperienceData_omitsAuthorizationUntilTokenRolledForward() {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
@@ -71,4 +71,27 @@ final class TestSelectEventMapper: XCTestCase {
 
         XCTAssertTrue(SelectEventMapper.untriggeredEvents(from: eventData).isEmpty)
     }
+
+    func test_untriggeredEvents_dropsEntriesMissingRequiredFields() throws {
+        // A signal missing event_type is invalid and is filtered out (matches UntriggeredEventsContainer).
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": {
+            "parent-1": { "token": "tok", "events": {
+              "Valid": { "event_type": "x", "payload": "y" },
+              "MissingType": { "payload": "z" }
+            } }
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        let untriggered = SelectEventMapper.untriggeredEvents(from: eventData)
+
+        XCTAssertEqual(untriggered.count, 1)
+        XCTAssertEqual(untriggered.first?.triggerEvent, "Valid")
+    }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
@@ -18,9 +18,8 @@ final class TestSelectEventMapper: XCTestCase {
         XCTAssertEqual(events.count, 1)
         let event = try XCTUnwrap(events.first)
         XCTAssertEqual(event.eventType, "impression")
-        XCTAssertNil(event.instanceId)
         XCTAssertEqual(event.timestamp, 1_782_484_201_000)
-        XCTAssertEqual(event.data?["payload"], .string("pl"))
+        XCTAssertEqual(event.payload, "pl")
     }
 
     func test_requestEvents_fallsBackToNowWhenEventTimeUnparseable() {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestSelectEventMapper.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Rokt_Widget
+
+/// Covers the real-time event bridge between the SDK store and the v2 offers
+/// request/response: triggered events map to the request `events[]` shape, and the
+/// response `event_data` flattens into untriggered events for the next call.
+final class TestSelectEventMapper: XCTestCase {
+
+    func test_requestEvents_mapsTriggeredEventToWireShape() throws {
+        // Round-trip the event time through the formatter so the epoch-ms is exact.
+        let eventTime = EventDateFormatter.dateFormatter.string(from: Date(timeIntervalSince1970: 1_782_484_201))
+        let triggered = [
+            TriggeredRealTimeEvent(parentGuid: "p", eventType: "impression", eventTime: eventTime, payload: "pl")
+        ]
+
+        let events = SelectEventMapper.requestEvents(from: triggered)
+
+        XCTAssertEqual(events.count, 1)
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(event.eventType, "impression")
+        XCTAssertNil(event.instanceId)
+        XCTAssertEqual(event.timestamp, 1_782_484_201_000)
+        XCTAssertEqual(event.data?["payload"], .string("pl"))
+    }
+
+    func test_requestEvents_fallsBackToNowWhenEventTimeUnparseable() {
+        let triggered = [
+            TriggeredRealTimeEvent(parentGuid: "p", eventType: "viewed", eventTime: "not-a-date", payload: "pl")
+        ]
+
+        let events = SelectEventMapper.requestEvents(from: triggered)
+
+        // Unparseable time falls back to ~now rather than dropping the event.
+        XCTAssertEqual(events.count, 1)
+        XCTAssertGreaterThan(events.first?.timestamp ?? 0, 0)
+    }
+
+    func test_untriggeredEvents_flattensResponseEventData() throws {
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": {
+            "parent-1": { "token": "tok", "events": { "SignalResponse": { "event_type": "x", "payload": "y" } } }
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        let untriggered = SelectEventMapper.untriggeredEvents(from: eventData)
+
+        XCTAssertEqual(untriggered.count, 1)
+        let event = try XCTUnwrap(untriggered.first)
+        XCTAssertEqual(event.triggerGuid, "parent-1")
+        XCTAssertEqual(event.triggerEvent, "SignalResponse")
+        XCTAssertEqual(event.eventType, "x")
+        XCTAssertEqual(event.payload, "y")
+        XCTAssertTrue(event.isValid())
+    }
+
+    func test_untriggeredEvents_isEmptyWhenEntryHasNoEvents() throws {
+        let json = """
+        {
+          "session_id": "s",
+          "session_token": { "token": "t", "expires_at": 32503680000000 },
+          "event_data": { "parent-1": { "token": "tok" } }
+        }
+        """
+        let decoded = try JSONDecoder().decode(SelectResponse.self, from: Data(json.utf8))
+        let eventData = try XCTUnwrap(decoded.eventData)
+
+        XCTAssertTrue(SelectEventMapper.untriggeredEvents(from: eventData).isEmpty)
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -80,6 +80,7 @@ final class TestTxnEventService: XCTestCase {
         XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-account-id"], "account-1")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-os-type"], "iOS")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-txn-shadow"], "false")
     }
 
     func test_send_withoutToken_omitsAuthorization() async throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -79,6 +79,7 @@ final class TestTxnInitService: XCTestCase {
         _ = try await makeService().initSession()
 
         XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-txn-shadow"], "false")
     }
 
     func test_initSession_withoutToken_omitsAuthorizationHeader() async throws {


### PR DESCRIPTION
## Summary

Stacked on #215. Closes the last v2 offers request-shape gap versus Android: real-time events triggered during the previous placement are now forwarded on `POST /v2/sessions/offers`, and the response's `event_data` is captured for the next call.

## Changes

**Request `events[]`.** Forwarded events reuse `TxnEvent` — the same element as `/v2/sessions/events` (`event_type`, epoch-ms `timestamp`, `data.payload`; `instance_id` omitted) — matching Android. The new `SelectEventMapper` maps the real-time event store's triggered events into that shape, parsing the stored event time to epoch-ms via `EventDateFormatter` (same as `TxnEventMapper`).

**Session-gated.** Events are forwarded only when there's a live session token to attribute them to (mirrors Android); the key is omitted when there are none.

**Response capture.** On a successful response, `event_data` is flattened into untriggered events and added to the store for the next placement. It only adds — no global clear — mirroring the v1 experiences capture, so the process-wide `RealTimeEventManager` (shared with the events and v1 paths) isn't wiped.

## Notes

The new `events[]` rides on the live request but is not asserted in the consumer pact yet, so the published contract is unchanged.

## Testing

`xcodebuild test` on the iPhone 17 Pro simulator — new `TestSelectEventMapper` (mapper round-trip + fallbacks), `TestSelectSerialization` (events element shape + omit-when-absent), `TestOffersService` (forward only with a live session; response-capture); `OffersClientPactSpec` unchanged and green.

### Verified end-to-end (live traffic)

Captured two consecutive offers requests from one live session in the iOS example app (credentials/payloads redacted):

1. **First selection** — no `events` key (nothing triggered yet).
2. **Second selection** (~28s later, after the placement rendered and fired signals) — `events[]` with 12 entries, each in the `/v2/sessions/events` element shape:

   ```json
   { "event_type": "PlacementImpressionV2", "timestamp": 1782487352257, "data": { "payload": "<base64 realtime-event protobuf>" } }
   ```

   - epoch-ms `timestamp`, no `instance_id` (matches Android)
   - every timestamp falls between the two requests — i.e. the events fired while the first placement was on screen
   - decoded payloads are `realtimeevents.v1.*PayloadData` protobufs echoed verbatim from the prior response's `event_data`, confirming the response → store → forward capture-back loop
   - 12 events, under the 50 cap

A fresh app relaunch started clean (no stale events on the first request), and the device headers from #215 were present throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
