### PR TITLE
perf(txn): gate Mock offline transports out of release builds

### DIFF
--- a/Sources/Rokt_Widget/Networking/MockOffersHTTPClient.swift
+++ b/Sources/Rokt_Widget/Networking/MockOffersHTTPClient.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 
 // Offline transport for the Mock environment: serves an offers selection response without
@@ -98,3 +99,4 @@ internal final class MockOffersHTTPClient: HTTPClientAdapter {
         completionHandler: ((RoktDownloadResult) -> Void)?
     ) {}
 }
+#endif

--- a/Sources/Rokt_Widget/Networking/MockTxnInitHTTPClient.swift
+++ b/Sources/Rokt_Widget/Networking/MockTxnInitHTTPClient.swift
@@ -1,6 +1,8 @@
+#if DEBUG
 import Foundation
 
-// Offline mock transport for init responses.
+// Offline mock transport for init responses. Development-only (Environment.Mock);
+// compiled out of release builds so it never ships in the SDK.
 internal final class MockTxnInitHTTPClient: HTTPClientAdapter {
     private static let fixtureName = "txn_init"
 
@@ -73,3 +75,4 @@ internal final class MockTxnInitHTTPClient: HTTPClientAdapter {
         completionHandler: ((RoktDownloadResult) -> Void)?
     ) {}
 }
+#endif

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -928,9 +928,12 @@ class RoktInternalImplementation {
     }
 
     private func defaultTxnInitService(roktTagId: String) -> TxnInitService {
-        let httpClient: HTTPClientAdapter = config.environment == .Mock
-            ? MockTxnInitHTTPClient()
-            : NetworkingHelper.shared.httpClient
+        // Mock transports are a development-only convenience (Environment.Mock) and
+        // are compiled out of release builds to keep them off the shipped SDK.
+        var httpClient: HTTPClientAdapter = NetworkingHelper.shared.httpClient
+        #if DEBUG
+        if config.environment == .Mock { httpClient = MockTxnInitHTTPClient() }
+        #endif
         return TxnInitService(
             environment: config.environment,
             accountId: roktTagId,
@@ -941,9 +944,10 @@ class RoktInternalImplementation {
     }
 
     private func defaultOffersService(roktTagId: String) -> OffersService {
-        let httpClient: HTTPClientAdapter = config.environment == .Mock
-            ? MockOffersHTTPClient()
-            : NetworkingHelper.shared.httpClient
+        var httpClient: HTTPClientAdapter = NetworkingHelper.shared.httpClient
+        #if DEBUG
+        if config.environment == .Mock { httpClient = MockOffersHTTPClient() }
+        #endif
         return OffersService(
             environment: config.environment,
             accountId: roktTagId,
@@ -979,9 +983,10 @@ class RoktInternalImplementation {
     }
 
     private func defaultTxnEventService(roktTagId: String) -> TxnEventService {
-        let httpClient: HTTPClientAdapter = config.environment == .Mock
-            ? MockTxnInitHTTPClient()
-            : NetworkingHelper.shared.httpClient
+        var httpClient: HTTPClientAdapter = NetworkingHelper.shared.httpClient
+        #if DEBUG
+        if config.environment == .Mock { httpClient = MockTxnInitHTTPClient() }
+        #endif
         return TxnEventService(
             environment: config.environment,
             accountId: roktTagId,


### PR DESCRIPTION
## Summary
First of two stacked SDK-size quick-wins addressing the +292 KB regression from the v2 transactions work ([#255 size report](https://github.com/ROKT/rokt-sdk-ios/pull/255#issuecomment-5007827856)).

`MockOffersHTTPClient` and `MockTxnInitHTTPClient` are **development-only** offline transports (selected only via `Environment.Mock`) that carry embedded fixture JSON. They shipped unconditionally in release builds. This wraps both in `#if DEBUG` and guards their instantiation in `RoktInternalImplementation`.

`Environment.Mock` is only reachable through a `"MOCK"` host Info.plist configuration (the Example app), never via the public `setEnvironment(_:)` API — so release partner integrations are unaffected.

## Impact
- **Primarily hygiene** — dev-only mocks + fake-data JSON no longer ship in release.
- Release SDK executable **−1,632 bytes** (the embedded `mock-session` fixture JSON; the mock code footprint was already small after release optimization).

## Verification
- Release archive compiles with the mocks excluded; the `mock-session` fixture JSON is absent from the release binary.
- Debug archive still compiles the Mock path.
- SwiftLint clean.

> Note: commits are unsigned — the local 1Password commit-signing agent was unavailable in the automation environment. Re-sign before merge if branch protection requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)