### PR TITLE
fix(txn): render shoppable catalog_items (fix blank instant-purchase overlay)

### DIFF
--- a/Sources/Rokt_Widget/Models/RenderExperience.swift
+++ b/Sources/Rokt_Widget/Models/RenderExperience.swift
@@ -111,12 +111,75 @@ internal struct RenderLayoutVariant: Encodable {
 internal struct RenderOffer: Encodable {
     let campaignId: String?
     let creative: RenderCreative
+    let catalogItems: [RenderCatalogItem]?
 
     /// Nil when the slot carries no creative — an offer is only renderable with one.
     init?(_ offer: SelectOffer?) {
         guard let offer, let creative = offer.creative else { return nil }
         campaignId = offer.campaignId
         self.creative = RenderCreative(creative)
+        // Shoppable/instant-purchase catalog content. Without this the overlay
+        // renders empty: the renderer's catalog components read `offer.catalogItems`,
+        // so an unmapped offer yields a blank shoppable ad.
+        catalogItems = offer.catalogItems?.map(RenderCatalogItem.init)
+    }
+}
+
+/// A shoppable catalog item, re-homed from the offers response's snake_case
+/// ``SelectCatalogItem`` to the renderer's camelCase `CatalogItem` contract.
+/// The renderer decodes with a plain `JSONDecoder` (no key strategy), so keys
+/// must match its property names verbatim. Fields the renderer requires but the
+/// response can omit are defaulted so the item always decodes; `positiveResponseText`
+/// / `negativeResponseText` are required by the renderer's model yet read nowhere,
+/// so they default to empty.
+internal struct RenderCatalogItem: Encodable {
+    let catalogItemId: String
+    let cartItemId: String
+    let instanceGuid: String
+    let title: String
+    let description: String
+    let price: Double?
+    let priceFormatted: String?
+    let originalPrice: Double?
+    let originalPriceFormatted: String?
+    let currency: String
+    let signalType: String?
+    let url: String?
+    let urlBehavior: String?
+    let minItemCount: Int?
+    let maxItemCount: Int?
+    let preSelectedQuantity: Int?
+    let providerData: String
+    let linkedProductId: String?
+    let positiveResponseText: String
+    let negativeResponseText: String
+    let images: [String: RenderImage]
+    let token: String
+
+    init(_ item: SelectCatalogItem) {
+        catalogItemId = item.catalogItemId ?? ""
+        cartItemId = item.cartItemId ?? ""
+        instanceGuid = item.instanceGuid ?? ""
+        title = item.title ?? ""
+        description = item.description ?? ""
+        price = item.price
+        priceFormatted = item.priceFormatted
+        originalPrice = item.originalPrice
+        originalPriceFormatted = item.originalPriceFormatted
+        currency = item.currency ?? ""
+        signalType = item.signalType
+        url = item.url
+        urlBehavior = item.urlBehavior
+        minItemCount = item.minItemCount
+        maxItemCount = item.maxItemCount
+        preSelectedQuantity = item.preSelectedQuantity
+        providerData = item.providerData ?? ""
+        linkedProductId = item.linkedProductId
+        // Required by the renderer's CatalogItem but consumed nowhere; empty is safe.
+        positiveResponseText = ""
+        negativeResponseText = ""
+        images = item.images?.mapValues(RenderImage.init) ?? [:]
+        token = item.token ?? ""
     }
 }
 

--- a/Sources/Rokt_Widget/Models/SelectResponse.swift
+++ b/Sources/Rokt_Widget/Models/SelectResponse.swift
@@ -230,8 +230,8 @@ internal struct SelectLayoutVariant: Decodable, Equatable {
 internal struct SelectOffer: Decodable, Equatable {
     let campaignId: String?
     let creative: SelectCreative?
-    // Shoppable-ad catalog items; surfacing them to the render models is
-    // deferred to the mapper in a follow-up.
+    // Shoppable-ad catalog items, mapped to the renderer via `RenderCatalogItem`
+    // (see RenderExperience) so instant-purchase layouts render their content.
     let catalogItems: [SelectCatalogItem]?
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/Rokt_WidgetTests/Resource/offers_render_shoppable.json
+++ b/Tests/Rokt_WidgetTests/Resource/offers_render_shoppable.json
@@ -1,0 +1,79 @@
+{
+  "session_id": "render-session",
+  "session_token": {
+    "token": "render-token",
+    "expires_at": 32503680000000
+  },
+  "page_instance_guid": "render-pig",
+  "page_context": {
+    "page_instance_guid": "render-pig",
+    "page_id": "checkout",
+    "token": "render-page-token"
+  },
+  "plugins": [
+    {
+      "plugin": {
+        "id": "render-plugin",
+        "name": "dcui",
+        "target_element_selector": "#rokt",
+        "config": {
+          "instance_guid": "render-plugin-ig",
+          "token": "render-plugin-token",
+          "outer_layout_schema": "{\"breakpoints\":{\"Landscape\":500,\"Portrait\":560},\"layout\":{\"type\":\"Column\",\"node\":{\"styles\":{\"elements\":{\"own\":[{\"default\":{\"border\":{\"borderRadius\":0},\"background\":{\"backgroundColor\":{\"light\":\"#ECEEE9\",\"dark\":\"#ECEEE9\"}}}}]}},\"children\":[{\"type\":\"Column\",\"node\":{\"styles\":{\"elements\":{\"own\":[{\"default\":{\"border\":{\"borderRadius\":0},\"spacing\":{\"margin\":\"10 10 10 10\"},\"background\":{\"backgroundColor\":{\"light\":\"#FFFFFFFF\",\"dark\":\"#FFFFFFFF\"}}}}]}},\"children\":[{\"type\":\"OneByOneDistribution\",\"node\":{\"transition\":{\"type\":\"FadeInOut\",\"settings\":{\"duration\":10}}}}]}}]}}}",
+          "slots": [
+            {
+              "instance_guid": "render-slot",
+              "token": "render-slot-token",
+              "layout_variant": {
+                "layout_variant_id": "render-lv",
+                "module_name": "",
+                "layout_variant_schema": "{\"type\":\"Column\",\"node\":{\"styles\":{\"elements\":{\"own\":[{\"default\":{\"spacing\":{\"margin\":\"18 8 0 8\"}}}]}},\"children\":[{\"type\":\"RichText\",\"node\":{\"value\":\"%^DATA.creativeCopy.creative.title^%\",\"styles\":{\"elements\":{\"own\":[{\"default\":{\"spacing\":{\"margin\":\"0 0 0 0\"},\"text\":{\"fontSize\":16,\"fontWeight\":\"600\",\"lineHeight\":14,\"textColor\":{\"light\":\"#000000\",\"dark\":\"#00ff00\"}}}}]}}}}]}}"
+              },
+              "offer": {
+                "campaign_id": "camp-shop-1",
+                "creative": {
+                  "referral_creative_id": "rc-1",
+                  "instance_guid": "cr-ig-1",
+                  "token": "creative-token-1",
+                  "copy": { "creative.title": "Shop the kit" },
+                  "response_options_map": {}
+                },
+                "catalog_items": [
+                  {
+                    "catalog_item_id": "cat-jm-1",
+                    "instance_guid": "cat-ig-1",
+                    "cart_item_id": "cart-1",
+                    "title": "Jason Markk Quick Clean Kit",
+                    "description": "Quick clean kit for sneakers",
+                    "price": 18.0,
+                    "original_price": 24.0,
+                    "price_formatted": "$18",
+                    "original_price_formatted": "$24",
+                    "currency": "USD",
+                    "url": "https://example.com/jm",
+                    "url_behavior": "internal",
+                    "signal_type": "instant_purchase",
+                    "min_item_count": 1,
+                    "max_item_count": 5,
+                    "pre_selected_quantity": 1,
+                    "provider_data": "{\"sku\":\"JM-QCK\"}",
+                    "linked_product_id": "prod-jm",
+                    "images": {
+                      "hero": {
+                        "light": "https://img.example.com/jm-light.png",
+                        "dark": "https://img.example.com/jm-dark.png",
+                        "alt": "Jason Markk Quick Clean Kit",
+                        "title": "Kit"
+                      }
+                    },
+                    "token": "catalog-token-jm"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Rokt_WidgetTests/Shared/Model/TestOffersRenderCompat.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Model/TestOffersRenderCompat.swift
@@ -24,4 +24,59 @@ final class TestOffersRenderCompat: XCTestCase {
         XCTAssertEqual(parsed.sessionId, "render-session")
         XCTAssertNotNil(parsed.pageModel, "adapter output produced no renderable page model")
     }
+
+    /// Guards BUG-011: a shoppable offer's `catalog_items` must survive the adapter
+    /// (with the renderer's camelCase keys) and satisfy the renderer's `CatalogItem`
+    /// decode contract. Before the `RenderCatalogItem` mapping the items were dropped,
+    /// so the catalog components rendered nothing and the overlay was blank.
+    func test_shoppableOfferCatalogItemsSurviveAdapterAndParse() throws {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: "offers_render_shoppable", withExtension: "json"),
+            "offers_render_shoppable.json missing from the test bundle"
+        )
+        let response = try JSONDecoder().decode(SelectResponse.self, from: Data(contentsOf: url))
+
+        let experienceString = try SelectExperienceAdapter.experienceJSONString(from: response)
+
+        // 1. The adapter forwards catalog_items under the renderer's camelCase keys.
+        let probe = try JSONDecoder().decode(CatalogProbe.self, from: Data(experienceString.utf8))
+        let items = try XCTUnwrap(
+            probe.plugins?.first?.plugin.config.slots.first?.offer?.catalogItems,
+            "catalog items were dropped by the adapter"
+        )
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.catalogItemId, "cat-jm-1")
+        XCTAssertEqual(items.first?.cartItemId, "cart-1")
+        XCTAssertEqual(items.first?.title, "Jason Markk Quick Clean Kit")
+        XCTAssertEqual(items.first?.priceFormatted, "$18")
+        XCTAssertNotNil(items.first?.images["hero"], "catalog item image was not carried through")
+
+        // 2. The renderer's decode contract accepts it — a missing required CatalogItem
+        //    field would throw in OfferModel decode and yield a nil page model.
+        let parsed = try XCTUnwrap(
+            RoktUX.parseExperience(experienceString),
+            "adapter output did not decode as a renderer experience"
+        )
+        XCTAssertNotNil(parsed.pageModel, "shoppable adapter output produced no renderable page model")
+    }
+}
+
+/// Decodes only the path to the catalog items in the adapter's experience JSON,
+/// asserting the camelCase keys the renderer expects (`RoktDecoder` uses a plain
+/// `JSONDecoder` with no key-decoding strategy, so keys must match verbatim).
+private struct CatalogProbe: Decodable {
+    let plugins: [PluginBox]?
+    struct PluginBox: Decodable { let plugin: Plugin }
+    struct Plugin: Decodable { let config: Config }
+    struct Config: Decodable { let slots: [Slot] }
+    struct Slot: Decodable { let offer: Offer? }
+    struct Offer: Decodable { let catalogItems: [Item]? }
+    struct Item: Decodable {
+        let catalogItemId: String
+        let cartItemId: String
+        let title: String
+        let priceFormatted: String?
+        let images: [String: Image]
+    }
+    struct Image: Decodable { let light: String?; let dark: String? }
 }


### PR DESCRIPTION
## What
Fixes **BUG-019**: shoppable / instant-purchase offers rendered a **blank overlay** despite the backend returning a complete catalog layout.

## Root cause (SDK-side)
The offers→experience adapter (`RenderExperience.swift`) mapped only `campaignId` + `creative` in `RenderOffer` and **never forwarded `catalog_items`** — they are parsed into `SelectOffer.catalogItems` but were "deferred to the mapper in a follow-up". The renderer's `OfferModel.catalogItems` therefore decoded `nil`, so the outer Overlay presented but the `Catalog*` components (`CatalogCombinedCollection`, `CatalogImageGallery`, `CatalogDropdown`, `CatalogDevicePayButton`) had no data → blank. The UX helper (0.13.0) already ships the full catalog render pipeline; the gap was solely the SDK adapter.

## Change
- `RenderOffer` now maps `catalog_items` → a new `RenderCatalogItem` mirroring the renderer's camelCase `CatalogItem` contract (the renderer decodes with a plain `JSONDecoder`, no key strategy). Reuses the existing `RenderImage`; defaults the two renderer-required-but-unread fields (`positiveResponseText`/`negativeResponseText`) to empty.
- Updated the stale "deferred to a follow-up" comment in `SelectResponse.swift`.

## Tests
- New `TestOffersRenderCompat.test_shoppableOfferCatalogItemsSurviveAdapterAndParse` + `offers_render_shoppable.json` fixture — a round-trip that (1) proves the items survive the adapter with the renderer's camelCase keys, and (2) parses through the real UX-helper decoder into a non-nil page model (a missing required `CatalogItem` field would throw).
- Regression: `TestSelectExperienceAdapter`, `TestSelectSerialization`, `TestOffersRenderCompat`, `TestOffersExecuteWiring` all green.

## Verification
- **Unit**: round-trip guard green.
- **Live E2E**: the shoppable overlay now renders its catalog — image gallery + pager dots, description, Billing & Shipping — vs the prior blank overlay.

## Risk
Low / additive: `RenderExperience` structs are encode-only; this adds one optional field + one struct. Non-shoppable offers are unchanged (nil `catalogItems` is omitted by `encodeIfPresent`). Device-pay (Apple Pay) still needs a simulator entitlement it lacks — orthogonal to this render fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
