### PR TITLE
fix(txn events): dedup unconditionally + exempt always-resend events (cross-platform consistency)

### DIFF
--- a/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
+++ b/Sources/Rokt_Widget/ViewModel/PlatformEventProcessor.swift
@@ -144,29 +144,45 @@ class PlatformEventProcessor {
             }
         }
 
-        guard !nonDiagnosticEvents.isEmpty,
-              #available(iOS 13.0, *),
-              Rokt.shared.roktImplementation.initFeatureFlags.isEnabled(.cacheEnabled),
+        guard !nonDiagnosticEvents.isEmpty else { return }
+
+        // In-memory dedup runs unconditionally, regardless of cache state.
+        // Previously this only ran when the cache was enabled, so with the cache off every event —
+        // including exact duplicates — was re-sent. Always-resend events (user interactions) are exempt
+        // so repeated user actions are never dropped.
+        let sentEventHashes = Rokt.shared.roktImplementation.sentEventHashes
+        let newEvents = nonDiagnosticEvents.filter { event in
+            guard Self.shouldDeduplicate(event) else { return true }
+            return sentEventHashes.insert(ProcessedEvent(event).getHashString()).inserted
+        }
+        guard !newEvents.isEmpty else { return }
+
+        sendEvents(newEvents)
+
+        // Cache-persistence stays gated: only persist the sent-event hashes when the cache is
+        // enabled + configured and we have cache properties for the current view.
+        guard Rokt.shared.roktImplementation.initFeatureFlags.isEnabled(.cacheEnabled),
               Rokt.shared.roktImplementation.roktConfig.cacheConfig.isCacheEnabled(),
               let cacheProperties
-        else {
-            sendEvents(nonDiagnosticEvents)
-            return
-        }
-        // If cache enabled, filters out already sent cached non-diagnostic events
-        let newEvents = nonDiagnosticEvents.filter {
-            let processedEvent = ProcessedEvent($0)
-            return Rokt.shared.roktImplementation.sentEventHashes.insert(processedEvent.getHashString()).inserted
-        }
-        guard !newEvents.isEmpty else {
-            return
-        }
-        // Sends new events and updates cache
-        sendEvents(newEvents)
+        else { return }
+
         ExperienceCacheManager.cacheExperiencesViewStateSentEventHashes(viewName: cacheProperties.viewName,
                                                                         attributes: cacheProperties
                                                                             .experienceCacheAttributes,
                                                                         sentEventHashes: Rokt.shared.roktImplementation
                                                                         .sentEventHashes.allElements)
