### PR TITLE
ci: target iPhone 16e simulator instead of iPhone 16 Pro

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme Rokt-Widget \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16e,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -178,7 +178,7 @@ jobs:
 
           xcodebuild test \
             -scheme "$SCHEME" \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16e,OS=latest' \
             -derivedDataPath "$DERIVED" \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -207,7 +207,7 @@ jobs:
           xcodebuild test \
             -project Example/rokt.xcodeproj \
             -scheme rokt-Example-MOCK \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16e,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
@@ -257,7 +257,7 @@ jobs:
 
       - name: Build Example App
         run: |
-          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
+          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16e,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
 
       - name: Run Periphery Scan
         run: periphery scan --format github-actions


### PR DESCRIPTION
## What

Switch the four hardcoded test/build destinations in `.github/workflows/pull-request.yml` from `iPhone 16 Pro` to **`iPhone 16e`** (`SPM Unit Tests`, `Package SPM Tests`, `UI Tests`, `Periphery` build).

## Why

The Xcode 26.3 macOS runner pool **inconsistently provisions the `iPhone 16 Pro` simulator** — many runners only ship `iPhone 16e` (+ visionOS). Jobs that pin:
```
-destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'
```
intermittently die at destination resolution, before any test runs:
```
xcodebuild: error: Unable to find a device matching: { platform:iOS Simulator, OS:latest, name:iPhone 16 Pro }  (exit 70)
```

### Evidence it's the runner, not the code
Running the same CI on **empty commits off `main`** (zero code changes) produced different results purely by which runner the job landed on:

| Run | UI Tests | Package SPM |
|---|---|---|
| diag A (main) | ✅ pass (runner had iPhone 16 Pro) | ❌ fail |
| diag B (main) | ✅ pass | ✅ pass |
| PR #218 | ❌ fail ×4 (`iPhone 16 Pro` not found) | ❌ fail |

A passing run's log even shows `Using the first of multiple matching destinations: { iOS Simulator, OS:26.2, name:iPhone 16 Pro }` — i.e. some runners have it, some don't. The failing runners list `iPhone 16e, OS:26.2` as available, hence the switch.

## Note / alternative

`iPhone 16e` is the device the failing runners consistently report as available, so it's the pragmatic stabilizer. If the team prefers to be fully runner-image-agnostic, a follow-up could select the simulator dynamically (e.g. `xcrun simctl list devices available`) instead of hard-coding a name. Draft so the SDK/CI owners can confirm `iPhone 16e` is guaranteed on the image (or pick a different target).

Unblocks the flaky `UI Tests` / `Package SPM Tests` failures seen on #218 (the `/v2/sessions/init` GET contract update), which are not caused by that diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)