### PR TITLE
fix(txn): align events retry backoff curve and jitter with web

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -27,7 +27,7 @@ internal struct TxnEventService {
         deviceHeaders: [String: String] = [:],
         maxRetries: Int = 3,
         requestTimeout: TimeInterval = 7,
-        baseBackoff: TimeInterval = 0.2,
+        baseBackoff: TimeInterval = 1.0,
         sleep: @escaping (TimeInterval) async throws -> Void = { seconds in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
@@ -147,9 +147,11 @@ internal struct TxnEventService {
         }
     }
 
-    // Exponential backoff with jitter to avoid hammering a struggling gateway.
+    // Exponential backoff with jitter to avoid hammering a struggling gateway. The `1000·4^n`
+    // curve and ≤25% jitter mirror web (`BASE_DELAY_MS * 4^(retryCount-1)` + `random·0.25`);
+    // `attempt` is 0-based here, so the first retry waits `baseBackoff` (1s).
     private func backoffDelay(attempt: Int) -> TimeInterval {
-        let base = baseBackoff * pow(2, Double(attempt))
-        return base + Double.random(in: 0...(base/2))
+        let base = baseBackoff * pow(4, Double(attempt))
+        return base + Double.random(in: 0...(base * 0.25))
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -25,6 +25,7 @@ final class TestTxnEventService: XCTestCase {
         environment: Environment = .Prod,
         deviceHeaders: [String: String] = ["rokt-os-type": "iOS"],
         maxRetries: Int = 3,
+        baseBackoff: TimeInterval = 0,
         sleep: @escaping (TimeInterval) async throws -> Void = { _ in }
     ) -> TxnEventService {
         TxnEventService(
@@ -35,7 +36,7 @@ final class TestTxnEventService: XCTestCase {
             httpClient: httpClient,
             deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
-            baseBackoff: 0,
+            baseBackoff: baseBackoff,
             sleep: sleep
         )
     }
@@ -150,6 +151,24 @@ final class TestTxnEventService: XCTestCase {
 
         XCTAssertEqual(httpClient.callCount, 2)
         XCTAssertEqual(recordedDelays, [0.0])
+    }
+
+    func test_backoffDelay_followsWebCurveWithJitterCap() async throws {
+        var delays: [TimeInterval] = []
+        let service = makeService(baseBackoff: 1.0, sleep: { delays.append($0) })
+        // Three retryable failures then success -> backoff sleeps for attempts 0, 1, 2.
+        httpClient.results = [.status(503), .status(503), .status(503),
+                              .success(status: 202, data: rotatedResponse())]
+
+        try await service.send(events: sampleEvents())
+
+        XCTAssertEqual(delays.count, 3)
+        // Web curve: base = 1000·4^n ms (== 4^n s here); jitter adds 0...25%.
+        for (n, delay) in delays.enumerated() {
+            let base = pow(4.0, Double(n)) // 1s, 4s, 16s
+            XCTAssertGreaterThanOrEqual(delay, base)
+            XCTAssertLessThanOrEqual(delay, base * 1.25)
+        }
     }
 
     func test_send_retriesOnTimeout_thenSucceeds() async throws {


### PR DESCRIPTION
## What

Aligns the transactions events-endpoint retry backoff with WSDK v2.

| | before (iOS) | after (web parity) |
|---|---|---|
| base delay | 200 ms | 1000 ms |
| curve | `200·2^n` | `1000·4^n` |
| jitter | up to 50% (`base/2`) | ≤25% (`base·0.25`) |

(`attempt` is 0-based, so the first retry waits ~1s, matching web's `BASE_DELAY_MS · 4^(retryCount-1)`.)

## Why

iOS retried much more aggressively and with noisier spacing than web under sustained gateway pressure. Part of the cross-platform transactions parity pass.

## Scope / merge order

Backoff **curve/jitter only**. Retry-eligibility (408/429 + `Retry-After`) is a separate PR; this changes only `backoffDelay` + the `baseBackoff` default, so the two are independent (they touch different methods).

Retry **attempt count** (iOS does 4 total sends vs web's 3) is intentionally left out of scope — flagged for a follow-up decision.

## Tests

`TestTxnEventService.test_backoffDelay_followsWebCurveWithJitterCap` asserts each retry delay is within `[4^n, 4^n·1.25]` seconds; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)