### PR TITLE
fix(txn): map instant_purchase_dismissal event (cross-platform consistency)

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -71,6 +71,10 @@ internal enum TxnEventMapper {
         case .SignalCartItemInstantPurchaseInitiated: return MappedType("cart_item_instant_purchase_initiated")
         case .SignalCartItemInstantPurchase: return MappedType("cart_item_instant_purchase")
         case .SignalCartItemInstantPurchaseFailure: return MappedType("cart_item_instant_purchase_failure")
+        case .SignalInstantPurchaseDismissal: return MappedType("instant_purchase_dismissal")
+        // NOTE: a `time_on_site` wire type also exists, but there is no corresponding
+        // case in RoktUXEventType in the pinned RoktUXHelper dependency, so it cannot
+        // be handled here yet. See PR notes.
         default: return nil
         }
     }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
@@ -38,7 +38,8 @@ final class TestTxnEventMapper: XCTestCase {
             (.SignalUserInteraction, "user_interaction"),
             (.SignalCartItemInstantPurchaseInitiated, "cart_item_instant_purchase_initiated"),
             (.SignalCartItemInstantPurchase, "cart_item_instant_purchase"),
-            (.SignalCartItemInstantPurchaseFailure, "cart_item_instant_purchase_failure")
+            (.SignalCartItemInstantPurchaseFailure, "cart_item_instant_purchase_failure"),
+            (.SignalInstantPurchaseDismissal, "instant_purchase_dismissal")
         ]
 
         for (eventType, expected) in cases {
@@ -61,9 +62,14 @@ final class TestTxnEventMapper: XCTestCase {
         XCTAssertEqual(event?.data?["interactionType"], .string("activation"))
     }
 
-    func test_diagnosticAndInstantPurchaseDismissal_areDropped() {
+    func test_diagnostic_isDropped() {
         XCTAssertNil(TxnEventMapper.event(from: makeRequest(eventType: .SignalSdkDiagnostic)))
-        XCTAssertNil(TxnEventMapper.event(from: makeRequest(eventType: .SignalInstantPurchaseDismissal)))
+    }
+
+    func test_instantPurchaseDismissal_mapsToInstantPurchaseDismissal() {
+        let event = TxnEventMapper.event(from: makeRequest(eventType: .SignalInstantPurchaseDismissal))
+
+        XCTAssertEqual(event?.eventType, "instant_purchase_dismissal")
     }
 
     func test_instanceIdAndTimestampAreCarried() {


### PR DESCRIPTION
## Finding

iOS `TxnEventMapper` was missing a txn event-name mapping:

- `SignalInstantPurchaseDismissal` -> `"instant_purchase_dismissal"`

Because this fell through to the `default: return nil` arm, `SignalInstantPurchaseDismissal` events were being silently dropped on iOS instead of forwarded to the v2 txn events pipeline.

## Fix

`Sources/Rokt_Widget/Networking/TxnEventMapper.swift` (`mappedType(for:)`):

- Added `case .SignalInstantPurchaseDismissal: return MappedType("instant_purchase_dismissal")`.
- Updated `Tests/.../TestTxnEventMapper.swift`: the old `test_diagnosticAndInstantPurchaseDismissal_areDropped` asserted this event was dropped. Split into `test_diagnostic_isDropped` (unchanged behaviour for `SignalSdkDiagnostic`) and a new positive assertion that `SignalInstantPurchaseDismissal` maps to `instant_purchase_dismissal`. Also added it to the `test_mapsEventTypeVocabulary` table.

## Limitation — `time_on_site` not mapped

A `time_on_site` wire type also exists, but `SignalTimeOnSite` **does not exist** as a case in `RoktUXEventType`, which is defined in the external `RoktUXHelper` dependency (`rokt-ux-helper-ios`, pinned `>= 0.13.0, < 1.0`). `mappedType(for:)` switches on `RoktUXEventType`, so there is no symbol to match — adding a `case .SignalTimeOnSite` would not compile. An inline `NOTE` documents this; mapping it requires first adding the enum case in `rokt-ux-helper-ios` and bumping the dependency, which is out of scope for this focused change.

## Verification

Compilation verified: `xcodebuild build -project Example/rokt.xcodeproj -scheme Rokt-Widget -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` -> **BUILD SUCCEEDED**. Tests updated but not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
