### PR TITLE
feat(txn events): cap events per batch at 25 (cross-platform consistency)

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 internal struct TxnEventService {
+    // Cap events per POST /v2/sessions/events so a large backlog is split across
+    // several requests instead of one oversized payload.
+    static let maxEventsPerBatch = 25
+
     enum TxnEventError: Error, Equatable {
         case invalidBaseURL
         case unexpectedStatusCode(Int)
@@ -48,6 +52,17 @@ internal struct TxnEventService {
 
     func send(events: [TxnEvent]) async throws {
         guard !events.isEmpty else { return }
+        guard client != nil else { throw TxnEventError.invalidBaseURL }
+
+        // Send batches sequentially (awaiting each) to preserve event order and so a
+        // session token refreshed by one batch is picked up by the next.
+        for start in stride(from: 0, to: events.count, by: Self.maxEventsPerBatch) {
+            let end = min(start + Self.maxEventsPerBatch, events.count)
+            try await sendBatch(events: Array(events[start..<end]))
+        }
+    }
+
+    private func sendBatch(events: [TxnEvent]) async throws {
         guard let client else { throw TxnEventError.invalidBaseURL }
 
         let authToken = await sessionManager.authorizationHeader

--- a/Tests/Rokt_WidgetTests/Shared/Networking/MockTxnEventsHTTPClient.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/MockTxnEventsHTTPClient.swift
@@ -11,6 +11,8 @@ final class MockTxnEventsHTTPClient: HTTPClientAdapter {
     var results: [Response] = []
     private(set) var callCount = 0
     private(set) var capturedHeaders: [RoktHTTPHeaders] = []
+    // Number of events in each request body, in the order requests were made.
+    private(set) var capturedEventCounts: [Int] = []
 
     func updateTimeout(timeout: Double) {}
 
@@ -27,6 +29,7 @@ final class MockTxnEventsHTTPClient: HTTPClientAdapter {
         completionHandler: ((RoktHTTPRequestResult) -> Void)?
     ) -> URLRequest? {
         capturedHeaders.append(headers ?? [:])
+        capturedEventCounts.append((parameters?["events"] as? [Any])?.count ?? 0)
         let response = results.isEmpty
             ? .success(status: 202, data: Data(#"{ "event_ids": ["event-1"] }"#.utf8))
             : results[min(callCount, results.count - 1)]

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -146,6 +146,42 @@ final class TestTxnEventService: XCTestCase {
         }
     }
 
+    private func events(_ count: Int) -> [TxnEvent] {
+        (0..<count).map { index in
+            TxnEvent(eventType: "impression", instanceId: "instance-\(index)", timestamp: 1_700_000_000_000, data: ["k": "v"])
+        }
+    }
+
+    func test_send_chunksEventsIntoBatchesOfMax25() async throws {
+        // 60 events -> batches of 25, 25, 10 sent as separate requests.
+        try await makeService().send(events: events(60))
+
+        XCTAssertEqual(httpClient.callCount, 3)
+        XCTAssertEqual(httpClient.capturedEventCounts, [25, 25, 10])
+    }
+
+    func test_send_countAtCap_sendsSingleRequest() async throws {
+        try await makeService().send(events: events(TxnEventService.maxEventsPerBatch))
+
+        XCTAssertEqual(httpClient.callCount, 1)
+        XCTAssertEqual(httpClient.capturedEventCounts, [TxnEventService.maxEventsPerBatch])
+    }
+
+    func test_send_chunkFailure_propagatesAndStopsSubsequentBatches() async {
+        // First batch exhausts retries on 400 (non-retryable); later batches must not be sent.
+        httpClient.results = [.status(400)]
+
+        do {
+            try await makeService().send(events: events(60))
+            XCTFail("Expected send to fail on first batch")
+        } catch let error as TxnEventService.TxnEventError {
+            XCTAssertEqual(error, .unexpectedStatusCode(400))
+            XCTAssertEqual(httpClient.callCount, 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func test_send_emptyEvents_skipsRequest() async throws {
         try await makeService().send(events: [])
 


### PR DESCRIPTION
## Finding

The iOS SDK had **no cap on events-per-request**: `TxnEventService.send(events:)` posted the entire events array in a single `POST /v2/sessions/events`. A large backlog therefore produced one oversized payload.

## Change

- Added `TxnEventService.maxEventsPerBatch = 25`.
- `send(events:)` now splits the outgoing events into batches of at most 25 and sends them **sequentially (awaiting each)** via a new private `sendBatch(events:)`.
- **Order preserved**: batches are sent in order using `stride`.
- **Auth/token-refresh preserved per chunk**: each batch fetches the current authorization header, so a `session_token` rotated by one batch's response is picked up by the next. The existing retry/backoff logic is unchanged and applies per request.
- If a batch fails (after exhausting retries), the error propagates and subsequent batches are not sent — same failure semantics as before, just per-batch.

Diff is scoped to the events send path plus tests.

## Why draft

This is a **behavioural change** to the network send path. **Please confirm the cap value of 25** — reviewers with gateway/payload-size context should validate whether 25 is the right number for iOS.

## Verification

- `xcodebuild build` of the `Rokt-Widget` scheme (iOS Simulator): **BUILD SUCCEEDED**.
- Unit tests (`Rokt_WidgetTests/TestTxnEventService`): **13 passed, 0 failures**, including 3 new tests:
  - `test_send_chunksEventsIntoBatchesOfMax25` — 60 events → requests of [25, 25, 10].
  - `test_send_countAtCap_sendsSingleRequest` — exactly 25 → single request.
  - `test_send_chunkFailure_propagatesAndStopsSubsequentBatches` — first batch failure stops later batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
