### PR TITLE
fix(txn): retry 408/429 and honor Retry-After on events endpoint

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -75,7 +75,9 @@ internal struct TxnEventService {
                 let statusCode = response?.statusCode ?? 0
 
                 if isRetryable(statusCode: statusCode), attempt < maxRetries {
-                    try await sleep(backoffDelay(attempt: attempt))
+                    // A rate-limited/overloaded gateway (429/503) can pace us via `Retry-After`;
+                    // honor it when present, otherwise fall back to exponential backoff.
+                    try await sleep(retryAfterDelay(from: response) ?? backoffDelay(attempt: attempt))
                     attempt += 1
                     continue
                 }
@@ -113,8 +115,20 @@ internal struct TxnEventService {
         }
     }
 
+    // 408 (request timeout) and 429 (too many requests) are transient and safe to replay,
+    // matching the web + Android recoverable-code set.
     private func isRetryable(statusCode: Int) -> Bool {
-        [500, 502, 503, 504].contains(statusCode)
+        [408, 429, 500, 502, 503, 504].contains(statusCode)
+    }
+
+    // Reads the `Retry-After` header in delta-seconds form (fractional allowed, mirroring web).
+    // The HTTP-date form is not honored; callers fall back to exponential backoff.
+    private func retryAfterDelay(from response: HTTPURLResponse?) -> TimeInterval? {
+        guard let raw = response?.value(forHTTPHeaderField: "Retry-After")?
+            .trimmingCharacters(in: .whitespaces),
+              let seconds = Double(raw), seconds >= 0
+        else { return nil }
+        return seconds
     }
 
     // Transient transport failures only; a hard-offline device fails fast.

