### PR TITLE
feat(txn): persist unsent event batches and replay on next init

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/TxnPendingEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnPendingEventStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A single unsent events batch awaiting replay.
+internal struct TxnPendingEventBatch: Codable, Equatable {
+    let events: [TxnEvent]
+    let persistedAtMs: Int64
+}
+
+/// Persists unsent event batches so they survive a process restart and can be replayed on the
+/// next init. Mirrors the web SDK's `RoktTransactionsPendingEvents` store: at most 10 batches,
+/// each with a 30-minute TTL.
+internal protocol TxnPendingEventStoring {
+    /// Persists a batch that failed to send. No-op once the store is full (newest dropped).
+    func persist(events: [TxnEvent])
+    /// Returns the non-expired batches and clears the store. The caller re-persists any that fail again.
+    func drainValid() -> [[TxnEvent]]
+}
+
+internal final class TxnPendingEventStore: TxnPendingEventStoring {
+    static let maxBatches = 10
+    static let ttlMs: Int64 = 30 * 60 * 1000
+
+    private let fileURL: URL?
+    private let clock: () -> Int64
+    private let queue = DispatchQueue(label: "com.rokt.TxnPendingEventStore")
+
+    init(
+        fileURL: URL? = TxnPendingEventStore.defaultFileURL(),
+        clock: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
+    ) {
+        self.fileURL = fileURL
+        self.clock = clock
+    }
+
+    // Transient replay data belongs in Caches (excluded from iCloud backup / not user-visible),
+    // matching where the font cache lives.
+    private static func defaultFileURL() -> URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("txn_pending_events.json")
+    }
+
+    func persist(events: [TxnEvent]) {
+        guard let fileURL, !events.isEmpty else { return }
+        let now = clock()
+        queue.sync {
+            // Drop expired entries first so the cap counts only live batches.
+            var batches = load(from: fileURL).filter { now - $0.persistedAtMs <= Self.ttlMs }
+            // Match web semantics: when full, drop the newest rather than evicting an older batch.
+            guard batches.count < Self.maxBatches else { return }
+            batches.append(TxnPendingEventBatch(events: events, persistedAtMs: now))
+            save(batches, to: fileURL)
+        }
+    }
+
+    func drainValid() -> [[TxnEvent]] {
+        guard let fileURL else { return [] }
+        let now = clock()
+        return queue.sync {
+            let batches = load(from: fileURL)
+            try? FileManager.default.removeItem(at: fileURL)
+            return batches
+                .filter { now - $0.persistedAtMs <= Self.ttlMs }
+                .map { $0.events }
+        }
+    }
+
+    private func load(from url: URL) -> [TxnPendingEventBatch] {
+        guard let data = try? Data(contentsOf: url) else { return [] }
+        return (try? JSONDecoder().decode([TxnPendingEventBatch].self, from: data)) ?? []
+    }
+
+    private func save(_ batches: [TxnPendingEventBatch], to url: URL) {
+        guard let data = try? JSONEncoder().encode(batches) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/Sources/Rokt_Widget/Models/Event/TxnEventModels.swift
+++ b/Sources/Rokt_Widget/Models/Event/TxnEventModels.swift
@@ -1,12 +1,26 @@
 import Foundation
 
 // Event `data` values are either flat strings or nested string maps (capture-attributes partner snapshot).
-internal enum TxnEventDataValue: Encodable, Equatable, ExpressibleByStringLiteral {
+internal enum TxnEventDataValue: Codable, Equatable, ExpressibleByStringLiteral {
     case string(String)
     case object([String: String])
 
     init(stringLiteral value: String) {
         self = .string(value)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: String].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "TxnEventDataValue is neither a String nor a [String: String]"
+            )
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -17,6 +17,7 @@ internal struct TxnEventService {
     let sleep: (TimeInterval) async throws -> Void
 
     private let client: TxnEventsClient?
+    private let pendingStore: TxnPendingEventStoring?
 
     init(
         environment: Environment,
@@ -28,6 +29,7 @@ internal struct TxnEventService {
         maxRetries: Int = 3,
         requestTimeout: TimeInterval = 7,
         baseBackoff: TimeInterval = 0.2,
+        pendingStore: TxnPendingEventStoring? = nil,
         sleep: @escaping (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -35,6 +37,7 @@ internal struct TxnEventService {
         self.sessionManager = sessionManager
         self.maxRetries = maxRetries
         self.baseBackoff = baseBackoff
+        self.pendingStore = pendingStore
         self.sleep = sleep
 
         if let baseURL = URL(string: environment.gatewayBaseURL) {
@@ -59,8 +62,27 @@ internal struct TxnEventService {
         // session token refreshed by one batch is picked up by the next.
         for start in stride(from: 0, to: events.count, by: Self.maxEventsPerBatch) {
             let end = min(start + Self.maxEventsPerBatch, events.count)
-            try await sendBatch(events: Array(events[start..<end]))
+            let batch = Array(events[start..<end])
+            do {
+                try await sendBatch(events: batch)
+            } catch {
+                // Persist recoverable failures (exhausted 5xx/transport) for replay on the next
+                // init instead of dropping them; permanent failures (400/401) are not replayed.
+                if shouldPersistOnFailure(error) {
+                    pendingStore?.persist(events: batch)
+                }
+                throw error
+            }
         }
+    }
+
+    // A recoverable failure that exhausted retries (or a transient transport error) is worth
+    // replaying; a 400/401 is permanent and must not be re-sent.
+    private func shouldPersistOnFailure(_ error: Error) -> Bool {
+        if let txnError = error as? TxnEventError, case .unexpectedStatusCode(let code) = txnError {
+            return isRetryable(statusCode: code)
+        }
+        return isRetryable(error: error)
     }
 
     private func sendBatch(events: [TxnEvent]) async throws {

--- a/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventsClient.swift
@@ -95,7 +95,7 @@ internal struct TxnEventsChannel: Encodable {
     }
 }
 
-internal struct TxnEvent: Encodable, Equatable {
+internal struct TxnEvent: Codable, Equatable {
     // periphery:ignore - encode-only; read by the synthesized Encodable, not by code
     let eventType: String
     // periphery:ignore - encode-only; read by the synthesized Encodable, not by code

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -69,6 +69,9 @@ class RoktInternalImplementation {
     private var linkHandler: LinkHandler = .init()
     var sentEventHashes: ThreadSafeSet<String> = .init()
 
+    // Persists unsent event batches so an offline/rate-limited failure is replayed on the next init.
+    private let txnPendingEventStore: TxnPendingEventStoring = TxnPendingEventStore()
+
     // store callback for partner event integration
     private var roktEvent: ((RoktEvent) -> Void)?
     private var roktEventMap: [String: ((RoktEvent) -> Void)?] = [:]
@@ -895,6 +898,9 @@ class RoktInternalImplementation {
             showNow(payload: page)
         }
 
+        // Replay event batches that failed to send in a previous session.
+        replayPendingTxnEvents()
+
         let initFonts = initResponse.fonts
         FontManager.removeUnusedFonts(fonts: initFonts)
         RoktAPIHelper.downloadFonts(initFonts) {
@@ -959,6 +965,15 @@ class RoktInternalImplementation {
         Task { try? await service.send(events: events) }
     }
 
+    // Replays event batches that failed to send in a previous session (offline / rate-limited),
+    // dropping any past their 30-minute TTL. Called once init succeeds.
+    func replayPendingTxnEvents() {
+        guard roktTagId != nil else { return }
+        for batch in txnPendingEventStore.drainValid() {
+            dispatchTxnEvents(batch)
+        }
+    }
+
     private func defaultTxnEventService(roktTagId: String) -> TxnEventService {
         let httpClient: HTTPClientAdapter = config.environment == .Mock
             ? MockTxnInitHTTPClient()
@@ -969,7 +984,8 @@ class RoktInternalImplementation {
             sdkVersion: libraryVersion,
             sessionManager: TxnSessionManager(roktTagId: roktTagId),
             httpClient: httpClient,
-            deviceHeaders: NetworkingHelper.txnDeviceHeaders()
+            deviceHeaders: NetworkingHelper.txnDeviceHeaders(),
+            pendingStore: txnPendingEventStore
         )
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnPendingEventStore.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnPendingEventStore.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class TestTxnPendingEventStore: XCTestCase {
+
+    private var fileURL: URL!
+    private var nowMs: Int64!
+
+    override func setUp() {
+        super.setUp()
+        nowMs = 1_700_000_000_000
+        fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("txn_pending_\(UUID().uuidString).json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: fileURL)
+        fileURL = nil
+        nowMs = nil
+        super.tearDown()
+    }
+
+    private func makeStore() -> TxnPendingEventStore {
+        TxnPendingEventStore(fileURL: fileURL, clock: { self.nowMs })
+    }
+
+    private func batch(_ id: String) -> [TxnEvent] {
+        [TxnEvent(eventType: "impression", instanceId: id, timestamp: 1_700_000_000_000, data: ["k": "v"])]
+    }
+
+    func test_persist_thenDrain_returnsBatch() {
+        let store = makeStore()
+        store.persist(events: batch("a"))
+
+        let drained = store.drainValid()
+
+        XCTAssertEqual(drained.count, 1)
+        XCTAssertEqual(drained.first?.first?.instanceId, "a")
+    }
+
+    func test_drain_clearsStore() {
+        let store = makeStore()
+        store.persist(events: batch("a"))
+
+        _ = store.drainValid()
+
+        XCTAssertTrue(store.drainValid().isEmpty)
+    }
+
+    func test_persist_emptyEvents_isNoOp() {
+        let store = makeStore()
+        store.persist(events: [])
+
+        XCTAssertTrue(store.drainValid().isEmpty)
+    }
+
+    func test_drain_dropsExpiredBatches() {
+        let store = makeStore()
+        store.persist(events: batch("old"))
+
+        // Advance past the 30-minute TTL before draining.
+        nowMs += TxnPendingEventStore.ttlMs + 1
+
+        XCTAssertTrue(store.drainValid().isEmpty)
+    }
+
+    func test_drain_keepsBatchExactlyAtTTLBoundary() {
+        let store = makeStore()
+        store.persist(events: batch("edge"))
+
+        nowMs += TxnPendingEventStore.ttlMs // still within TTL (<=)
+
+        XCTAssertEqual(store.drainValid().count, 1)
+    }
+
+    func test_persist_enforcesCapOf10_dropsNewest() {
+        let store = makeStore()
+        for index in 0..<12 {
+            store.persist(events: batch("batch-\(index)"))
+        }
+
+        let drained = store.drainValid()
+
+        XCTAssertEqual(drained.count, TxnPendingEventStore.maxBatches)
+        // Oldest 10 are kept; the 11th and 12th were dropped.
+        XCTAssertEqual(drained.first?.first?.instanceId, "batch-0")
+        XCTAssertEqual(drained.last?.first?.instanceId, "batch-9")
+    }
+
+    func test_expiredBatchesDoNotConsumeCapacity() {
+        let store = makeStore()
+        store.persist(events: batch("stale"))
+
+        // Expire the first batch, then fill to cap: all 10 fresh batches should be retained.
+        nowMs += TxnPendingEventStore.ttlMs + 1
+        for index in 0..<TxnPendingEventStore.maxBatches {
+            store.persist(events: batch("fresh-\(index)"))
+        }
+
+        let drained = store.drainValid()
+        XCTAssertEqual(drained.count, TxnPendingEventStore.maxBatches)
+        XCTAssertFalse(drained.contains { $0.first?.instanceId == "stale" })
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -25,6 +25,7 @@ final class TestTxnEventService: XCTestCase {
         environment: Environment = .Prod,
         deviceHeaders: [String: String] = ["rokt-os-type": "iOS"],
         maxRetries: Int = 3,
+        pendingStore: TxnPendingEventStoring? = nil,
         sleep: @escaping (TimeInterval) async throws -> Void = { _ in }
     ) -> TxnEventService {
         TxnEventService(
@@ -36,6 +37,7 @@ final class TestTxnEventService: XCTestCase {
             deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
             baseBackoff: 0,
+            pendingStore: pendingStore,
             sleep: sleep
         )
     }
@@ -247,6 +249,53 @@ final class TestTxnEventService: XCTestCase {
         }
     }
 
+    func test_send_exhaustedRecoverableFailure_persistsBatchForReplay() async {
+        let store = SpyTxnPendingEventStore()
+        httpClient.results = [.status(503)]
+
+        do {
+            try await makeService(pendingStore: store).send(events: sampleEvents())
+            XCTFail("Expected send to fail after exhausting retries")
+        } catch {
+            XCTAssertEqual(store.persistedBatches.count, 1)
+            XCTAssertEqual(store.persistedBatches.first?.first?.instanceId, "instance-1")
+        }
+    }
+
+    func test_send_nonRetryableFailure_doesNotPersist() async {
+        let store = SpyTxnPendingEventStore()
+        httpClient.results = [.status(400)]
+
+        do {
+            try await makeService(pendingStore: store).send(events: sampleEvents())
+            XCTFail("Expected send to fail on 400")
+        } catch {
+            XCTAssertTrue(store.persistedBatches.isEmpty)
+        }
+    }
+
+    func test_send_unauthorized_doesNotPersist() async {
+        await storeValidToken()
+        let store = SpyTxnPendingEventStore()
+        httpClient.results = [.status(401)]
+
+        do {
+            try await makeService(pendingStore: store).send(events: sampleEvents())
+            XCTFail("Expected send to fail on 401")
+        } catch {
+            XCTAssertTrue(store.persistedBatches.isEmpty)
+        }
+    }
+
+    func test_send_success_doesNotPersist() async throws {
+        let store = SpyTxnPendingEventStore()
+        httpClient.results = [.success(status: 202, data: rotatedResponse())]
+
+        try await makeService(pendingStore: store).send(events: sampleEvents())
+
+        XCTAssertTrue(store.persistedBatches.isEmpty)
+    }
+
     func test_send_emptyEvents_skipsRequest() async throws {
         try await makeService().send(events: [])
 
@@ -265,5 +314,19 @@ final class TestTxnEventService: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+    }
+}
+
+private final class SpyTxnPendingEventStore: TxnPendingEventStoring {
+    private(set) var persistedBatches: [[TxnEvent]] = []
+    var batchesToDrain: [[TxnEvent]] = []
+
+    func persist(events: [TxnEvent]) {
+        persistedBatches.append(events)
+    }
+
+    func drainValid() -> [[TxnEvent]] {
+        defer { batchesToDrain = [] }
+        return batchesToDrain
     }
 }


### PR DESCRIPTION
## What

Adds a persisted offline replay queue for transaction events, aligning with the web SDK's `RoktTransactionsPendingEvents` store.

- **`TxnPendingEventStore`** (new): disk-backed (Caches dir), **cap 10 batches, 30-min TTL**, newest dropped when full (matches web `_persistRequest`). Expired batches don't consume capacity.
- **`TxnEventService`**: on a *terminal recoverable* failure (exhausted 5xx / transient transport), the batch is persisted instead of dropped. Permanent failures (**400/401**) are not replayed.
- **Replay on init**: `replayPendingTxnEvents()` drains non-expired batches and re-dispatches them; invoked from `handleInitSuccess`. Drained batches that fail again are re-persisted.
- `TxnEvent` / `TxnEventDataValue` are now `Codable` so batches round-trip to disk.

## Why

Previously `dispatchTxnEvents` did `Task { try? await service.send(...) }` — any post-retry failure was silently dropped. This was the largest caching divergence from web in the parity analysis.

## Design note

Web persists each request *while in flight* and removes it on completion (kill-resilience via `sessionStorage`). iOS here **enqueues on terminal failure** — this matches the sdk-android PR4 parity plan and is lower-I/O; observable replay behavior (offline/rate-limited batches survive and replay next init, 10/30-min) is equivalent. Dedup of persisted batches is intentionally not mirrored (web dedups by `JSON.stringify(body)`); called out for review.

## Tests

- `TestTxnPendingEventStore` (7): persist/drain, clear-on-drain, empty no-op, TTL drop, TTL boundary, cap-of-10 drops-newest, expired-don't-consume-capacity.
- `TestTxnEventService` (4 new): persists on exhausted 503; does **not** persist on 400 / 401 / success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)