### PR TITLE
fix: Persist session identity so offers requests reuse the session token

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -64,7 +64,7 @@ internal actor TxnSessionManager {
         persist(includeSessionId: true)
     }
 
-    // Token-only refresh for offers/events responses, keeping the session id.
+    // Token-only refresh for events responses (they carry no session id), keeping the session id.
     func update(sessionToken: TxnSessionToken) {
         token = sessionToken.token
         expiresAt = sessionToken.expiresAtDate
@@ -108,11 +108,12 @@ internal actor TxnSessionManager {
 
     private func persist(includeSessionId: Bool) {
         guard let store, let roktTagId else { return }
-        if includeSessionId {
-            store.setString(roktTagId, forKey: Keys.tagId)
-            if let sessionId {
-                store.setString(sessionId, forKey: Keys.sessionId)
-            }
+        // Always record the tag-id binding: restoreFromStore treats a missing/mismatched
+        // tag id as another account's data and clears the session, so a token persisted
+        // without it would never survive a reload.
+        store.setString(roktTagId, forKey: Keys.tagId)
+        if includeSessionId, let sessionId {
+            store.setString(sessionId, forKey: Keys.sessionId)
         }
         if let token {
             store.setString(token, forKey: Keys.token)

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -166,8 +166,8 @@ internal struct OffersService {
                 }
 
                 let decoded = try JSONDecoder().decode(SelectResponse.self, from: data)
-                // Roll the refreshed token forward for the next offers/events call.
-                await sessionManager.update(sessionToken: decoded.sessionToken)
+                // Roll the session id and refreshed token forward for the next offers/events call.
+                await sessionManager.update(sessionId: decoded.sessionId, sessionToken: decoded.sessionToken)
                 // Capture the echoed events so the next placement can forward them back.
                 if let eventData = decoded.eventData {
                     captureEvents(SelectEventMapper.untriggeredEvents(from: eventData))

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -170,6 +170,21 @@ final class TestTxnSessionManager: XCTestCase {
         XCTAssertTrue(isExpired)
     }
 
+    func test_persistence_tokenOnlyRefreshAloneSurvivesReload() async {
+        // Arrange: the first persisted state comes from a token-only refresh
+        // (no prior full update wrote the tag-id binding).
+        let store = InMemoryStore()
+        let manager = persistentManager(tagId: "tag-1", store: store)
+
+        // Act
+        await manager.update(sessionToken: token("fresh", expiresInSeconds: 1800))
+        let restored = persistentManager(tagId: "tag-1", store: store)
+
+        // Assert
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(header, "Bearer fresh")
+    }
+
     func test_persistence_tokenOnlyRefreshDoesNotLoseSessionIdAcrossLoads() async {
         let store = InMemoryStore()
         let manager = persistentManager(tagId: "tag-1", store: store)

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -134,9 +134,11 @@ final class TestOffersService: XCTestCase {
         })
 
         await fulfillment(of: [completed], timeout: 5)
-        // The refreshed token is rolled forward for the next call.
+        // The session id and refreshed token are rolled forward for the next call.
         let header = await sessionManager.authorizationHeader
+        let sessionId = await sessionManager.currentSessionId
         XCTAssertEqual(header, "Bearer rolled-token")
+        XCTAssertEqual(sessionId, "session-1")
     }
 
     func test_getExperienceData_retriesRetryableStatusThenSucceeds() {


### PR DESCRIPTION
## Background

On the transactions path, the session token returned by `POST /v2/sessions/offers` was never reused: every subsequent offers request went out without an `Authorization` header, so the server minted a brand-new session on each call instead of continuing the existing one. Verified against production with a proxy capture: two consecutive offer selections in one app run produced two different `session_id` values, and neither the second offers request nor any events request carried a Bearer token.

Root cause is in session persistence:

- `TxnSessionManager.persist(includeSessionId: false)` (the token-only refresh path used by the offers and events services) never wrote the `ROKT_TXN_TAG_ID` binding. Since a fresh `TxnSessionManager` is created per request and `restoreFromStore()` clears everything when the stored tag id does not match, the persisted token was wiped on every restore.
- `OffersService` used the token-only update, so the `session_id` from the offers response was never stored, and the full `update(sessionId:sessionToken:)` had no runtime callers.

## What Has Changed

- `TxnSessionManager.persist` now always writes the tag-id binding, so a token-only refresh survives a reload.
- `OffersService` now rolls the offers response forward via `update(sessionId:sessionToken:)`, persisting the session id together with the refreshed token. (`TxnEventService` keeps the token-only path — events responses carry no session id.)

## How Has This Been Tested

- New regression test `TestTxnSessionManager.test_persistence_tokenOnlyRefreshAloneSurvivesReload` (fails without the fix) and a session-id assertion in `TestOffersService.test_getExperienceData_adaptsResponseAndRollsTokenForward`.
- Affected unit suites pass locally: `TestTxnSessionManager`, `TestOffersService`, `TestTxnEventService`, `TestOffersExecuteWiring`, `TestTxnEventWiring`.
- `trunk check` clean; example app builds.
- Manual verification against production with a proxy: after the fix, the second offers request carries `Authorization: Bearer <latest token>` and both offers responses return the same `session_id`, with the token rotating on each response.

## Notes

No public API changes; behaviour change is limited to session persistence on the transactions path.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.