### PR TITLE
fix(txn): retry events when the device is offline

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -131,13 +131,15 @@ internal struct TxnEventService {
         return seconds
     }
 
-    // Transient transport failures only; a hard-offline device fails fast.
+    // Transient transport failures worth retrying, including a device that is offline
+    // (matches ForwardPaymentRetryRules and the web/Android recoverable-transport set).
     private func isRetryable(error: Error) -> Bool {
         let nsError = error as NSError
         guard nsError.domain == NSURLErrorDomain else { return false }
         switch nsError.code {
         case NSURLErrorTimedOut,
              NSURLErrorNetworkConnectionLost,
+             NSURLErrorNotConnectedToInternet,
              NSURLErrorCannotConnectToHost,
              NSURLErrorCannotFindHost,
              NSURLErrorDNSLookupFailed:

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -161,6 +161,17 @@ final class TestTxnEventService: XCTestCase {
         XCTAssertEqual(httpClient.callCount, 2)
     }
 
+    func test_send_retriesWhenOffline_thenSucceeds() async throws {
+        // A device that is offline surfaces NSURLErrorNotConnectedToInternet; treat it as a
+        // transient transport failure so the batch is retried rather than dropped.
+        httpClient.results = [.transport(NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)),
+                              .success(status: 202, data: rotatedResponse())]
+
+        try await makeService().send(events: sampleEvents())
+
+        XCTAssertEqual(httpClient.callCount, 2)
+    }
+
     func test_send_exhaustsRetries_throwsUnexpectedStatus() async {
         httpClient.results = [.status(503)]
 


### PR DESCRIPTION
## What
Add `NSURLErrorNotConnectedToInternet` to `TxnEventService.isRetryable(error:)` so an offline device retries the events request instead of failing fast and dropping the batch.

## Why
`isRetryable(error:)` listed timeout / connection-lost / host / DNS failures but not the plain offline case, so a device in airplane mode dropped events on the first attempt. The sibling `ForwardPaymentRetryRules` already classifies offline as recoverable — this aligns the two.

## Tests
- `test_send_retriesWhenOffline_thenSucceeds`: offline transport error is retried, then succeeds on the next attempt.
- Full `TestTxnEventService` suite passes (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)