### PR TITLE
chore(txn): remove stale v1-migration comments

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 internal actor TxnSessionManager {
-    // Persistence keys for the v2 path, separate from the legacy SessionManager's `rokt.*` keys.
+    // Persistence keys namespaced (ROKT_TXN_*) to avoid collision with SessionManager's `rokt.*` keys.
     private enum Keys {
         static let tagId = "ROKT_TXN_TAG_ID"
         static let sessionId = "ROKT_TXN_SESSION_ID"

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionStore.swift
@@ -8,7 +8,7 @@ internal protocol TxnSessionStore: AnyObject {
 }
 
 // Plain UserDefaults rather than the Keychain: the token is short-lived and
-// sandbox-protected, matching the legacy SessionManager and the other SDK platforms.
+// sandbox-protected, matching the other SDK platforms.
 internal final class UserDefaultsTxnSessionStore: TxnSessionStore {
     private let defaults: UserDefaults
 

--- a/Sources/Rokt_Widget/Models/TxnInitResponse+InitRespose.swift
+++ b/Sources/Rokt_Widget/Models/TxnInitResponse+InitRespose.swift
@@ -3,9 +3,9 @@ import Foundation
 extension TxnInitResponse {
     private static let clientTimeoutFlag = "client-timeout-ms"
 
-    // Adapts the v2 response into the legacy InitRespose so downstream init is unchanged.
+    // Adapts the response into `InitRespose` so downstream init is unchanged.
     // timeout 0 lets the caller keep its existing default; delay and clientSessionTimeout
-    // are intentionally dropped (v2 session lifetime is governed by the JWT expiry).
+    // are intentionally dropped (session lifetime is governed by the JWT expiry).
     func toInitRespose(featureFlags: InitFeatureFlags) -> InitRespose {
         InitRespose(
             timeout: self.featureFlags.int(forKey: Self.clientTimeoutFlag).map(Double.init) ?? 0,

--- a/Sources/Rokt_Widget/Models/UntriggeredRealTimeEvent.swift
+++ b/Sources/Rokt_Widget/Models/UntriggeredRealTimeEvent.swift
@@ -40,8 +40,8 @@ private struct RawEvent: Decodable, RealTimeEventSignal {
 }
 
 // A decoded real-time-event signal: the minimal shape (event_type + payload) shared by the
-// v1 (camelCase RawEvent) and v2 (snake_case SelectRealTimeEvent) decode types. They stay
-// separate Decodables for the casing difference, but flatten/validate through one path.
+// camelCase (RawEvent) and snake_case (SelectRealTimeEvent) decode types. They stay separate
+// Decodables for the casing difference, but flatten/validate through one path.
 internal protocol RealTimeEventSignal {
     var eventType: String? { get }
     var payload: String? { get }
@@ -49,7 +49,8 @@ internal protocol RealTimeEventSignal {
 
 extension UntriggeredRealTimeEvent {
     /// Flatten a decoded event_data envelope (parentGuid -> signalKey -> signal) into untriggered
-    /// events, dropping invalid entries. Single home for the validity rule so v1/v2 can't drift.
+    /// events, dropping invalid entries. Single home for the validity rule so the two decode
+    /// types can't drift.
     static func flattenedValid<Signal: RealTimeEventSignal>(
         from eventData: [String: [String: Signal]?]
     ) -> [UntriggeredRealTimeEvent] {

--- a/Sources/Rokt_Widget/Networking/MockTxnInitHTTPClient.swift
+++ b/Sources/Rokt_Widget/Networking/MockTxnInitHTTPClient.swift
@@ -7,7 +7,7 @@ import Foundation
 internal final class MockTxnInitHTTPClient: HTTPClientAdapter {
     private static let fixtureName = "txn_init"
 
-    // Guaranteed success response, mirroring the hard-coded init the legacy mock path returned.
+    // Guaranteed success response so Mock init always succeeds.
     private static let defaultResponse = Data(
         """
         {

--- a/Sources/Rokt_Widget/Networking/OffersClient.swift
+++ b/Sources/Rokt_Widget/Networking/OffersClient.swift
@@ -37,10 +37,10 @@ internal struct OffersClient {
         var headers = TxnRequestHeaders.common(accountId: accountId, authToken: authToken)
         headers["x-request-id"] = input.requestId
         headers["rokt-page-instance-guid"] = pageInstanceGuid
-        // Advertise the DCUI layout schema version this client can render, matching the v2 init
-        // (TxnInitClient.swift) and v1 (RoktNetworkAPI.swift) requests. Without it the gateway
-        // serves a legacy layout schema the pinned DcuiSchema decoder cannot parse, so the
-        // placement fails to render (see the layout_schema_version negotiation contract).
+        // Advertise the DCUI layout schema version this client can render, matching the init
+        // request (TxnInitClient.swift). Without it the gateway serves a layout schema the
+        // pinned DcuiSchema decoder cannot parse, so the placement fails to render (see the
+        // layout_schema_version negotiation contract).
         headers["rokt-layout-schema-version"] = layoutSchemaVersion
         // Device headers (os, model, locale, app version) and the load-bearing
         // rokt-package-name ride in via NetworkingHelper.txnDeviceHeaders — the

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -27,8 +27,8 @@ internal struct OffersService {
     let makePageInstanceGuid: () -> String
     let completionQueue: DispatchQueue
     // Real-time event store seams (injected for tests). `captureEvents` stores the response's
-    // events for the next call; it only adds (no global clear) to mirror the v1 capture and
-    // avoid wiping triggered events the events/v1 paths share in RealTimeEventManager.shared.
+    // events for the next call; it only adds (no global clear) to avoid wiping triggered
+    // events shared in RealTimeEventManager.shared.
     let triggeredEvents: () -> [TriggeredRealTimeEvent]
     let captureEvents: ([UntriggeredRealTimeEvent]) -> Void
 
@@ -131,10 +131,10 @@ internal struct OffersService {
         let authToken = await sessionManager.authorizationHeader
         let client = makeOffersClient(baseURL: baseURL, pageInstanceGuid: pageInstanceGuid, authToken: authToken)
         // Forward events triggered during the previous placement; read once, before retries,
-        // and only with a live session to attribute them to (matching Android). As on the v1
-        // path, triggered events are not cleared after forwarding — they ride subsequent
-        // requests until session invalidation; re-send is expected (the "only adds, no clear"
-        // note elsewhere is about the untriggered response-capture, not this read).
+        // and only with a live session to attribute them to (matching Android). Triggered
+        // events are not cleared after forwarding — they ride subsequent requests until
+        // session invalidation; re-send is expected (the "only adds, no clear" note elsewhere
+        // is about the untriggered response-capture, not this read).
         let forwardedEvents = authToken != nil ? SelectEventMapper.requestEvents(from: triggeredEvents()) : []
         let input = makeOffersInput(
             requestId: requestId,

--- a/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/SelectEventMapper.swift
@@ -21,9 +21,8 @@ internal enum SelectEventMapper {
     }
 
     /// Response `event_data` → untriggered events for the store, consulted when the next
-    /// placement fires. Shares the flatten/validate path with the v1 ``UntriggeredEventsContainer``
-    /// (`UntriggeredRealTimeEvent.flattenedValid`); the two keep separate Decodables only because
-    /// v1 is camelCase `eventType` and v2 is snake_case `event_type`.
+    /// placement fires. Uses the shared flatten/validate path
+    /// (`UntriggeredRealTimeEvent.flattenedValid`).
     static func untriggeredEvents(from eventData: [String: SelectEventDataEntry]) -> [UntriggeredRealTimeEvent] {
         UntriggeredRealTimeEvent.flattenedValid(from: eventData.mapValues { $0.events })
     }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -51,14 +51,9 @@ class RoktInternalImplementation {
 
     // MARK: - v2 Transactions init (isolated)
 
-    // v2 is the only active init path; v1 is retained but inactive (flag keeps v1 code reachable for periphery)
-    // swiftlint:disable:next todo
-    // TODO: Remove once v2 is fully rolled out.
     private static let useTxnInit = true
-    // Offers source: v2 by default; v1 is retained as the alternative until the
-    // v1/v2 selection is finalised.
     private static let useV2Offers = true
-    // Layout schema version sent to the v2 init endpoint, matching the legacy header.
+    // Layout schema version sent to the v2 init endpoint.
     private static var txnLayoutSchemaVersion: String {
         RoktUX.integrationInfo.integration.layoutSchemaVersion
             .split(separator: ".").prefix(2).joined(separator: ".")
@@ -68,9 +63,6 @@ class RoktInternalImplementation {
     // Test-only override for the offers service factory; nil uses the real builder.
     var makeOffersServiceOverride: ((String) -> OffersService)?
 
-    // v2 events is the only active events path; v1 is retained but inactive (flag keeps v1 code reachable for periphery)
-    // swiftlint:disable:next todo
-    // TODO: Remove once v2 is fully rolled out.
     private static let useTxnEvents = true
     var isTxnEventsEnabled: Bool { Self.useTxnEvents }
     // Test-only override for the events service factory; nil uses the real builder.
@@ -879,10 +871,9 @@ class RoktInternalImplementation {
         performInit(roktTagId: roktTagId, initStartTime: initStartTime)
     }
 
-    // The transactions path is the only active one; the legacy `else` is retained but inactive until it is removed.
     private func performInit(roktTagId: String, initStartTime: Date) {
         guard Self.useTxnInit else {
-            // Legacy path: fonts gate render/init completion, so observe font load state.
+            // Fonts gate render/init completion, so observe font load state.
             setupFontObservers()
             RoktAPIHelper.initialize(
                 roktTagId: roktTagId,
@@ -1214,8 +1205,8 @@ class RoktInternalImplementation {
                         }
 
                         if Self.useV2Offers {
-                            // pageInit timing travels in attributes; record it here for parity
-                            // with the v1 path, since the offers service doesn't own timing extraction.
+                            // pageInit timing travels in attributes; record it here since the
+                            // offers service doesn't own timing extraction.
                             if let pageInitAttr = RoktAPIHelper.getPageInitData(attributes: attributes),
                                let validPageInitTime = self.processedTimingsRequests?.getValidPageInitTime(
                                    selectionId: selectionId,


### PR DESCRIPTION
## What

Removes leftover v1→v2 migration commentary that accumulated in the transactions SDK code from earlier rollout PRs. These comments were added to clarify v1/v2 coexistence during the migration and are now clutter.

**Comment-only change — no logic touched.**

### Removed (migration-state cruft)
- `useTxnInit` / `useV2Offers` / `useTxnEvents` "v1 is retained but inactive" notes and the associated `swiftlint:disable:next todo` + `// TODO: Remove once v2 is fully rolled out.` trackers in `RoktInternalImplementation.swift`.
- The `performInit` "legacy `else` is retained but inactive until it is removed" note.

### Reworded (v1/legacy comparison framing stripped, rationale kept)
- `OffersClient` layout-schema header rationale
- `OffersService` event-capture / forwarding notes
- `SelectEventMapper` + `UntriggeredRealTimeEvent` (camelCase/snake_case, "v1/v2 can't drift")
- `TxnSessionManager`, `TxnSessionStore`, `TxnInitResponse+InitRespose`, `MockTxnInitHTTPClient` "legacy" references
- `RoktInternalImplementation` pageInit "parity with the v1 path" note

### Deliberately left untouched
- Real API endpoint paths (`/v1/cart/purchase`, `v1/experiences`, `v1/timings/events`) and the v1 `RoktNetworkAPI`.
- Test helpers whose `v1` references match live identifiers (`makeOffersData(fromV1Experience:)`, `forV1Fixture:`) and describe real fixture-reshaping behavior.
- Comments where `v2` merely names the current architecture, and periphery `:ignore` directives.

## Why
Reduces noise and keeps comments accurate as v1 is phased out. Lower maintenance cost, clearer code for the team.

## Risk
Minimal — documentation-only, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)