### PR TITLE
feat(init): call /v2/sessions/init as a body-less GET with headers

### DIFF
--- a/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/V2SessionsInitClient.swift
@@ -23,6 +23,12 @@ internal struct V2SessionsInitClient {
         self.httpClient = httpClient
     }
 
+    /// Calls `GET /v2/sessions/init`.
+    ///
+    /// All inputs travel as request headers — there is no body — so the request
+    /// is a plain, cacheable GET. Operating system, layout schema version and
+    /// SDK version are carried as `rokt-os-type`, `rokt-layout-schema-version`
+    /// and `rokt-sdk-version` respectively.
     func initSession(
         operating_system: String,
         sdk_version: String,
@@ -33,30 +39,22 @@ internal struct V2SessionsInitClient {
             .appendingPathComponent("sessions")
             .appendingPathComponent("init")
 
-        let requestBody = V2SessionsInitRequest(
-            operatingSystem: operating_system,
-            sdkVersion: sdk_version,
-            layoutSchemaVersion: layout_schema_version
-        )
-        let bodyData = try JSONEncoder().encode(requestBody)
-        guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
-            throw V2SessionsInitClientError.bodyEncodingFailed
-        }
-
         let headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,
+            "rokt-os-type": operating_system,
+            "rokt-layout-schema-version": layout_schema_version,
+            "rokt-sdk-version": sdk_version,
             "Authorization": authToken,
             "rokt-platform-type": "iOS",
             "rokt-integration-type": "msdk-ios",
-            "x-request-id": UUID().uuidString,
-            "Content-Type": "application/json"
+            "x-request-id": UUID().uuidString
         ]
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(
                 urlAddress: url.absoluteString,
-                method: .post,
-                parameters: bodyParameters,
+                method: .get,
+                parameters: nil,
                 parameterArray: nil,
                 headers: headers,
                 onRequestStart: nil,
@@ -71,21 +69,5 @@ internal struct V2SessionsInitClient {
                 }
             )
         }
-    }
-}
-
-internal enum V2SessionsInitClientError: Error {
-    case bodyEncodingFailed
-}
-
-internal struct V2SessionsInitRequest: Encodable {
-    let operatingSystem: String
-    let sdkVersion: String
-    let layoutSchemaVersion: String
-
-    enum CodingKeys: String, CodingKey {
-        case operatingSystem = "operating_system"
-        case sdkVersion = "sdk_version"
-        case layoutSchemaVersion = "layout_schema_version"
     }
 }

--- a/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
+++ b/Tests/ContractTests/V2SessionsInitClientPactSpec.swift
@@ -21,25 +21,24 @@ class V2SessionsInitClientPactSpec: XCTestCase {
         )
     }
 
-    func test_sessionInitHappyPath_returnsSessionAndFeatureFlags() {
+    func test_sessionInitHappyPath_returnsFeatureFlags() {
         Self.mockService
-            .uponReceiving("a v2 sessions init request from rokt-sdk-ios initializes a session and returns feature flags")
+            .uponReceiving("a v2 sessions init request from rokt-sdk-ios returns feature flags and fonts")
             .given(ProviderState(description: "a valid session initialization request is submitted", params: [:]))
+            // Body-less GET: every input travels as a header so the CDN edge
+            // can route (and cache-key) without deserializing a body.
             .withRequest(
-                method: .POST,
+                method: .GET,
                 path: "/v2/sessions/init",
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
+                    "rokt-os-type": "ios",
+                    "rokt-layout-schema-version": Matcher.SomethingLike("2.1.0"),
+                    "rokt-sdk-version": Matcher.SomethingLike("5.2.2"),
                     "Authorization": Matcher.RegexLike("Bearer session-token-abc", term: #".+"#),
                     "rokt-platform-type": "iOS",
                     "rokt-integration-type": "msdk-ios",
-                    "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),
-                    "Content-Type": "application/json"
-                ],
-                body: [
-                    "operating_system": "ios",
-                    "sdk_version": Matcher.SomethingLike("5.2.2"),
-                    "layout_schema_version": Matcher.SomethingLike("2.1.0")
+                    "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#)
                 ]
             )
             // fonts is a literal `[]` (exact match), not EachLike: the provider always
@@ -48,11 +47,9 @@ class V2SessionsInitClientPactSpec: XCTestCase {
                 status: 200,
                 headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
                 body: [
-                    "session_id": Matcher.SomethingLike("550e8400-e29b-41d4-a716-446655440000"),
-                    "session_token": [
-                        "token": Matcher.SomethingLike("pact-stub-session-token"),
-                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
-                    ],
+                    // init is config-only: no session_id / session_token. The SDK
+                    // sources its session from offers/select, and this client never
+                    // decodes init's body, so the response is just flags + fonts.
                     "feature_flags": [
                         "rokt-tracking-status": Matcher.SomethingLike(true),
                         "client-timeout-ms": Matcher.SomethingLike(30_000),


### PR DESCRIPTION
## What

Updates the `/v2/sessions/init` consumer client + pact to a **body-less GET** whose inputs are headers, and a **config-only** response (`feature_flags` + `fonts`, no session fields).

## Changes

- **`V2SessionsInitClient.initSession`** — issues `GET` (was `POST`); carries `operating_system`, `layout_schema_version`, `sdk_version` as the `rokt-os-type` / `rokt-layout-schema-version` / `rokt-sdk-version` headers; drops the JSON body (and the now-unused `V2SessionsInitRequest` / `V2SessionsInitClientError`). Public method signature unchanged.
- **`V2SessionsInitClientPactSpec`** — request is now `GET` with those headers and no body / `Content-Type`; the response expectation is config-only (`feature_flags` + `fonts`), with `session_id` / `session_token` removed. The client returns the raw body undecoded and never reads session fields, so the client needs no change for that.

## CI status

The checks that validate this change pass: **Consumer Test (PactSwift)** ✅ (the GET client + updated pact compile and the contract test passes), **Publish to Broker** ✅, plus SPM Unit Tests, Periphery, Podspec Lint, Trunk, Detect Contract Changes.

The two red jobs — **`UI Tests`** and **`Package SPM Tests (rokt-payment-extension-ios)`** — are **not caused by this diff**. They die at the runner before any test executes when they land on a runner that lacks the hardcoded `iPhone 16 Pro,OS=latest` simulator:
```
xcodebuild: error: Unable to find a device matching: { platform:iOS Simulator, OS:latest, name:iPhone 16 Pro }  (exit 70)
```
This diff only touches the init client + pact — neither the `rokt-Example-MOCK` UI scheme nor the `rokt-payment-extension-ios` package.

**Evidence it's runner-dependent:** an empty-commit diagnostic PR off `main` (zero code changes) had `UI Tests` **pass**, and its log showed the runner *did* have the sim (`Using the first of multiple matching destinations: { iOS Simulator, OS:26.2, name:iPhone 16 Pro }`); this PR's runs landed on runners without it. So the macOS runner fleet is heterogeneous — a re-run can go green once it lands on a good runner.

**Durable fix:** PR #221 switches the workflow `-destination` from `iPhone 16 Pro` to `iPhone 16e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)