### PR TITLE
feat(txn): migrate iOS init to config-only GET /v2/init

### DIFF
--- a/Example/Tests/NetworkMock/MockResponse.swift
+++ b/Example/Tests/NetworkMock/MockResponse.swift
@@ -9,7 +9,7 @@ let invalidInitFilename = "InvalidInit"
 
 // Derived from the same environment as the live path so the mock URL matches the request.
 var txnInitResourceURL: String {
-    config.environment.gatewayBaseURL + "/v2/sessions/init"
+    config.environment.gatewayBaseURL + "/v2/config"
 }
 
 var txnEventResourceURL: String {

--- a/Example/Tests/NetworkMock/MockResponse.swift
+++ b/Example/Tests/NetworkMock/MockResponse.swift
@@ -9,7 +9,7 @@ let invalidInitFilename = "InvalidInit"
 
 // Derived from the same environment as the live path so the mock URL matches the request.
 var txnInitResourceURL: String {
-    config.environment.gatewayBaseURL + "/v2/config"
+    config.environment.gatewayBaseURL + "/v2/init"
 }
 
 var txnEventResourceURL: String {

--- a/Sources/Rokt_Widget/Models/TxnInitResponse.swift
+++ b/Sources/Rokt_Widget/Models/TxnInitResponse.swift
@@ -2,35 +2,27 @@
 import Foundation
 
 internal struct TxnInitResponse: Decodable, Equatable {
-    let sessionId: String
-    let sessionToken: TxnSessionToken
     let featureFlags: TxnFeatureFlags
     let fonts: [TxnFontItem]
 
     enum CodingKeys: String, CodingKey {
-        case sessionId = "session_id"
-        case sessionToken = "session_token"
         case featureFlags = "feature_flags"
         case fonts
     }
 
     init(
-        sessionId: String,
-        sessionToken: TxnSessionToken,
         featureFlags: TxnFeatureFlags,
         fonts: [TxnFontItem]
     ) {
-        self.sessionId = sessionId
-        self.sessionToken = sessionToken
         self.featureFlags = featureFlags
         self.fonts = fonts
     }
 
+    // Config-only: /v2/config carries no session (the SDK sources its session
+    // from offers/select). Tolerate absent feature_flags/fonts so a missing
+    // block doesn't fail decoding.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        sessionId = try container.decode(String.self, forKey: .sessionId)
-        sessionToken = try container.decode(TxnSessionToken.self, forKey: .sessionToken)
-        // Tolerate absent feature_flags/fonts so a missing block doesn't fail init.
         featureFlags = try container.decodeIfPresent(TxnFeatureFlags.self, forKey: .featureFlags)
             ?? TxnFeatureFlags(flags: [:])
         fonts = try container.decodeIfPresent([TxnFontItem].self, forKey: .fonts) ?? []

--- a/Sources/Rokt_Widget/Models/TxnInitResponse.swift
+++ b/Sources/Rokt_Widget/Models/TxnInitResponse.swift
@@ -18,9 +18,8 @@ internal struct TxnInitResponse: Decodable, Equatable {
         self.fonts = fonts
     }
 
-    // Config-only: /v2/init carries no session (the SDK sources its session
-    // from offers/select). Tolerate absent feature_flags/fonts so a missing
-    // block doesn't fail decoding.
+    // feature_flags/fonts are optional config: default to empty rather than throwing,
+    // so a partial response never fails the startup-blocking init decode.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         featureFlags = try container.decodeIfPresent(TxnFeatureFlags.self, forKey: .featureFlags)

--- a/Sources/Rokt_Widget/Models/TxnInitResponse.swift
+++ b/Sources/Rokt_Widget/Models/TxnInitResponse.swift
@@ -18,7 +18,7 @@ internal struct TxnInitResponse: Decodable, Equatable {
         self.fonts = fonts
     }
 
-    // Config-only: /v2/config carries no session (the SDK sources its session
+    // Config-only: /v2/init carries no session (the SDK sources its session
     // from offers/select). Tolerate absent feature_flags/fonts so a missing
     // block doesn't fail decoding.
     init(from decoder: Decoder) throws {

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -27,8 +27,7 @@ internal struct TxnInitClient {
     ) async throws -> (Data?, HTTPURLResponse?) {
         let url = baseURL
             .appendingPathComponent("v2")
-            .appendingPathComponent("sessions")
-            .appendingPathComponent("init")
+            .appendingPathComponent("config")
 
         let requestBody = TxnInitRequest(
             operatingSystem: operating_system,

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -18,12 +18,8 @@ internal struct TxnInitClient {
         self.httpClient = httpClient
     }
 
-    /// Calls the config-only `GET /v2/init`.
-    ///
-    /// Every input travels as a request header — there is no body and no
-    /// `Authorization` — so the request is a plain, cacheable GET. The response
-    /// carries no session; the SDK sources its session from the offers/select
-    /// response instead.
+    /// Config-only `GET /v2/init`: inputs as headers, no body/auth, no session
+    /// in the response (session comes from offers/select).
     func initSession(
         operating_system: String,
         layout_schema_version: String

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -18,7 +18,7 @@ internal struct TxnInitClient {
         self.httpClient = httpClient
     }
 
-    /// Calls the config-only `GET /v2/config`.
+    /// Calls the config-only `GET /v2/init`.
     ///
     /// Every input travels as a request header — there is no body and no
     /// `Authorization` — so the request is a plain, cacheable GET. The response
@@ -30,7 +30,7 @@ internal struct TxnInitClient {
     ) async throws -> (Data?, HTTPURLResponse?) {
         let url = baseURL
             .appendingPathComponent("v2")
-            .appendingPathComponent("config")
+            .appendingPathComponent("init")
 
         let headers: RoktHTTPHeaders = [
             "rokt-account-id": accountId,

--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -3,24 +3,27 @@ import Foundation
 internal struct TxnInitClient {
     let baseURL: URL
     let accountId: String
-    let authToken: String?
     let sdkVersion: String
     let httpClient: HTTPClientAdapter
 
     init(
         baseURL: URL,
         accountId: String,
-        authToken: String? = nil,
         sdkVersion: String,
         httpClient: HTTPClientAdapter = RoktHTTPClient()
     ) {
         self.baseURL = baseURL
         self.accountId = accountId
-        self.authToken = authToken
         self.sdkVersion = sdkVersion
         self.httpClient = httpClient
     }
 
+    /// Calls the config-only `GET /v2/config`.
+    ///
+    /// Every input travels as a request header — there is no body and no
+    /// `Authorization` — so the request is a plain, cacheable GET. The response
+    /// carries no session; the SDK sources its session from the offers/select
+    /// response instead.
     func initSession(
         operating_system: String,
         layout_schema_version: String
@@ -29,24 +32,19 @@ internal struct TxnInitClient {
             .appendingPathComponent("v2")
             .appendingPathComponent("config")
 
-        let requestBody = TxnInitRequest(
-            operatingSystem: operating_system,
-            sdkVersion: sdkVersion,
-            layoutSchemaVersion: layout_schema_version
-        )
-        let bodyData = try JSONEncoder().encode(requestBody)
-        guard let bodyParameters = try JSONSerialization.jsonObject(with: bodyData) as? RoktHTTPParameters else {
-            throw TxnInitClientError.bodyEncodingFailed
-        }
-
-        var headers = TxnRequestHeaders.common(accountId: accountId, authToken: authToken)
-        headers["x-request-id"] = UUID().uuidString
+        let headers: RoktHTTPHeaders = [
+            "rokt-account-id": accountId,
+            "rokt-os-type": operating_system,
+            "rokt-sdk-version": sdkVersion,
+            "rokt-layout-schema-version": layout_schema_version,
+            "x-request-id": UUID().uuidString
+        ]
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(
                 urlAddress: url.absoluteString,
-                method: .post,
-                parameters: bodyParameters,
+                method: .get,
+                parameters: nil,
                 parameterArray: nil,
                 headers: headers,
                 onRequestStart: nil,
@@ -61,24 +59,5 @@ internal struct TxnInitClient {
                 }
             )
         }
-    }
-}
-
-internal enum TxnInitClientError: Error {
-    case bodyEncodingFailed
-}
-
-internal struct TxnInitRequest: Encodable {
-    // periphery:ignore - encode-only; read by the synthesized Encodable, not by code
-    let operatingSystem: String
-    // periphery:ignore - encode-only; read by the synthesized Encodable, not by code
-    let sdkVersion: String
-    // periphery:ignore - encode-only; read by the synthesized Encodable, not by code
-    let layoutSchemaVersion: String
-
-    enum CodingKeys: String, CodingKey {
-        case operatingSystem = "operating_system"
-        case sdkVersion = "sdk_version"
-        case layoutSchemaVersion = "layout_schema_version"
     }
 }

--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -82,8 +82,6 @@ internal struct TxnInitService {
                     throw TxnInitError.missingResponseData
                 }
 
-                // Config-only: no session is minted here. The SDK sources its
-                // session from the offers/select response instead.
                 let decoded = try JSONDecoder().decode(TxnInitResponse.self, from: data)
                 return InitResult(response: decoded, featureFlags: decoded.featureFlags.toInitFeatureFlags())
             } catch let error where isRetryable(error: error) && attempt < maxRetries {

--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -16,7 +16,6 @@ internal struct TxnInitService {
     let accountId: String
     let sdkVersion: String
     let layoutSchemaVersion: String
-    let sessionManager: TxnSessionManager
     let httpClient: HTTPClientAdapter
     let maxRetries: Int
     let requestTimeout: TimeInterval
@@ -28,7 +27,6 @@ internal struct TxnInitService {
         accountId: String,
         sdkVersion: String,
         layoutSchemaVersion: String,
-        sessionManager: TxnSessionManager,
         httpClient: HTTPClientAdapter = RoktHTTPClient(),
         maxRetries: Int = 3,
         requestTimeout: TimeInterval = 7,
@@ -41,7 +39,6 @@ internal struct TxnInitService {
         self.accountId = accountId
         self.sdkVersion = sdkVersion
         self.layoutSchemaVersion = layoutSchemaVersion
-        self.sessionManager = sessionManager
         self.httpClient = httpClient
         self.maxRetries = maxRetries
         self.requestTimeout = requestTimeout
@@ -56,11 +53,9 @@ internal struct TxnInitService {
 
         httpClient.updateTimeout(timeout: requestTimeout)
 
-        let authToken = await sessionManager.authorizationHeader
         let client = TxnInitClient(
             baseURL: baseURL,
             accountId: accountId,
-            authToken: authToken,
             sdkVersion: sdkVersion,
             httpClient: httpClient
         )
@@ -87,8 +82,9 @@ internal struct TxnInitService {
                     throw TxnInitError.missingResponseData
                 }
 
+                // Config-only: no session is minted here. The SDK sources its
+                // session from the offers/select response instead.
                 let decoded = try JSONDecoder().decode(TxnInitResponse.self, from: data)
-                await sessionManager.update(sessionId: decoded.sessionId, sessionToken: decoded.sessionToken)
                 return InitResult(response: decoded, featureFlags: decoded.featureFlags.toInitFeatureFlags())
             } catch let error where isRetryable(error: error) && attempt < maxRetries {
                 try await sleep(backoffDelay(attempt: attempt))

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -958,7 +958,6 @@ class RoktInternalImplementation {
             accountId: roktTagId,
             sdkVersion: libraryVersion,
             layoutSchemaVersion: Self.txnLayoutSchemaVersion,
-            sessionManager: TxnSessionManager(roktTagId: roktTagId),
             httpClient: httpClient
         )
     }

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -2,7 +2,7 @@ import XCTest
 import PactSwift
 @testable import Rokt_Widget
 
-/// Consumer-driven pact spec for `POST /v2/sessions/init`. Drives
+/// Consumer-driven pact spec for `POST /v2/config`. Drives
 /// `TxnInitClient.initSession` through the pact mock service so any drift
 /// in the client's wire shape fails here.
 class TxnInitClientPactSpec: XCTestCase {
@@ -27,9 +27,7 @@ class TxnInitClientPactSpec: XCTestCase {
             .given(ProviderState(description: "a valid session initialization request is submitted", params: [:]))
             .withRequest(
                 method: .POST,
-                path: "/v2/sessions/init",
-                // Cold init: no Authorization — the client has no session token yet,
-                // so the server mints one. x-request-id is always sent.
+                path: "/v2/config",
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
                     "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -2,9 +2,7 @@ import XCTest
 import PactSwift
 @testable import Rokt_Widget
 
-/// Consumer-driven pact spec for the config-only `GET /v2/init`. Drives
-/// `TxnInitClient.initSession` through the pact mock service so any drift in
-/// the client's wire shape fails here.
+/// Consumer-driven pact spec for the config-only `GET /v2/init`.
 class TxnInitClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -25,8 +23,7 @@ class TxnInitClientPactSpec: XCTestCase {
         Self.mockService
             .uponReceiving("a v2 config request from rokt-sdk-ios returns feature flags and fonts")
             .given(ProviderState(description: "a valid config request is submitted", params: [:]))
-            // Body-less GET: every input travels as a header and there is no
-            // Authorization (config is unauthenticated), so the request is cacheable.
+            // Body-less GET: inputs as headers, no Authorization (cacheable).
             .withRequest(
                 method: .GET,
                 path: "/v2/init",
@@ -38,9 +35,8 @@ class TxnInitClientPactSpec: XCTestCase {
                     "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#)
                 ]
             )
-            // Config-only response: no session_id / session_token. The SDK sources
-            // its session from offers/select. fonts is a literal `[]` (exact match),
-            // not EachLike: the provider always returns empty today.
+            // Config-only response: no session. fonts is a literal `[]` (exact
+            // match, not EachLike) — the provider returns empty today.
             .willRespondWith(
                 status: 200,
                 headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -19,7 +19,7 @@ class TxnInitClientPactSpec: XCTestCase {
         )
     }
 
-    func test_configHappyPath_returnsFeatureFlags() {
+    func test_initHappyPath_returnsFeatureFlags() {
         Self.mockService
             .uponReceiving("a v2 config request from rokt-sdk-ios returns feature flags and fonts")
             .given(ProviderState(description: "a valid config request is submitted", params: [:]))

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -2,7 +2,7 @@ import XCTest
 import PactSwift
 @testable import Rokt_Widget
 
-/// Consumer-driven pact spec for the config-only `GET /v2/config`. Drives
+/// Consumer-driven pact spec for the config-only `GET /v2/init`. Drives
 /// `TxnInitClient.initSession` through the pact mock service so any drift in
 /// the client's wire shape fails here.
 class TxnInitClientPactSpec: XCTestCase {
@@ -29,7 +29,7 @@ class TxnInitClientPactSpec: XCTestCase {
             // Authorization (config is unauthenticated), so the request is cacheable.
             .withRequest(
                 method: .GET,
-                path: "/v2/config",
+                path: "/v2/init",
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
                     "rokt-os-type": "ios",

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -21,8 +21,8 @@ class TxnInitClientPactSpec: XCTestCase {
 
     func test_initHappyPath_returnsFeatureFlags() {
         Self.mockService
-            .uponReceiving("a v2 config request from rokt-sdk-ios returns feature flags and fonts")
-            .given(ProviderState(description: "a valid config request is submitted", params: [:]))
+            .uponReceiving("a v2 init request from rokt-sdk-ios returns feature flags and fonts")
+            .given(ProviderState(description: "a valid init request is submitted", params: [:]))
             // Body-less GET: inputs as headers, no Authorization (cacheable).
             .withRequest(
                 method: .GET,
@@ -59,7 +59,7 @@ class TxnInitClientPactSpec: XCTestCase {
                 ]
             )
 
-        let expectation = expectation(description: "v2 config request completes")
+        let expectation = expectation(description: "v2 init request completes")
 
         // Timeout sized for CI cold-start. See TxnEventsClientPactSpec.
         Self.mockService.run(timeout: 30) { baseURL, done in

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -2,9 +2,9 @@ import XCTest
 import PactSwift
 @testable import Rokt_Widget
 
-/// Consumer-driven pact spec for `POST /v2/config`. Drives
-/// `TxnInitClient.initSession` through the pact mock service so any drift
-/// in the client's wire shape fails here.
+/// Consumer-driven pact spec for the config-only `GET /v2/config`. Drives
+/// `TxnInitClient.initSession` through the pact mock service so any drift in
+/// the client's wire shape fails here.
 class TxnInitClientPactSpec: XCTestCase {
     static var mockService: MockService!
 
@@ -21,41 +21,35 @@ class TxnInitClientPactSpec: XCTestCase {
         )
     }
 
-    func test_sessionInitHappyPath_returnsSessionAndFeatureFlags() {
+    func test_configHappyPath_returnsFeatureFlags() {
         Self.mockService
-            .uponReceiving("a v2 sessions init request from rokt-sdk-ios initializes a session and returns feature flags")
-            .given(ProviderState(description: "a valid session initialization request is submitted", params: [:]))
+            .uponReceiving("a v2 config request from rokt-sdk-ios returns feature flags and fonts")
+            .given(ProviderState(description: "a valid config request is submitted", params: [:]))
+            // Body-less GET: every input travels as a header and there is no
+            // Authorization (config is unauthenticated), so the request is cacheable.
             .withRequest(
-                method: .POST,
+                method: .GET,
                 path: "/v2/config",
                 headers: [
                     "rokt-account-id": Matcher.RegexLike("account-456", term: #".+"#),
-                    "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#),
-                    "Content-Type": "application/json"
-                ],
-                body: [
-                    "operating_system": "ios",
-                    "sdk_version": Matcher.SomethingLike("5.2.2"),
-                    "layout_schema_version": Matcher.SomethingLike("2.1.0")
+                    "rokt-os-type": "ios",
+                    "rokt-sdk-version": Matcher.SomethingLike("5.2.2"),
+                    "rokt-layout-schema-version": Matcher.SomethingLike("2.1.0"),
+                    "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#)
                 ]
             )
-            // fonts is a literal `[]` (exact match), not EachLike: the provider always
-            // returns empty today, and EachLike's default min:1 would demand a non-empty array.
+            // Config-only response: no session_id / session_token. The SDK sources
+            // its session from offers/select. fonts is a literal `[]` (exact match),
+            // not EachLike: the provider always returns empty today.
             .willRespondWith(
                 status: 200,
                 headers: ["Content-Type": Matcher.RegexLike("application/json; charset=utf-8", term: #"application/json(;.*)?"#)],
                 body: [
-                    "session_id": Matcher.SomethingLike("550e8400-e29b-41d4-a716-446655440000"),
-                    "session_token": [
-                        "token": Matcher.SomethingLike("pact-stub-session-token"),
-                        "expires_at": Matcher.SomethingLike(1_774_474_053_000)
-                    ],
                     "feature_flags": [
-                        // Provider returns these four verbatim — pin exact (not type) match.
-                        "rokt-tracking-status": true,
-                        "client-timeout-ms": 30_000,
-                        "ios-sdk-log-font-happy-path": true,
-                        "ios-sdk-use-font-register-with-url": false,
+                        "rokt-tracking-status": Matcher.SomethingLike(true),
+                        "client-timeout-ms": Matcher.SomethingLike(30_000),
+                        "ios-sdk-log-font-happy-path": Matcher.SomethingLike(true),
+                        "ios-sdk-use-font-register-with-url": Matcher.SomethingLike(false),
                         "mobile-sdk-use-bounding-box": Matcher.SomethingLike(false),
                         "mobile-sdk-use-partner-events": Matcher.SomethingLike(false),
                         "mobile-sdk-use-open-url-from-rokt": Matcher.SomethingLike(false),
@@ -69,7 +63,7 @@ class TxnInitClientPactSpec: XCTestCase {
                 ]
             )
 
-        let expectation = expectation(description: "v2 sessions init request completes")
+        let expectation = expectation(description: "v2 config request completes")
 
         // Timeout sized for CI cold-start. See TxnEventsClientPactSpec.
         Self.mockService.run(timeout: 30) { baseURL, done in

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponse.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponse.swift
@@ -33,8 +33,7 @@ final class TestTxnInitResponse: XCTestCase {
     // MARK: - Top-level decoding
 
     func test_decode_happyPath_topLevelFields() throws {
-        // Config-only: any session fields in the payload are ignored (the
-        // decoder declares only feature_flags + fonts).
+        // Config-only: session fields in the payload are ignored.
         let response = try decode(happyPathJSON)
         XCTAssertEqual(response.fonts, [])
     }
@@ -154,8 +153,7 @@ final class TestTxnInitResponse: XCTestCase {
     }
 
     func test_decode_sessionFieldsAreIgnored() throws {
-        // Config-only: a session block in the payload must not be required and
-        // is simply ignored — decoding succeeds with only feature_flags + fonts.
+        // A session block must not be required; the decoder ignores it.
         let json = """
         {
             "session_id": "s",

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponse.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponse.swift
@@ -33,19 +33,15 @@ final class TestTxnInitResponse: XCTestCase {
     // MARK: - Top-level decoding
 
     func test_decode_happyPath_topLevelFields() throws {
+        // Config-only: any session fields in the payload are ignored (the
+        // decoder declares only feature_flags + fonts).
         let response = try decode(happyPathJSON)
-        XCTAssertEqual(response.sessionId, "550e8400-e29b-41d4-a716-446655440000")
-        XCTAssertEqual(response.sessionToken.token, "pact-stub-session-token")
-        XCTAssertEqual(response.sessionToken.expiresAt, 1_774_474_053_000)
         XCTAssertEqual(response.fonts, [])
     }
 
     func test_init_memberwise_setsAllFields() {
-        let token = TxnSessionToken(token: "t", expiresAt: 1_774_474_053_000)
         let flags = TxnFeatureFlags(flags: ["rokt-tracking-status": .bool(true)])
-        let response = TxnInitResponse(sessionId: "sid", sessionToken: token, featureFlags: flags, fonts: [])
-        XCTAssertEqual(response.sessionId, "sid")
-        XCTAssertEqual(response.sessionToken, token)
+        let response = TxnInitResponse(featureFlags: flags, fonts: [])
         XCTAssertEqual(response.featureFlags, flags)
         XCTAssertEqual(response.fonts, [])
     }
@@ -152,22 +148,25 @@ final class TestTxnInitResponse: XCTestCase {
     // MARK: - Resilience
 
     func test_decode_missingFeatureFlagsAndFonts_defaultsToEmpty() throws {
+        let response = try decode("{}")
+        XCTAssertTrue(response.featureFlags.flags.isEmpty)
+        XCTAssertEqual(response.fonts, [])
+    }
+
+    func test_decode_sessionFieldsAreIgnored() throws {
+        // Config-only: a session block in the payload must not be required and
+        // is simply ignored — decoding succeeds with only feature_flags + fonts.
         let json = """
         {
             "session_id": "s",
-            "session_token": { "token": "t", "expires_at": 1 }
+            "session_token": { "token": "t", "expires_at": 1 },
+            "feature_flags": {},
+            "fonts": []
         }
         """
         let response = try decode(json)
         XCTAssertTrue(response.featureFlags.flags.isEmpty)
         XCTAssertEqual(response.fonts, [])
-    }
-
-    func test_decode_missingSessionToken_throws() {
-        let json = """
-        { "session_id": "s", "feature_flags": {}, "fonts": [] }
-        """
-        XCTAssertThrowsError(try decode(json))
     }
 
     // MARK: - toInitFeatureFlags mapping

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponseAdapter.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestTxnInitResponseAdapter.swift
@@ -8,8 +8,6 @@ final class TestTxnInitResponseAdapter: XCTestCase {
         fonts: [TxnFontItem] = []
     ) -> TxnInitResponse {
         TxnInitResponse(
-            sessionId: "sess",
-            sessionToken: TxnSessionToken(token: "jwt", expiresAt: 1),
             featureFlags: TxnFeatureFlags(flags: flags),
             fonts: fonts
         )

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
@@ -48,8 +48,6 @@ final class TestMockTxnInitHTTPClient: XCTestCase {
         writeFixture(
             """
             {
-              "session_id": "mock-sess",
-              "session_token": { "token": "mock-jwt", "expires_at": 32503680000000 },
               "feature_flags": { "client-timeout-ms": 8000 },
               "fonts": []
             }
@@ -63,8 +61,8 @@ final class TestMockTxnInitHTTPClient: XCTestCase {
         XCTAssertNil(result?.responseError)
         let data = try XCTUnwrap(result?.responseData)
         let decoded = try JSONDecoder().decode(TxnInitResponse.self, from: data)
-        XCTAssertEqual(decoded.sessionId, "mock-sess")
         XCTAssertEqual(decoded.featureFlags.int(forKey: "client-timeout-ms"), 8000)
+        XCTAssertEqual(decoded.fonts, [])
     }
 
     func test_missingFixture_servesEmbeddedDefaultAs200() throws {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
@@ -27,7 +27,7 @@ final class TestMockTxnInitHTTPClient: XCTestCase {
         let expectation = expectation(description: "completion")
         var captured: RoktHTTPRequestResult?
         client.startRequestWith(
-            urlAddress: "https://apps.rokt.com/v2/config",
+            urlAddress: "https://apps.rokt.com/v2/init",
             method: .post,
             parameters: nil,
             parameterArray: nil,

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestMockTxnInitHTTPClient.swift
@@ -27,7 +27,7 @@ final class TestMockTxnInitHTTPClient: XCTestCase {
         let expectation = expectation(description: "completion")
         var captured: RoktHTTPRequestResult?
         client.startRequestWith(
-            urlAddress: "https://apps.rokt.com/v2/sessions/init",
+            urlAddress: "https://apps.rokt.com/v2/config",
             method: .post,
             parameters: nil,
             parameterArray: nil,

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersExecuteWiring.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersExecuteWiring.swift
@@ -117,7 +117,6 @@ final class TestOffersExecuteWiring: XCTestCase {
                 accountId: tagId,
                 sdkVersion: "5.2.2",
                 layoutSchemaVersion: "1.0",
-                sessionManager: TxnSessionManager(),
                 httpClient: stub,
                 baseBackoff: 0,
                 sleep: { _ in }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -3,20 +3,14 @@ import XCTest
 
 final class TestTxnInitService: XCTestCase {
 
-    private var now: Date!
-    private var sessionManager: TxnSessionManager!
     private var httpClient: MockTxnHTTPClient!
 
     override func setUp() {
         super.setUp()
-        now = Date(timeIntervalSince1970: 1_000_000)
-        sessionManager = TxnSessionManager(clock: { self.now })
         httpClient = MockTxnHTTPClient()
     }
 
     override func tearDown() {
-        now = nil
-        sessionManager = nil
         httpClient = nil
         super.tearDown()
     }
@@ -27,7 +21,6 @@ final class TestTxnInitService: XCTestCase {
             accountId: "account-1",
             sdkVersion: "5.2.2",
             layoutSchemaVersion: "2.3",
-            sessionManager: sessionManager,
             httpClient: httpClient,
             maxRetries: maxRetries,
             baseBackoff: 0,
@@ -35,12 +28,12 @@ final class TestTxnInitService: XCTestCase {
         )
     }
 
-    private func successJSON(token: String = "minted-jwt", expiresAt: Int64 = 2_000_000_000_000) -> Data {
+    // Config-only payload — no session_id / session_token. A session block in
+    // the JSON would simply be ignored by the decoder.
+    private func successJSON() -> Data {
         Data(
             """
             {
-              "session_id": "sess-123",
-              "session_token": { "token": "\(token)", "expires_at": \(expiresAt) },
               "feature_flags": {
                 "rokt-tracking-status": true,
                 "client-timeout-ms": 30000,
@@ -53,49 +46,35 @@ final class TestTxnInitService: XCTestCase {
         )
     }
 
-    func test_initSession_success_decodesAndStoresSession() async throws {
+    func test_initSession_success_decodesFeatureFlags() async throws {
         httpClient.results = [.success(data: successJSON())]
         let result = try await makeService().initSession()
 
-        let storedSessionId = await sessionManager.currentSessionId
-        let storedHeader = await sessionManager.authorizationHeader
-        XCTAssertEqual(result.response.sessionId, "sess-123")
-        XCTAssertEqual(result.response.sessionToken.token, "minted-jwt")
-        XCTAssertEqual(storedSessionId, "sess-123")
-        XCTAssertEqual(storedHeader, "Bearer minted-jwt")
         XCTAssertTrue(result.featureFlags.isEnabled(.roktTrackingStatus))
         XCTAssertTrue(result.featureFlags.isEnabled(.minimumPostPurchaseSchema))
         XCTAssertEqual(httpClient.capturedHeaders.count, 1)
     }
 
-    func test_initSession_withValidStoredToken_sendsAuthorizationHeader() async throws {
-        let expiryMs = Int64(now.addingTimeInterval(1800).timeIntervalSince1970 * 1000)
-        await sessionManager.update(
-            sessionId: "existing",
-            sessionToken: TxnSessionToken(token: "stored-jwt", expiresAt: expiryMs)
-        )
+    func test_initSession_sendsHeaderInputs_andNoAuthorization() async throws {
         httpClient.results = [.success(data: successJSON())]
 
         _ = try await makeService().initSession()
 
-        XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
-        XCTAssertNil(httpClient.capturedHeaders.first?["rokt-txn-shadow"])
-    }
-
-    func test_initSession_withoutToken_omitsAuthorizationHeader() async throws {
-        httpClient.results = [.success(data: successJSON())]
-
-        _ = try await makeService().initSession()
-
-        XCTAssertNil(httpClient.capturedHeaders.first?["Authorization"])
+        let headers = httpClient.capturedHeaders.first
+        // Body-less GET: inputs travel as headers.
+        XCTAssertEqual(headers?["rokt-account-id"], "account-1")
+        XCTAssertEqual(headers?["rokt-os-type"], "ios")
+        XCTAssertEqual(headers?["rokt-sdk-version"], "5.2.2")
+        XCTAssertEqual(headers?["rokt-layout-schema-version"], "2.3")
+        // Config-only is unauthenticated: never send Authorization.
+        XCTAssertNil(headers?["Authorization"])
     }
 
     func test_initSession_retriesOnTransient5xx_thenSucceeds() async throws {
         httpClient.results = [.status(500), .status(503), .status(504), .success(data: successJSON())]
 
-        let result = try await makeService().initSession()
+        _ = try await makeService().initSession()
 
-        XCTAssertEqual(result.response.sessionId, "sess-123")
         XCTAssertEqual(httpClient.callCount, 4)
     }
 
@@ -103,9 +82,8 @@ final class TestTxnInitService: XCTestCase {
         httpClient.results = [.transport(NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)),
                               .success(data: successJSON())]
 
-        let result = try await makeService().initSession()
+        _ = try await makeService().initSession()
 
-        XCTAssertEqual(result.response.sessionId, "sess-123")
         XCTAssertEqual(httpClient.callCount, 2)
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -28,8 +28,7 @@ final class TestTxnInitService: XCTestCase {
         )
     }
 
-    // Config-only payload — no session_id / session_token. A session block in
-    // the JSON would simply be ignored by the decoder.
+    // Config-only payload — no session fields.
     private func successJSON() -> Data {
         Data(
             """
@@ -61,12 +60,12 @@ final class TestTxnInitService: XCTestCase {
         _ = try await makeService().initSession()
 
         let headers = httpClient.capturedHeaders.first
-        // Body-less GET: inputs travel as headers.
+        // Inputs travel as headers.
         XCTAssertEqual(headers?["rokt-account-id"], "account-1")
         XCTAssertEqual(headers?["rokt-os-type"], "ios")
         XCTAssertEqual(headers?["rokt-sdk-version"], "5.2.2")
         XCTAssertEqual(headers?["rokt-layout-schema-version"], "2.3")
-        // Config-only is unauthenticated: never send Authorization.
+        // Never send Authorization.
         XCTAssertNil(headers?["Authorization"])
     }
 

--- a/Tests/Rokt_WidgetTests/TestTxnInitWiring.swift
+++ b/Tests/Rokt_WidgetTests/TestTxnInitWiring.swift
@@ -25,7 +25,6 @@ final class TestTxnInitWiring: XCTestCase {
                 accountId: tagId,
                 sdkVersion: "5.2.2",
                 layoutSchemaVersion: "1.0",
-                sessionManager: TxnSessionManager(),
                 httpClient: stub!,
                 baseBackoff: 0,
                 sleep: { _ in }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Move the v2 init call from `POST /v2/sessions/init` to a body-less
`GET /v2/init` (all inputs as headers) that returns **config only** —
`feature_flags` + `fonts`, with no `session_id` / `session_token`.

`POST /v2/sessions/init` previously returned config **and** minted a per-client
`session_id` + JWT `session_token` in one response. Carrying a per-client secret
made the response impossible to edge-cache safely (a partner/platform-keyed cache
would share one user's token across the whole audience). Per the init/font
alignment decision, init becomes config-only and cacheable, and the session is
now sourced from the first `offers/select` response (the v1 shape) — v2 offers
already mints + returns a session token when none is sent.

The endpoint is named `/v2/init` to match the SDK's public
`Rokt.init` surface, per the alignment decision. 

**Dependencies:** requires tx-api to serve `GET /v2/init`
(`transactions#feat/txn-init-rename-v2-init`) and Akamai to route it
(`rokt-akamai#feat/v2-init-get`, on PR #350). Keep in lockstep with the Android
change (`sdk-android-source#feat/v2-init-get`).

Fixes [(issue)]

## What Has Changed

- **`TxnInitClient`** — migrated from POST to body-less `GET /v2/init`; inputs
  passed as explicit headers, no request body, no `Authorization`. Removed the
  now-unused `authToken`, `TxnInitRequest`, and `TxnInitClientError`.
- **`TxnInitResponse`** — config-only: dropped `session_id` / `session_token`
  (keeps `feature_flags` + `fonts`).
- **`TxnInitService`** — updated to the config-only GET call shape (no token
  input).
- **`RoktInternalImplementation` / `TestTxnInitWiring`** — removed the init
  session/token wiring that no longer applies.
- **Tests / mocks** — `TxnInitClientPactSpec`, `TestTxnInitService`,
  `TestMockTxnInitHTTPClient`, `TestTxnInitResponse`,
  `TestTxnInitResponseAdapter`, and `MockResponse` updated to the
  GET `/v2/init` config-only, header-based shape.

## How Has This Been Tested

- Updated and ran the unit tests for the init client/service/response
  (`TestTxnInitService`, `TestTxnInitResponse`, `TestMockTxnInitHTTPClient`).
- Updated the consumer contract test (`TxnInitClientPactSpec`) to assert the
  body-less `GET /v2/init` request and config-only response; verified the Pact
  regenerates against the tx-api provider state.

## Notes

- Fonts ride the config-only response and are populated server-side from the
  op3 `AccountIntegration` projection — no iOS change needed for fonts.
- Session sourcing already exists in the offers/select path, so init minting
  nothing does not change the public init API behaviour for integrators.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.