### PR TITLE
fix(ci): use iPhone 17 Pro simulator in pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme Rokt-Widget \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -retry-tests-on-failure \
@@ -183,7 +183,7 @@ jobs:
 
           xcodebuild test \
             -scheme "$SCHEME" \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -derivedDataPath "$DERIVED" \
             -resultBundlePath "${DERIVED}/Tests.xcresult" \
             -enableCodeCoverage YES \
@@ -231,7 +231,7 @@ jobs:
           xcodebuild test \
             -project Example/rokt.xcodeproj \
             -scheme rokt-Example-MOCK \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
@@ -281,7 +281,7 @@ jobs:
 
       - name: Build Example App
         run: |
-          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
+          xcodebuild -project "Example/rokt.xcodeproj" -scheme "rokt-Example" -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath "DerivedData-periphery" -quiet build CODE_SIGNING_ALLOWED="NO" ENABLE_BITCODE="NO" DEBUG_INFORMATION_FORMAT="dwarf" COMPILER_INDEX_STORE_ENABLE="YES" INDEX_ENABLE_DATA_STORE="YES"
 
       - name: Run Periphery Scan
         run: periphery scan --format github-actions


### PR DESCRIPTION
## Background

The GitHub macOS runner image no longer provides an `iPhone 16 Pro` simulator, so the PR workflow's simulator-based jobs fail with `Unable to find a device matching the provided destination specifier` (SPM Unit Tests, Package SPM Tests, UI Tests, Periphery build all exit 70).

## What Has Changed

- `.github/workflows/pull-request.yml`: the 4 hardcoded `platform=iOS Simulator,name=iPhone 16 Pro,OS=latest` destinations → `iPhone 17 Pro,OS=latest`, matching the device `pact-consumer.yml` already uses.

## Notes

- Same class of runner-image breakage recently fixed in `rokt-ux-helper-ios`. For a more durable cross-repo approach, these could be driven by repository variables (e.g. `CI_SIMULATOR_MODEL`) so future image changes need no PR — happy to follow up if you want that pattern here too.
- Independent of the in-flight RoktUXHelper 0.13.0 bump (#231); this just unblocks the SDK's own CI.

## Checklist

- [x] Self-review performed.
- [x] Tested locally (device availability verified; `iPhone 17 Pro`/17 present on Xcode 26.x runners).