### PR TITLE
feat(txn): flush buffered events when the app backgrounds

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -69,6 +69,9 @@ class RoktInternalImplementation {
     private var linkHandler: LinkHandler = .init()
     var sentEventHashes: ThreadSafeSet<String> = .init()
 
+    // Flushes buffered events when the app backgrounds so they are not lost in the debounce window.
+    private let eventFlushLifecycleObserver = EventFlushLifecycleObserver()
+
     // store callback for partner event integration
     private var roktEvent: ((RoktEvent) -> Void)?
     private var roktEventMap: [String: ((RoktEvent) -> Void)?] = [:]

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -70,6 +70,7 @@ class RoktInternalImplementation {
     var sentEventHashes: ThreadSafeSet<String> = .init()
 
     // Flushes buffered events when the app backgrounds so they are not lost in the debounce window.
+    // periphery:ignore - held only for its side effect (registers the didEnterBackground observer); never read.
     private let eventFlushLifecycleObserver = EventFlushLifecycleObserver()
 
     // store callback for partner event integration

--- a/Sources/Rokt_Widget/Util/EventFlushLifecycleObserver.swift
+++ b/Sources/Rokt_Widget/Util/EventFlushLifecycleObserver.swift
@@ -1,0 +1,29 @@
+import Foundation
+import UIKit
+
+/// Flushes buffered events when the app moves to the background.
+///
+/// Events queued through `EventQueue` sit in a short debounce window before they are sent. If the
+/// app backgrounds inside that window the buffered events would otherwise be lost. Observing
+/// `didEnterBackgroundNotification` and flushing on it is the iOS analog of the web SDK's
+/// `pagehide` / `visibilitychange == hidden` flush.
+final class EventFlushLifecycleObserver {
+    private let flush: () -> Void
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        flush: @escaping () -> Void = { EventQueue.flush() }
+    ) {
+        self.flush = flush
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(handleEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleEnterBackground() {
+        flush()
+    }
+}

--- a/Sources/Rokt_Widget/Util/EventQueue.swift
+++ b/Sources/Rokt_Widget/Util/EventQueue.swift
@@ -22,8 +22,18 @@ class EventQueue: NSObject {
 
     @objc static func fireNow() {
         DispatchQueue(label: eventQueueLabel).sync {
+            guard !EventQueue.events.isEmpty else { return }
             EventQueue.callback?(EventQueue.events)
             EventQueue.events = [EventRequest]()
         }
+    }
+
+    /// Drains the buffer immediately, cancelling the pending debounce timer. A no-op when the
+    /// buffer is empty. Used to flush queued events when the app backgrounds so they are not
+    /// lost inside the debounce window (analog of web's pagehide/visibilitychange flush).
+    static func flush() {
+        timer?.invalidate()
+        timer = nil
+        fireNow()
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestEventFlushLifecycleObserver.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestEventFlushLifecycleObserver.swift
@@ -1,0 +1,28 @@
+import XCTest
+import UIKit
+@testable import Rokt_Widget
+
+final class TestEventFlushLifecycleObserver: XCTestCase {
+
+    func test_didEnterBackground_triggersFlush() {
+        let center = NotificationCenter()
+        var flushCount = 0
+        let observer = EventFlushLifecycleObserver(notificationCenter: center, flush: { flushCount += 1 })
+
+        center.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        XCTAssertEqual(flushCount, 1)
+        withExtendedLifetime(observer) {}
+    }
+
+    func test_otherNotifications_doNotTriggerFlush() {
+        let center = NotificationCenter()
+        var flushCount = 0
+        let observer = EventFlushLifecycleObserver(notificationCenter: center, flush: { flushCount += 1 })
+
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertEqual(flushCount, 0)
+        withExtendedLifetime(observer) {}
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestEventQueue.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestEventQueue.swift
@@ -69,6 +69,29 @@ class TestEventQueue: XCTestCase {
         waitForExpectations(timeout: 0.3, handler: nil)
     }
 
+    func test_flush_drainsBufferedEventsImmediately() {
+        // flush() must deliver synchronously, well before the 0.25s debounce timer would fire.
+        let expectation = self.expectation(description: "flush drains buffered events")
+        EventQueue.call(event: getSampleEvent()) { events in
+            XCTAssertEqual(events.count, 1)
+            expectation.fulfill()
+        }
+
+        EventQueue.flush()
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func test_flush_whenBufferEmpty_isNoOp() {
+        var callbackCount = 0
+        EventQueue.call(event: getSampleEvent()) { _ in callbackCount += 1 }
+
+        EventQueue.flush() // drains the single buffered event
+        EventQueue.flush() // buffer now empty -> must not invoke the callback again
+
+        XCTAssertEqual(callbackCount, 1)
+    }
+
     private func getSampleEvent() -> EventRequest {
         return EventRequest(sessionId: "", eventType: .SignalLoadStart, parentGuid: "", jwtToken: "jwt")
     }


### PR DESCRIPTION
## What

Adds a background/lifecycle flush for buffered transaction events, the iOS analog of the web SDK's `pagehide` / `visibilitychange == hidden` flush.

- `EventQueue.flush()` — cancels the pending 0.25s debounce timer and drains the buffer immediately; no-op when the buffer is empty.
- `EventFlushLifecycleObserver` — observes `UIApplication.didEnterBackgroundNotification` and calls `EventQueue.flush()`. Registered eagerly during SDK init.

## Why

Events queued via `EventQueue` (e.g. `capture_attributes` from fulfillment) wait up to 0.25s before sending. If the app backgrounds inside that window they were **lost** — iOS had no lifecycle-driven flush, unlike web. Part of the cross-platform transactions parity pass.

## Known limitation

This flushes the *debounce buffer* into the send pipeline on background. An in-flight `URLSession` request started right at background can still be suspended by the OS; durable delivery across process death is addressed by the separate **persisted offline replay** PR (web's `keepalive` + pending-events store).

## Tests

- `TestEventQueue`: `test_flush_drainsBufferedEventsImmediately`, `test_flush_whenBufferEmpty_isNoOp` (+ existing 4 pass).
- `TestEventFlushLifecycleObserver`: `test_didEnterBackground_triggersFlush`, `test_otherNotifications_doNotTriggerFlush`.

## E2E validation

Verified with a **side-by-side (fix vs base) run** on an iPhone 16 Pro (iOS 18.5) simulator against live Prod — Example app (`rokt-Example`), Mobile Team Test tag `2754655826098840951`, view identifier `MSDKOverlayLayout`. Proxyman decrypts `apps.rokt.com` traffic and is used purely for **observation** here (no fault injection): we watch *when* the debounced `capture_attributes` POST to `POST /v2/sessions/events` arrives relative to backgrounding.

Test harness (local, test-only — not part of this PR):
- The debounced `EventQueue` path is fed **only** by `capture_attributes`, which is emitted only when the host app invokes `setFulfillmentAttributes(...)` on a `FirstPositiveEngagement`. The Example app doesn't do this by default, so a `setFulfillmentAttributes(["confirmationref": "ORD-E2E-250", ...])` call was added to its event handler (the real partner integration).
- The 0.25s debounce (`EventQueue.eventDelay`) was temporarily widened to 5s so the background window is observable without racing a 250ms timer. This changes only the *window size*, not the flush logic under test.
- Flow: render overlay → tap the offer's positive-engagement button ("Claim") → this queues `capture_attributes` (5s debounce) → background the app via the Home button **before** the timer → observe in Proxyman.

Result:

| Build | Claim | Backgrounded | `capture_attributes` POST | Interpretation |
|-------|-------|--------------|---------------------------|----------------|
| **This PR (fix)** | T | T+1s | **at T+1s — the moment of backgrounding**, before the 5s timer | `didEnterBackground → EventQueue.flush()` drained the buffer immediately ✅ |
| **base (`workstation/transactions`)** | T | T+2s | **only on foreground reopen** (not at the background instant, not during background) | No lifecycle flush; the debounce timer was suspended in background and fired on resume |

So the fix pushes buffered `capture_attributes` out at background time, whereas base holds them across the background and only sends on foreground return — i.e. they would be lost if the OS suspended/killed the process in that gap. Distinguishing signal: the `capture_attributes` POST fires **at the background instant** (fix) vs **at/after the debounce timer** (base). Consistent with the Known limitation above (this flushes the debounce buffer, not in-flight/persisted delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
