### PR TITLE
fix(txn): strip event timestamps outside the year range [2000, 2100]

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -125,14 +125,21 @@ internal enum TxnEventMapper {
         return data.isEmpty ? nil : data
     }
 
+    // The transactions gateway rejects a whole events batch if any timestamp falls outside the
+    // year range [2000, 2100], so an out-of-range value (e.g. from a device with a misconfigured
+    // clock) is stripped rather than sent — the gateway then defaults to receive-time. Bounds
+    // mirror web's `Date.UTC(2000, 0, 1)` / `Date.UTC(2101, 0, 1)`.
+    private static let minAcceptedTimestampMs: Int64 = 946_684_800_000 // 2000-01-01T00:00:00Z
+    private static let maxAcceptedTimestampMs: Int64 = 4_133_980_800_000 // 2101-01-01T00:00:00Z (exclusive)
+
     // Returns nil (so the timestamp is dropped from the wire) when the capture time is
-    // missing/unparseable or non-positive. The gateway then defaults to receive-time
-    // rather than us sending a misleading value (mirrors web + Android).
+    // missing/unparseable or outside the accepted year range. The gateway then defaults to
+    // receive-time rather than us sending a value it would reject (mirrors web + Android).
     private static func epochMilliseconds(from eventTime: String) -> Int64? {
         guard let date = EventDateFormatter.dateFormatter.date(from: eventTime) else {
             return nil
         }
         let ms = Int64(date.timeIntervalSince1970 * 1000)
-        return ms > 0 ? ms : nil
+        return (minAcceptedTimestampMs..<maxAcceptedTimestampMs).contains(ms) ? ms : nil
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
@@ -12,13 +12,14 @@ final class TestTxnEventMapper: XCTestCase {
         objectData: [String: String]? = nil,
         parentGuid: String = "parent-1",
         pageInstanceGuid: String = "page-1",
-        jwtToken: String = "jwt-1"
+        jwtToken: String = "jwt-1",
+        eventTime: Date? = nil
     ) -> RoktEventRequest {
         RoktEventRequest(
             sessionId: "session-1",
             eventType: eventType,
             parentGuid: parentGuid,
-            eventTime: eventTime,
+            eventTime: eventTime ?? self.eventTime,
             eventData: eventData,
             objectData: objectData,
             pageInstanceGuid: pageInstanceGuid,
@@ -103,6 +104,34 @@ final class TestTxnEventMapper: XCTestCase {
         XCTAssertNotNil(event)
         // Dropped from the wire so the gateway defaults to receive-time (mirrors web + Android).
         XCTAssertNil(event?.timestamp)
+    }
+
+    func test_stripsTimestampBefore2000() {
+        // 1999-12-31 — before the accepted range.
+        let request = makeRequest(eventType: .SignalImpression,
+                                  eventTime: Date(timeIntervalSince1970: 946_684_800 - 86_400))
+        XCTAssertNil(TxnEventMapper.event(from: request)?.timestamp)
+    }
+
+    func test_stripsTimestampAtOrAfter2101() {
+        // 2101-01-01T00:00:00Z — the exclusive upper bound.
+        let request = makeRequest(eventType: .SignalImpression,
+                                  eventTime: Date(timeIntervalSince1970: 4_133_980_800))
+        XCTAssertNil(TxnEventMapper.event(from: request)?.timestamp)
+    }
+
+    func test_keepsTimestampAtLowerBound2000() {
+        // 2000-01-01T00:00:00Z — inclusive lower bound.
+        let request = makeRequest(eventType: .SignalImpression,
+                                  eventTime: Date(timeIntervalSince1970: 946_684_800))
+        XCTAssertEqual(TxnEventMapper.event(from: request)?.timestamp, 946_684_800_000)
+    }
+
+    func test_keepsTimestampWithinRange2100() {
+        // 2100-12-31 — inside the accepted range.
+        let request = makeRequest(eventType: .SignalImpression,
+                                  eventTime: Date(timeIntervalSince1970: 4_133_980_800 - 86_400))
+        XCTAssertEqual(TxnEventMapper.event(from: request)?.timestamp, (4_133_980_800 - 86_400) * 1000)
     }
 
     func test_attributesAreFlattenedAndMetadataMapped() {


### PR DESCRIPTION
## What

Adds a year-range gate to `TxnEventMapper.epochMilliseconds`. Timestamps outside **[2000-01-01, 2101-01-01) UTC** are stripped (omitted from the wire) so the gateway defaults to receive-time — the same fallback already used for unparseable timestamps. Bounds mirror web's `Date.UTC(2000,0,1)` / `Date.UTC(2101,0,1)`.

## Why

The mapper previously only rejected non-positive values (`> 0`). Per the web SDK, the transactions gateway rejects an **entire events batch** if any single timestamp is out of the [2000, 2100] year range — so one device with a misconfigured system clock (iOS `eventTime` defaults to `Date()`, so this needs a wrong clock) could silently poison whole batches.

## Legitimacy note

The trigger is low-frequency (device clock set before 2000 or in/after 2101). RoktGPT could not find a doc that explicitly confirms the whole-batch-rejection rule, but documented behavior is that a *missing* timestamp falls back to server receive-time — so stripping an out-of-range value is safe and matches web. Framed as defensive parity hardening rather than a confirmed server-contract fix.

## Tests

`TestTxnEventMapper` (4 new): strips before-2000 and at/after-2101; keeps the 2000 lower bound (inclusive) and an in-range 2100 value. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)