--- a/Tests/Rokt_WidgetTests/Shared/Networking/MockTxnEventsHTTPClient.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/MockTxnEventsHTTPClient.swift
@@ -5,6 +5,7 @@ final class MockTxnEventsHTTPClient: HTTPClientAdapter {
     enum Response {
         case success(status: Int, data: Data)
         case status(Int)
+        case statusWithHeaders(Int, [String: String])
         case transport(Error)
     }
 
@@ -48,6 +49,13 @@ final class MockTxnEventsHTTPClient: HTTPClientAdapter {
         case .status(let code):
             result = RoktHTTPRequestResult(
                 httpURLResponse: HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil),
+                responseData: nil,
+                responseError: nil,
+                jsonSerialisedResponseData: .success(NSNull())
+            )
+        case .statusWithHeaders(let code, let headers):
+            result = RoktHTTPRequestResult(
+                httpURLResponse: HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: headers),
                 responseData: nil,
                 responseError: nil,
                 jsonSerialisedResponseData: .success(NSNull())

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -24,7 +24,8 @@ final class TestTxnEventService: XCTestCase {
     private func makeService(
         environment: Environment = .Prod,
         deviceHeaders: [String: String] = ["rokt-os-type": "iOS"],
-        maxRetries: Int = 3
+        maxRetries: Int = 3,
+        sleep: @escaping (TimeInterval) async throws -> Void = { _ in }
     ) -> TxnEventService {
         TxnEventService(
             environment: environment,
@@ -35,7 +36,7 @@ final class TestTxnEventService: XCTestCase {
             deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
             baseBackoff: 0,
-            sleep: { _ in }
+            sleep: sleep
         )
     }
 
@@ -107,6 +108,48 @@ final class TestTxnEventService: XCTestCase {
         try await makeService().send(events: sampleEvents())
 
         XCTAssertEqual(httpClient.callCount, 3)
+    }
+
+    func test_send_retriesOn429_thenSucceeds() async throws {
+        httpClient.results = [.status(429), .success(status: 202, data: rotatedResponse())]
+
+        try await makeService().send(events: sampleEvents())
+
+        XCTAssertEqual(httpClient.callCount, 2)
+    }
+
+    func test_send_retriesOn408_thenSucceeds() async throws {
+        httpClient.results = [.status(408), .success(status: 202, data: rotatedResponse())]
+
+        try await makeService().send(events: sampleEvents())
+
+        XCTAssertEqual(httpClient.callCount, 2)
+    }
+
+    func test_send_honorsRetryAfterHeader_overExponentialBackoff() async throws {
+        var recordedDelays: [TimeInterval] = []
+        let service = makeService(sleep: { recordedDelays.append($0) })
+        httpClient.results = [.statusWithHeaders(429, ["Retry-After": "2"]),
+                              .success(status: 202, data: rotatedResponse())]
+
+        try await service.send(events: sampleEvents())
+
+        XCTAssertEqual(httpClient.callCount, 2)
+        XCTAssertEqual(recordedDelays, [2.0])
+    }
+
+    func test_send_retryAfterMalformed_fallsBackToBackoff() async throws {
+        var recordedDelays: [TimeInterval] = []
+        let service = makeService(sleep: { recordedDelays.append($0) })
+        // Non-numeric (HTTP-date) Retry-After is not honored; backoff is used instead.
+        // baseBackoff is 0 in tests, so the fallback delay is 0 rather than the header value.
+        httpClient.results = [.statusWithHeaders(503, ["Retry-After": "Wed, 21 Oct 2025 07:28:00 GMT"]),
+                              .success(status: 202, data: rotatedResponse())]
+
+        try await service.send(events: sampleEvents())
+
+        XCTAssertEqual(httpClient.callCount, 2)
+        XCTAssertEqual(recordedDelays, [0.0])
     }
 
     func test_send_retriesOnTimeout_thenSucceeds() async throws {


### PR DESCRIPTION
## What

Aligns the iOS transactions **events** endpoint retry policy with WSDK v2 and sdk-android.

- Add **408** and **429** to the retryable status set (was `{500,502,503,504}` only).
- Honor a delta-seconds **`Retry-After`** header when present (fractional allowed); the HTTP-date form is not parsed and falls back to exponential backoff.

## Why

Under gateway rate-limiting (429) or a request timeout (408) the SDK previously **dropped the batch** instead of backing off and replaying. Web (`RECOVERABLE_STATUS_CODES = {408,429,500,502,503,504}` + `retry-after` via `RateLimitedError`) and Android both treat these as recoverable. This is part of a cross-platform (web/Android/iOS) transactions parity pass.

## Scope

This PR is **retry-eligibility + Retry-After only**. The backoff *curve/jitter* alignment (web `1000·4^(n-1)`, ≤25% jitter) is a separate follow-up PR to keep diffs focused.

## Tests

`TestTxnEventService` (all 18 pass), incl. new:
- `test_send_retriesOn429_thenSucceeds`
- `test_send_retriesOn408_thenSucceeds`
- `test_send_honorsRetryAfterHeader_overExponentialBackoff`
- `test_send_retryAfterMalformed_fallsBackToBackoff`

## E2E validation

Verified end-to-end on a real build (Example app, `rokt-Example` scheme) running on an **iPhone 16 Pro (iOS 18.5) simulator against live Prod** — Mobile Team Test tag `2754655826098840951`, view identifier `MSDKOverlayLayout`, endpoint `POST https://apps.rokt.com/v2/sessions/events`. Faults injected via a Proxyman Custom Response on the events endpoint only (session-init/offers left untouched).

| # | Scenario | Injected response | Expected | Observed | Result |
|---|----------|-------------------|----------|----------|--------|
| 1 | Baseline | none | 1× 2xx | 2xx POST | ✅ |
| 2 | 429 retry | `429` | 4 POSTs/batch (1 + `maxRetries=3`) then drop | 12 total ≈ 4/batch × 3 batches | ✅ |
| 3 | 408 retry | `408` | same as 429 | ~4/batch | ✅ |
| 4 | `Retry-After` honored | `429` + `Retry-After: 5` | retries ~5s apart (not sub-second backoff) | ~5s apart | ✅ |
| 5 | `Retry-After` absent/malformed | `429`, header not a valid delta-seconds value | fall back to exponential backoff | sub-second gaps (~0.2/0.4/0.8s) | ✅ |

Takeaways:
- 408 and 429 are now retried (previously dropped after the first response); the SDK replays up to `maxRetries = 3` before giving up.
- The delta-seconds `Retry-After` header paces retries at the gateway-specified interval; the malformed/absent case correctly reverts to exponential backoff, exercising `test_send_retryAfterMalformed_fallsBackToBackoff` live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
