### PR TITLE
feat(txn): emit signal_gated_response as its own wire type

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -62,7 +62,7 @@ internal enum TxnEventMapper {
         case .SignalLoadStart: return MappedType("load_start")
         case .SignalLoadComplete: return MappedType("load_complete")
         case .SignalResponse: return MappedType("signal_response")
-        case .SignalGatedResponse: return MappedType("signal_response", ["gated": "true"])
+        case .SignalGatedResponse: return MappedType("signal_gated_response")
         case .SignalDismissal: return MappedType("dismissal")
         case .SignalActivation: return MappedType("user_interaction", ["interactionType": "activation"])
         case .SignalUserInteraction: return MappedType("user_interaction")

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
@@ -48,11 +48,11 @@ final class TestTxnEventMapper: XCTestCase {
         }
     }
 
-    func test_gatedResponse_mapsToSignalResponseWithMarker() {
+    func test_gatedResponse_mapsToOwnWireType() {
         let event = TxnEventMapper.event(from: makeRequest(eventType: .SignalGatedResponse))
 
-        XCTAssertEqual(event?.eventType, "signal_response")
-        XCTAssertEqual(event?.data?["gated"], .string("true"))
+        XCTAssertEqual(event?.eventType, "signal_gated_response")
+        XCTAssertNil(event?.data?["gated"])
     }
 
     func test_activation_mapsToUserInteractionWithType() {


### PR DESCRIPTION
## Background

Transactions is reviving `signal_gated_response` as its own v2 wire type. Previously all platforms (Web/Android/iOS) mapped `SignalGatedResponse` → `signal_response` with a `gated: true` marker. The contract is moving to a distinct wire type per response kind:

- `SignalResponse` → `signal_response` (unchanged)
- `SignalGatedResponse` → `signal_gated_response` (was `signal_response` + `gated: true`)

This aligns the iOS mSDK ahead of the Transactions + OpenAPI landing. Android is being handled separately.

## What changed

- `TxnEventMapper`: `SignalGatedResponse` now maps to the `signal_gated_response` wire type and no longer sets the `gated: true` marker.
- Updated `TestTxnEventMapper` to assert the new wire type and the absence of the `gated` marker.

## Risk / rollout

- Behavioral wire change (marked `!`). Gated-response signals begin emitting `signal_gated_response` immediately once shipped.
- **Sequencing:** the server must accept `signal_gated_response` before this ships, otherwise gated-response signals could be dropped during the gap. Confirm the backend contract is live before merging/releasing.

## Checklist

- [x] Unit tests updated
- [ ] Verified backend accepts `signal_gated_response` prior to release

🤖 Generated with [Claude Code](https://claude.com/claude-code)