+    }
+
+    // Events exempt from dedup are always re-sent. User interactions are exempt: on iOS they surface as
+    // both `.SignalUserInteraction` and `.SignalActivation` (both map to the `user_interaction` wire type
+    // in TxnEventMapper), so both are exempt — a user tapping the same control twice must reach the server
+    // both times.
+    private static func shouldDeduplicate(_ event: RoktEventRequest) -> Bool {
+        switch event.eventType {
+        case .SignalUserInteraction, .SignalActivation:
+            return false
+        default:
+            return true
+        }
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessorDedup.swift
+++ b/Tests/Rokt_WidgetTests/Shared/ViewModel/TestPlatformEventProcessorDedup.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import Rokt_Widget
+@testable internal import RoktUXHelper
+
+// Verifies that in-memory event dedup runs unconditionally, that always-resend
+// events (user interactions) are exempt from dedup, and that cache-persistence stays gated on the
+// cache being enabled + configured.
+final class TestPlatformEventProcessorDedup: XCTestCase {
+
+    private var sut: PlatformEventProcessor!
+    private var impl: RoktInternalImplementation!
+    private var originalImpl: RoktInternalImplementation!
+    private var stub: MockTxnEventsHTTPClient!
+
+    private let cacheFlagKey = "mobile-sdk-use-sdk-cache"
+    private let mockedViewName = "dedup-test-view"
+    private let mockedAttributes = ["email": "dedup1593754986316@rokt.com"]
+
+    override func setUp() {
+        super.setUp()
+        XCTestCase.prepareExperienceCacheTestFiles()
+        XCTestCase.deleteExperienceCacheTestFiles()
+
+        // Swap the shared implementation for a controlled instance with an injected txn HTTP stub so
+        // we can observe exactly which events reach the wire. Cache is OFF by default on a fresh impl.
+        originalImpl = Rokt.shared.roktImplementation
+        stub = MockTxnEventsHTTPClient()
+        impl = RoktInternalImplementation()
+        impl.roktTagId = "tag-1"
+        impl.makeTxnEventServiceOverride = { [stub] tagId in
+            TxnEventService(
+                environment: .Prod,
+                accountId: tagId,
+                sdkVersion: "5.2.2",
+                sessionManager: TxnSessionManager(),
+                httpClient: stub!,
+                baseBackoff: 0,
+                sleep: { _ in }
+            )
+        }
+        Rokt.shared.roktImplementation = impl
+
+        sut = PlatformEventProcessor()
+    }
+
+    override func tearDown() {
+        XCTestCase.deleteExperienceCacheTestFiles()
+        Rokt.shared.roktImplementation = originalImpl
+        sut = nil
+        impl = nil
+        stub = nil
+        originalImpl = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func payload(_ events: [RoktEventRequest]) -> [String: Any] {
+        let payload = RoktUXEventsPayload(events: events)
+        guard let data = try? JSONEncoder().encode(payload),
+              let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return [:]
+        }
+        return dict
+    }
+
+    private func settle(_ interval: TimeInterval = 0.3) {
+        let settled = expectation(description: "settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval) { settled.fulfill() }
+        wait(for: [settled], timeout: 2)
+    }
+
+    private func enableCache() {
+        impl.initFeatureFlags = InitFeatureFlags(featureFlags: [cacheFlagKey: FeatureFlagItem(match: true)])
+        impl.roktConfig = RoktConfig.Builder().cacheConfig(RoktConfig.CacheConfig()).build()
+    }
+
+    private func cacheProperties() -> LayoutPageCacheProperties {
+        LayoutPageCacheProperties(
+            viewName: mockedViewName,
+            experienceCacheAttributes: mockedAttributes,
+            pluginViewStates: nil,
+            onPluginViewStateChange: nil
+        )
+    }
+
+    // MARK: - (a) Cache OFF: duplicate event is NOT re-sent
+
+    func test_cacheOff_duplicateEvent_isNotResent() {
+        sut.process(payload([.mock(eventType: .SignalImpression)]), executeId: "1", cacheProperties: nil)
+        waitUntil { self.stub.callCount == 1 }
+
+        // Re-processing the exact same event must be deduped away even though the cache is off.
+        sut.process(payload([.mock(eventType: .SignalImpression)]), executeId: "1", cacheProperties: nil)
+        settle()
+
+        XCTAssertEqual(stub.callCount, 1)
+        XCTAssertEqual(impl.sentEventHashes.count, 1)
+    }
+
+    // MARK: - (b) Exempt (user-interaction) event IS re-sent even when duplicated
+
+    func test_cacheOff_userInteractionEvent_isAlwaysResent() {
+        sut.process(payload([.mock(eventType: .SignalUserInteraction)]), executeId: "1", cacheProperties: nil)
+        waitUntil { self.stub.callCount == 1 }
+
+        // User interactions are exempt from dedup, so the duplicate must still reach the wire.
+        sut.process(payload([.mock(eventType: .SignalUserInteraction)]), executeId: "1", cacheProperties: nil)
+        waitUntil { self.stub.callCount == 2 }
+
+        XCTAssertEqual(stub.callCount, 2)
+        // Exempt events are never recorded in the dedup set.
+        XCTAssertEqual(impl.sentEventHashes.count, 0)
+    }
+
+    func test_cacheOff_activationEvent_isAlwaysResent() {
+        sut.process(payload([.mock(eventType: .SignalActivation)]), executeId: "1", cacheProperties: nil)
+        waitUntil { self.stub.callCount == 1 }
+
+        sut.process(payload([.mock(eventType: .SignalActivation)]), executeId: "1", cacheProperties: nil)
+        waitUntil { self.stub.callCount == 2 }
+
+        XCTAssertEqual(stub.callCount, 2)
+        XCTAssertEqual(impl.sentEventHashes.count, 0)
+    }
+
+    // MARK: - (c) Cache-persistence only runs when cache is enabled
+
+    func test_cacheOff_doesNotPersistSentEventHashes() {
+        sut.process(payload([.mock(eventType: .SignalImpression)]),
+                    executeId: "1",
+                    cacheProperties: cacheProperties())
+        settle(1)
+
+        XCTAssertFalse(XCTestCase.experienceCacheExperiencesViewStateFileExists(
+            viewName: mockedViewName, attributes: mockedAttributes
+        ))
+    }
+
+    func test_cacheOn_persistsSentEventHashes() {
+        enableCache()
+
+        sut.process(payload([.mock(eventType: .SignalImpression)]),
+                    executeId: "1",
+                    cacheProperties: cacheProperties())
+        waitUntil { self.stub.callCount == 1 }
+        settle(1)
+
+        XCTAssertTrue(XCTestCase.experienceCacheExperiencesViewStateFileExists(
+            viewName: mockedViewName, attributes: mockedAttributes
+        ))
+    }
+}


### PR DESCRIPTION
## The gap

`PlatformEventProcessor.sendAndCacheEvents(...)` only deduplicated events **inside the cache-enabled branch**. The guard bailed to `sendEvents(nonDiagnosticEvents)` whenever the cache was off (feature flag `cacheEnabled` off, `cacheConfig.isCacheEnabled()` false, or no `cacheProperties`), so with the cache off **every event — including exact duplicates — was re-sent**. This inflates server-side event counts (e.g. duplicate impressions/conversions) whenever the same payload is processed twice. Dedup should apply regardless of cache state so duplicates aren't re-sent.

## Approach B (implemented)

1. **In-memory dedup now runs unconditionally**, not just when the cache is on. Order-preserving filter over `Rokt.shared.roktImplementation.sentEventHashes` (a `ThreadSafeSet`, reference type — shared across calls).
2. **Always-resend exemption.** A new `shouldDeduplicate(_:)` returns `false` for user-interaction events so they are never dropped. On iOS user interactions surface as both `.SignalUserInteraction` and `.SignalActivation` (both map to the `user_interaction` wire type in `TxnEventMapper`), so both are exempt — a user tapping the same control twice must reach the server both times.
3. **Cache-persistence stays conditional.** `ExperienceCacheManager.cacheExperiencesViewStateSentEventHashes(...)` still only runs when the cache is enabled + configured and `cacheProperties` is present. Only the dedup step became unconditional; the persistence step is unchanged in its gating.

The now-redundant `#available(iOS 13.0, *)` check was dropped — the package deployment target is iOS 15.

## Tests

Added `TestPlatformEventProcessorDedup` (mirrors existing `PlatformEventProcessor` / txn-wiring tests, injecting a stub txn HTTP client):
- (a) cache OFF: a duplicate event (same hash) is **not** re-sent.
- (b) exempt events (`.SignalUserInteraction`, `.SignalActivation`) **are** re-sent even when duplicated.
- (c) cache-persistence file is written only when the cache is enabled, not when it is off.

## Verification

- `xcodebuild build -scheme Rokt-Widget -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**.
- `xcodebuild test -only-testing:Rokt_WidgetTests/TestPlatformEventProcessorDedup` → **5 tests, 0 failures**.

## Ask for reviewers

Please confirm the previous cache-gating of dedup was **incidental** and not an intentional "when the cache is off, send everything" boundary. This change assumes dedup should always apply; if there was a deliberate reason to skip dedup on the non-cache path, flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
