### PR TITLE
fix: Store font cache in Caches directory instead of Documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Store font files and font cache metadata in the Caches directory instead of Documents, avoiding write failures when Documents is unavailable (e.g. background or locked device)
+- Downgrade font cache metadata diagnostics to informational severity since cache write failures do not block placement rendering
+
 ## [5.2.5] - 2026-06-18
 
 ### Core

--- a/Sources/Rokt_Widget/DataAccess/ConcurrentQueueFileStorageDecorator.swift
+++ b/Sources/Rokt_Widget/DataAccess/ConcurrentQueueFileStorageDecorator.swift
@@ -10,10 +10,12 @@ class ConcurrentQueueFileStorageDecorator: FileStorage {
     }
 
     // WRITES should be asynchronous and use a `barrier`
-    func write<T: Encodable>(payload: T,
-                             to fileURL: URL,
-                             options: [RoktDownloadOptions]? = nil,
-                             completion: ((Result<Void, Error>) -> Void)?) {
+    func write<T: Encodable>(
+        payload: T,
+        to fileURL: URL,
+        options: [RoktDownloadOptions]? = nil,
+        completion: ((Result<Void, Error>) -> Void)?
+    ) {
         concurrentQueue.async(flags: .barrier) { [weak self] in
             self?.decoratee.write(payload: payload, to: fileURL, options: options, completion: completion)
         }
@@ -63,7 +65,12 @@ class ConcurrentQueueFileStorageDecorator: FileStorage {
             let newValue = transform(currentValue)
 
             // Write back
-            self.decoratee.write(payload: newValue, to: url, options: nil, completion: completion)
+            self.decoratee.write(
+                payload: newValue,
+                to: url,
+                options: [.createIntermediateDirectories],
+                completion: completion
+            )
         }
     }
 }

