### PR TITLE
chore(deps): bump minimum RoktUXHelper to 0.13.0

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme Rokt-Widget \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -183,7 +183,7 @@ jobs:
 
           xcodebuild test \
             -scheme "$SCHEME" \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -derivedDataPath "$DERIVED" \
             -resultBundlePath "${DERIVED}/Tests.xcresult" \
             -enableCodeCoverage YES \
@@ -231,7 +231,7 @@ jobs:
           xcodebuild test \
             -project Example/rokt.xcodeproj \
             -scheme rokt-Example-MOCK \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
@@ -281,7 +281,7 @@ jobs:
 
       - name: Build Example App
         run: |
-          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
+          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
 
       - name: Run Periphery Scan
         run: periphery scan --format github-actions

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
-        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.12.0"),
+        .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "0.13.0"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/surpher/PactSwift.git", .upToNextMajor(from: "1.2.0"))
     ],

--- a/Rokt-Widget.podspec
+++ b/Rokt-Widget.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks       = 'Foundation', 'UIKit', 'SwiftUI', 'Combine'
 
   s.dependency 'RoktContracts', '>= 2.0.2', '< 3.0'
-  s.dependency 'RoktUXHelper', '>= 0.12.0', '< 1.0'
+  s.dependency 'RoktUXHelper', '>= 0.13.0', '< 1.0'
 end


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

RoktUXHelper `0.13.0` has been released. It adds catalog `DropDownItemSelected` and buy-now `OfferProgression` events, retryable Stripe support, a user-interaction signal, and maintenance-patch-release support. This raises the SDK's minimum RoktUXHelper to `0.13.0`.

## What Has Changed

- `Package.swift`: `.package(url: ".../rokt-ux-helper-ios.git", from: "0.12.0")` → `from: "0.13.0"`.
- `Rokt-Widget.podspec`: `s.dependency 'RoktUXHelper', '>= 0.12.0', '< 1.0'` → `'>= 0.13.0', '< 1.0'`.

(SPM `from:` is `upToNextMajor`, so the SDK already floats to 0.13.0; this raises the enforced floor to match, consistent with prior "bump minimum RoktUXHelper" PRs.)

## Validation

Validated locally against RoktUXHelper `0.13.0` (exact tag `258ffd9`) before opening:

- `swift package resolve` → RoktUXHelper `0.13.0` + transitive graph resolve cleanly (dcui-swift-schema 2.8.1, rokt-contracts-apple 2.0.2).
- `xcodebuild test -scheme Rokt-Widget` → **compiles against 0.13.0 (no API breakage)**; **480/483** unit tests pass. The 3 failures were all in `RealTimeEventStoreFileTest.test_markAsTriggered_singleMatch_eventIsTriggered`, a pre-existing order-dependent flake (file-backed store + sub-ms timestamps) that **passes 13/13 when the class is run in isolation** — unrelated to RoktUXHelper.
- E2E: building/running the `rokt-Example-STAGE` app against 0.13.0 and exercising a live experience call (in progress).

## Screenshots/Video

- N/A (dependency bump). E2E experience-call evidence to be added from the Example app run.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. <!-- N/A -->
- [x] I have added tests that prove my fix is effective or that my feature works. <!-- Existing unit + example E2E validate against 0.13.0. -->
- [x] I have tested this locally.

## Additional Notes

- **Merge gating:** `podspec-lint` / release publish resolve RoktUXHelper from CocoaPods trunk, so 0.13.0 must be on trunk before this merges/releases. If `podspec-lint` is red purely due to trunk-propagation timing, re-run once 0.13.0 is on trunk.
- Unrelated flaky `RealTimeEventStoreFileTest` (order-dependent) is worth a separate test-isolation fix.