--- a/Sources/Rokt_Widget/DataAccess/FontRepository.swift
+++ b/Sources/Rokt_Widget/DataAccess/FontRepository.swift
@@ -180,10 +180,11 @@ class FontRepository {
 
     // MARK: - Diagnostics
 
-    private static func sendDiagnosticWith(prefix: String, error: Error) {
+    private static func sendDiagnosticWith(prefix: String, error: Error, severity: Severity = .info) {
         RoktAPIHelper.sendDiagnostics(
             message: fontDiagnosticCode,
-            callStack: "\(prefix) \(error.localizedDescription)"
+            callStack: "\(prefix) \(error.localizedDescription)",
+            severity: severity
         )
     }
 
@@ -197,12 +198,26 @@ class FontRepository {
         fontDownloadDetailFileName = fileName
     }
 
-    internal static func getFileUrl(name: String) -> URL? {
-        if let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let fullPath = documentsUrl.appendingPathComponent(name).appendingPathExtension("json")
-            return fullPath
+    private static let cacheDirectory = "RoktFonts"
+
+    internal static func getCacheDirectoryUrl() -> URL? {
+        guard let cachesUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
         }
-        return nil
+
+        let fullPath: URL
+        if #available(iOS 16.0, *) {
+            fullPath = cachesUrl.appending(component: cacheDirectory, directoryHint: .isDirectory)
+        } else {
+            fullPath = cachesUrl.appendingPathComponent(cacheDirectory, isDirectory: true)
+        }
+
+        return fullPath
+    }
+
+    internal static func getFileUrl(name: String) -> URL? {
+        guard let cacheDirectoryUrl = getCacheDirectoryUrl() else { return nil }
+        return cacheDirectoryUrl.appendingPathComponent(name).appendingPathExtension("json")
     }
 
     internal static func isFileExist(name: String) -> Bool {

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -86,7 +86,7 @@ internal class FontManager {
                     continue
                 }
 
-                // additional check if font can be created in local documents directory
+                // additional check if font can be created in local caches directory
                 guard let fileUrl = getFileUrl(name: registeredFontName) else {
                     Rokt.shared.roktImplementation.isInitialized = false
                     Rokt.shared.roktImplementation.isInitFailedForFont = true
@@ -272,15 +272,16 @@ internal class FontManager {
     }
 
     internal static func getFileUrl(name: String) -> URL? {
-        if let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let fullPath = documentsUrl.appendingPathComponent("\(name)\(fontExtension)")
-            // Log FFL008
-            sendFullFontLogs("Full file path URL: \(fullPath)", fontLogId: fullFontLogCode8)
-            return fullPath
+        guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
+            // Log FFL009
+            sendFullFontLogs("File Manager failed to read caches directory in user home", fontLogId: fullFontLogCode9)
+            return nil
         }
-        // Log FFL009
-        sendFullFontLogs("File Manager failed to read documents directory in user home", fontLogId: fullFontLogCode9)
-        return nil
+
+        let fullPath = cacheDirectoryUrl.appendingPathComponent("\(name)\(fontExtension)")
+        // Log FFL008
+        sendFullFontLogs("Full file path URL: \(fullPath)", fontLogId: fullFontLogCode8)
+        return fullPath
     }
 
     internal static func isFontFileExist(name: String) -> Bool {

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -320,6 +320,101 @@ class FontRepositoryTests: XCTestCase {
 
         XCTAssertEqual(result, .success)
     }
+
+    // MARK: - Cache directory paths
+
+    func test_getCacheDirectoryUrl_returnsRoktFontsSubdirectoryUnderCaches() throws {
+        let cacheDirectoryUrl = try XCTUnwrap(FontRepository.getCacheDirectoryUrl())
+
+        XCTAssertTrue(cacheDirectoryUrl.path.contains("Caches"))
+        XCTAssertTrue(cacheDirectoryUrl.path.hasSuffix("RoktFonts"))
+    }
+
+    func test_getFileUrl_returnsJsonFileUnderCacheDirectory() throws {
+        let fileUrl = try XCTUnwrap(FontRepository.getFileUrl(name: "custom-cache-file"))
+
+        XCTAssertEqual(fileUrl.pathExtension, "json")
+        XCTAssertTrue(fileUrl.path.contains("RoktFonts"))
+        XCTAssertEqual(fileUrl.deletingPathExtension().lastPathComponent, "custom-cache-file")
+    }
+
+    func test_isFileExist_returnsTrueAfterSuccessfulSave() {
+        let expectation = expectation(description: "save font url")
+
+        FontRepository.saveFontUrl(key: "exists-test") {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+
+        XCTAssertTrue(FontRepository.isFileExist(name: FontRepository.fontDownloadURLFileName))
+    }
+
+    func test_saveFontURL_movesDuplicateToFrontOfList() throws {
+        let expectation1 = expectation(description: "save font 1")
+        let expectation2 = expectation(description: "save font 2")
+        let expectation3 = expectation(description: "save font 1 again")
+
+        FontRepository.saveFontUrl(key: "test-1") {
+            expectation1.fulfill()
+        }
+        FontRepository.saveFontUrl(key: "test-2") {
+            expectation2.fulfill()
+        }
+        FontRepository.saveFontUrl(key: "test-1") {
+            expectation3.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+
+        let savedURLs = try XCTUnwrap(FontRepository.loadAllFontURLs())
+
+        XCTAssertEqual(savedURLs, ["test-1", "test-2"])
+    }
+
+    func test_removeFontUrl_withMissingKey_leavesSavedURLsUntouched() throws {
+        let saveExpectation1 = expectation(description: "save font 1")
+        let saveExpectation2 = expectation(description: "save font 2")
+
+        FontRepository.saveFontUrl(key: "test-1") {
+            saveExpectation1.fulfill()
+        }
+        FontRepository.saveFontUrl(key: "test-2") {
+            saveExpectation2.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+
+        let removeExpectation = expectation(description: "remove missing key")
+        FontRepository.removeFontUrl(key: "missing-key") {
+            removeExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+
+        let savedURLs = try XCTUnwrap(FontRepository.loadAllFontURLs())
+
+        XCTAssertEqual(["test-1", "test-2"], savedURLs.sorted())
+    }
+
+    func test_loadFontURLs_withCorruptFile_sendsDiagnostics() throws {
+        let fileURL = try XCTUnwrap(FontRepositoryTests.downloadURLFileURL())
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not-json".utf8).write(to: fileURL)
+
+        _ = FontRepository.loadAllFontURLs()
+
+        let expectation = expectation(description: "Wait for async diagnostics")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertFalse(diagnosticsReceived.isEmpty)
+    }
 }
 
 extension XCTestCase {
@@ -407,5 +502,14 @@ extension XCTestCase {
             XCTFail("could not decode URL file with error \(error.localizedDescription)")
             return nil
         }
+    }
+
+    static func writeFontFileToCache(named name: String, data: Data = Data([0x00])) throws {
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: name))
+        try FileManager.default.createDirectory(
+            at: fileUrl.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: fileUrl)
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -345,13 +345,12 @@ extension XCTestCase {
     }
 
     static func fileURLFor(fileName: String) -> URL? {
-        guard let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        else {
-            XCTFail("documents url does not exist")
+        guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
+            XCTFail("caches url does not exist")
             return nil
         }
 
-        return documentsUrl.appendingPathComponent(fileName).appendingPathExtension("json")
+        return cacheDirectoryUrl.appendingPathComponent(fileName).appendingPathExtension("json")
     }
 
     static func deleteJSONFileWith(name: String) {

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -3,14 +3,17 @@ import XCTest
 
 class FontRepositoryTests: XCTestCase {
     var diagnosticsReceived: [String] = []
+    var diagnosticModelsReceived: [XCTestCase.StubbedDiagnosticsModel] = []
 
     override func setUp() {
         super.setUp()
 
         diagnosticsReceived = []
+        diagnosticModelsReceived = []
         Rokt.shared.roktImplementation.roktTagId = "123"
-        stubDiagnostics { [weak self] code in
-            self?.diagnosticsReceived.append(code)
+        stubDiagnostics { [weak self] model in
+            self?.diagnosticModelsReceived.append(model)
+            self?.diagnosticsReceived.append(model.code)
         }
 
         FontRepositoryTests.prepareTestFiles()
@@ -20,7 +23,9 @@ class FontRepositoryTests: XCTestCase {
 
     override func tearDown() {
         FontRepositoryTests.deleteAllTestFiles()
+        FontRepositoryTests.unblockJSONFileWrites()
         diagnosticsReceived = []
+        diagnosticModelsReceived = []
 
         super.tearDown()
     }
@@ -415,6 +420,117 @@ class FontRepositoryTests: XCTestCase {
 
         XCTAssertFalse(diagnosticsReceived.isEmpty)
     }
+
+    func test_loadFontDetail_withCorruptFile_sendsDiagnosticsAndReturnsNil() throws {
+        let fileURL = try XCTUnwrap(FontRepositoryTests.downloadDetailFileURL())
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not-json".utf8).write(to: fileURL)
+
+        XCTAssertNil(FontRepository.loadFontDetail(key: "any-key"))
+
+        let expectation = expectation(description: "Wait for async diagnostics")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertFalse(diagnosticsReceived.isEmpty)
+    }
+
+    func test_isFileExist_returnsFalseWhenFileMissing() {
+        XCTAssertFalse(FontRepository.isFileExist(name: FontRepository.fontDownloadURLFileName))
+    }
+
+    func test_saveFontUrl_whenWriteBlocked_sendsInfoDiagnosticAndCallsCompletion() throws {
+        try FontRepositoryTests.blockJSONFileWrite(fileName: FontRepository.fontDownloadURLFileName)
+
+        let expectation = expectation(description: "completion called on write failure")
+        FontRepository.saveFontUrl(key: "test-url") {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        waitForDiagnostics()
+
+        XCTAssertTrue(
+            diagnosticModelsReceived.contains {
+                $0.code == fontDiagnosticCode
+                    && $0.severity == Severity.info.rawValue
+                    && $0.stackTrace.contains("Failed to save font urls:")
+            }
+        )
+    }
+
+    func test_removeFontUrl_whenWriteBlocked_sendsInfoDiagnosticAndCallsCompletion() throws {
+        try FontRepositoryTests.blockJSONFileWrite(fileName: FontRepository.fontDownloadURLFileName)
+
+        let expectation = expectation(description: "completion called on write failure")
+        FontRepository.removeFontUrl(key: "test-url") {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        waitForDiagnostics()
+
+        XCTAssertTrue(
+            diagnosticModelsReceived.contains {
+                $0.code == fontDiagnosticCode
+                    && $0.severity == Severity.info.rawValue
+                    && $0.stackTrace.contains("Failed to delete font urls:")
+            }
+        )
+    }
+
+    func test_saveFontDetail_whenWriteBlocked_sendsInfoDiagnosticAndCallsCompletion() throws {
+        try FontRepositoryTests.blockJSONFileWrite(fileName: FontRepository.fontDownloadDetailFileName)
+
+        let expectation = expectation(description: "completion called on write failure")
+        FontRepository.saveFontDetail(key: "test", values: ["key": "value"]) {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        waitForDiagnostics()
+
+        XCTAssertTrue(
+            diagnosticModelsReceived.contains {
+                $0.code == fontDiagnosticCode
+                    && $0.severity == Severity.info.rawValue
+                    && $0.stackTrace.contains("Failed to save font details:")
+            }
+        )
+    }
+
+    func test_removeFontDetail_whenWriteBlocked_sendsInfoDiagnosticAndCallsCompletion() throws {
+        try FontRepositoryTests.blockJSONFileWrite(fileName: FontRepository.fontDownloadDetailFileName)
+
+        let expectation = expectation(description: "completion called on write failure")
+        FontRepository.removeFontDetail(key: "test") {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        waitForDiagnostics()
+
+        XCTAssertTrue(
+            diagnosticModelsReceived.contains {
+                $0.code == fontDiagnosticCode
+                    && $0.severity == Severity.info.rawValue
+                    && $0.stackTrace.contains("Failed to delete font details:")
+            }
+        )
+    }
+
+    private func waitForDiagnostics() {
+        let expectation = expectation(description: "Wait for async diagnostics")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
 }
 
 extension XCTestCase {
@@ -511,5 +627,22 @@ extension XCTestCase {
             withIntermediateDirectories: true
         )
         try data.write(to: fileUrl)
+    }
+
+    static func blockJSONFileWrite(fileName: String) throws {
+        let fileURL = try XCTUnwrap(fileURLFor(fileName: fileName))
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+        try FileManager.default.createDirectory(at: fileURL, withIntermediateDirectories: false)
+    }
+
+    static func unblockJSONFileWrites() {
+        deleteJSONFileWith(name: fontDownloadURLFileName)
+        deleteJSONFileWith(name: fontDownloadDetailFileName)
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -75,8 +75,8 @@ class TestFontManager: XCTestCase {
     }
 
     func test_getFileURL_returnsMappedURL() throws {
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let expectedURL = documentsUrl.appendingPathComponent("test.ttf")
+        let cacheDirectoryUrl = try XCTUnwrap(FontRepository.getCacheDirectoryUrl())
+        let expectedURL = cacheDirectoryUrl.appendingPathComponent("test.ttf")
 
         let url = try XCTUnwrap(FontManager.getFileUrl(name: "test"))
 

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -25,6 +25,12 @@ class TestFontManager: XCTestCase {
 
     override func tearDown() {
         XCTestCase.deleteAllTestFiles()
+        Rokt.shared.roktImplementation.initFeatureFlags = InitFeatureFlags(
+            roktTrackingStatus: true,
+            shouldLogFontHappyPath: false,
+            shouldUseFontRegisterWithUrl: false,
+            featureFlags: [:]
+        )
 
         super.tearDown()
     }
@@ -130,6 +136,113 @@ class TestFontManager: XCTestCase {
         let font = FontModel(name: "some other font", url: "")
 
         XCTAssertFalse(FontManager.isSystemFont(font: font))
+    }
+
+    func test_isFontFileExist_returnsFalseWhenFileMissing() {
+        XCTAssertFalse(FontManager.isFontFileExist(name: "missing-font-file"))
+    }
+
+    func test_isFontFileExist_returnsTrueWhenFileExists() throws {
+        try XCTestCase.writeFontFileToCache(named: "cached-font-file")
+
+        XCTAssertTrue(FontManager.isFontFileExist(name: "cached-font-file"))
+    }
+
+    func test_isDownloadingFontRequired_withValidCachedFont_returnsFalse() throws {
+        let font = FontModel(name: "cached-font", url: "https://font.test/cached.ttf")
+        let saveExpectation = expectation(description: "save font details")
+
+        FontRepository.saveFontDetail(
+            key: font.url,
+            values: [
+                FontManager.keyName: "cached-font",
+                FontManager.keyTimestamp: "\(Date().timeIntervalSince1970)"
+            ]
+        ) {
+            saveExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        try XCTestCase.writeFontFileToCache(named: "cached-font")
+
+        XCTAssertFalse(FontManager.isDownloadingFontRequired(font: font))
+    }
+
+    func test_isDownloadingFontRequired_withExpiredCacheAndTemporaryFlag_returnsTrue() throws {
+        Rokt.shared.roktImplementation.initFeatureFlags = InitFeatureFlags(
+            featureFlags: ["mobile-sdk-use-temporary-font-cache": FeatureFlagItem(match: true)]
+        )
+
+        let font = FontModel(name: "expired-font", url: "https://font.test/expired.ttf")
+        let expiredTimestamp = Calendar.current.date(byAdding: .day, value: -10, to: Date())!.timeIntervalSince1970
+        let saveExpectation = expectation(description: "save font details")
+
+        FontRepository.saveFontDetail(
+            key: font.url,
+            values: [
+                FontManager.keyName: "expired-font",
+                FontManager.keyTimestamp: "\(expiredTimestamp)"
+            ]
+        ) {
+            saveExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        try XCTestCase.writeFontFileToCache(named: "expired-font")
+
+        XCTAssertTrue(FontManager.isDownloadingFontRequired(font: font))
+    }
+
+    func test_removeUnusedFonts_removesFontsNotInProvidedList() throws {
+        let keepFont = FontModel(name: "keep-font", url: "https://font.test/keep.ttf")
+        let removeFont = FontModel(name: "remove-font", url: "https://font.test/remove.ttf")
+
+        let saveKeepExpectation = expectation(description: "save keep url")
+        let saveRemoveExpectation = expectation(description: "save remove url")
+        let saveRemoveDetailExpectation = expectation(description: "save remove detail")
+
+        FontRepository.saveFontUrl(key: keepFont.url) {
+            saveKeepExpectation.fulfill()
+        }
+        FontRepository.saveFontUrl(key: removeFont.url) {
+            saveRemoveExpectation.fulfill()
+        }
+        FontRepository.saveFontDetail(
+            key: removeFont.url,
+            values: [
+                FontManager.keyName: "remove-font",
+                FontManager.keyTimestamp: "\(Date().timeIntervalSince1970)"
+            ]
+        ) {
+            saveRemoveDetailExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15)
+        try XCTestCase.writeFontFileToCache(named: "remove-font")
+
+        FontManager.removeUnusedFonts(fonts: [keepFont])
+
+        let waitExpectation = expectation(description: "wait for async cleanup")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            waitExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+
+        let remainingURLs = try XCTUnwrap(FontRepository.loadAllFontURLs())
+
+        XCTAssertEqual(remainingURLs, [keepFont.url])
+        XCTAssertNil(FontRepository.loadFontDetail(key: removeFont.url))
+        XCTAssertFalse(FontManager.isFontFileExist(name: "remove-font"))
+    }
+
+    func test_reRegisterFonts_withNoPendingFonts_callsCompletion() {
+        let expectation = expectation(description: "reRegisterFonts completion")
+
+        FontManager.reRegisterFonts {
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
     }
 
     func test_downloadFonts_should_call_onFontDownloadComplete_when_fonts_are_empty() {


### PR DESCRIPTION
## Background

Font files and font cache metadata were stored under the Documents directory, which can be unavailable or unwritable in some app states (e.g. background or locked device). This mirrors the same fix applied in sdk-ios-source.

## What Has Changed

- Store font files and JSON cache metadata under `Caches/RoktFonts` via `FontRepository.getCacheDirectoryUrl()`
- `FontManager.getFileUrl` resolves paths through the shared cache directory helper
- `ConcurrentQueueFileStorageDecorator.atomicReadModifyWrite` creates intermediate directories on write
- Font cache metadata diagnostics use informational severity by default (`fontDiagnosticCode`)
- Updated unit tests and CHANGELOG

## How Has This Been Tested

- `xcodebuild test -scheme Rokt-Widget` with `-only-testing:Rokt_WidgetTests/FontRepositoryTests` and `-only-testing:Rokt_WidgetTests/TestFontManager` on iPhone 17 Pro simulator (37 tests, 0 failures)
- `trunk check` on modified Swift sources (pre-commit hook on commit)

## Notes

N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.