### PR TITLE
fix(security): add iOS Data Protection to persisted event stores

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -157,23 +157,6 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         }
     }
 
-    #if DEBUG
-    // Test hook: cancels any pending debounce and drops accumulated marks so a scheduled
-    // write cannot fire after a test finishes. Not referenced in production code.
-    func cancelPendingWorkForTesting() {
-        let invalidate = {
-            self.debounceTimer?.invalidate()
-            self.debounceTimer = nil
-        }
-        if Thread.isMainThread {
-            invalidate()
-        } else {
-            DispatchQueue.main.sync(execute: invalidate)
-        }
-        eventProcessingQueue.sync { self.accumulatedEventsToMark.removeAll() }
-    }
-    #endif
-
     private func getUntriggeredEvents() -> [UntriggeredRealTimeEvent] {
         guard let untriggeredEventsFilePath else { return [] }
         return load(from: untriggeredEventsFilePath)

--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -52,20 +52,25 @@ class RealTimeEventStoreFile: RealTimeEventStore {
     private let debounceInterval: TimeInterval = 0.5
     private let eventProcessingQueue = DispatchQueue(label: "com.rokt.RealTimeEventManager.eventProcessingQueue")
 
-    init() {
+    // File paths are injectable so tests can isolate each case to its own temporary files.
+    // Production uses the document-directory defaults.
+    init(
+        triggeredEventsFilePath: URL? = RealTimeEventStoreFile.defaultFileURL(named: "triggered_events.json"),
+        untriggeredEventsFilePath: URL? = RealTimeEventStoreFile.defaultFileURL(named: "untriggered_events.json")
+    ) {
+        self.triggeredEventsFilePath = triggeredEventsFilePath
+        self.untriggeredEventsFilePath = untriggeredEventsFilePath
+    }
+
+    private static func defaultFileURL(named name: String) -> URL? {
         guard let directory = FileManager
             .default
-            .urls(
-                for: .documentDirectory,
-                in: .userDomainMask
-            ).first else {
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first else {
             RoktLogger.shared.error("Document directory unavailable - RealTimeEventStore will not persist events")
-            self.triggeredEventsFilePath = nil
-            self.untriggeredEventsFilePath = nil
-            return
+            return nil
         }
-        self.triggeredEventsFilePath = directory.appendingPathComponent("triggered_events.json")
-        self.untriggeredEventsFilePath = directory.appendingPathComponent("untriggered_events.json")
+        return directory.appendingPathComponent(name)
     }
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
@@ -152,6 +157,23 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         }
     }
 
+    #if DEBUG
+    // Test hook: cancels any pending debounce and drops accumulated marks so a scheduled
+    // write cannot fire after a test finishes. Not referenced in production code.
+    func cancelPendingWorkForTesting() {
+        let invalidate = {
+            self.debounceTimer?.invalidate()
+            self.debounceTimer = nil
+        }
+        if Thread.isMainThread {
+            invalidate()
+        } else {
+            DispatchQueue.main.sync(execute: invalidate)
+        }
+        eventProcessingQueue.sync { self.accumulatedEventsToMark.removeAll() }
+    }
+    #endif
+
     private func getUntriggeredEvents() -> [UntriggeredRealTimeEvent] {
         guard let untriggeredEventsFilePath else { return [] }
         return load(from: untriggeredEventsFilePath)
@@ -161,7 +183,11 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         do {
             let encoder = JSONEncoder()
             let data = try encoder.encode(value)
-            try data.write(to: url, options: .atomic)
+            // Encrypt at rest with iOS Data Protection. Use `.completeFileProtectionUntilFirstUserAuthentication`
+            // (not `.completeFileProtection`): events are persisted during normal app runtime, including while
+            // backgrounded and the device is locked. A stricter class would make those writes fail and drop
+            // events. This mirrors the protection level used by TxnPendingEventStore.
+            try data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
         } catch {
             RoktLogger.shared.error("Failed to save real-time events", error: error)
         }

--- a/Sources/Rokt_Widget/DataAccess/TxnPendingEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnPendingEventStore.swift
@@ -71,6 +71,10 @@ internal final class TxnPendingEventStore: TxnPendingEventStoring {
 
     private func save(_ batches: [TxnPendingEventBatch], to url: URL) {
         guard let data = try? JSONEncoder().encode(batches) else { return }
-        try? data.write(to: url, options: .atomic)
+        // Encrypt at rest with iOS Data Protection. Use `.completeFileProtectionUntilFirstUserAuthentication`
+        // (not `.completeFileProtection`): persist() runs from network-failure callbacks that can fire while
+        // the app is backgrounded and the device is locked, and this write is best-effort (try?). A stricter
+        // class would make those writes fail silently and drop pending batches, defeating the replay store.
+        try? data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
@@ -4,6 +4,8 @@ internal import RoktUXHelper
 
 class RealTimeEventStoreFileTest: XCTestCase {
     var sut: RealTimeEventStoreFile!
+    private var triggeredFileURL: URL!
+    private var untriggeredFileURL: URL!
     let debounceInterval: TimeInterval = 0.5
     let expectationTimeout: TimeInterval = 1.0
 
@@ -35,12 +37,26 @@ class RealTimeEventStoreFileTest: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        sut = RealTimeEventStoreFile()
+        // Isolate each test to its own temporary files so a debounced write from one test
+        // cannot leak into the next (the production store shares fixed document-directory files).
+        let tmp = FileManager.default.temporaryDirectory
+        triggeredFileURL = tmp.appendingPathComponent("triggered_\(UUID().uuidString).json")
+        untriggeredFileURL = tmp.appendingPathComponent("untriggered_\(UUID().uuidString).json")
+        sut = RealTimeEventStoreFile(
+            triggeredEventsFilePath: triggeredFileURL,
+            untriggeredEventsFilePath: untriggeredFileURL
+        )
     }
 
     override func tearDown() {
+        // Cancel any in-flight debounce so a pending write cannot fire after the test ends.
+        sut.cancelPendingWorkForTesting()
         sut.clear()
         sut = nil
+        try? FileManager.default.removeItem(at: triggeredFileURL)
+        try? FileManager.default.removeItem(at: untriggeredFileURL)
+        triggeredFileURL = nil
+        untriggeredFileURL = nil
         super.tearDown()
     }
 
@@ -463,6 +479,26 @@ class RealTimeEventStoreFileTest: XCTestCase {
             markExpectation1.fulfill()
         })
         wait(for: [markExpectation1], timeout: expectationTimeout + 0.5)
+    }
+
+    // MARK: - Tests for Data Protection
+
+    func test_addUntriggeredEvents_writesFileWithDataProtection() throws {
+        let untriggeredEvent = createRoktUXRealTimeEventResponse(
+            triggerGuid: guid1,
+            triggerEvent: signalImpressionRawValue,
+            eventType: finalType1,
+            payload: payload1
+        )
+        sut.addUntriggeredEvents([untriggeredEvent])
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: untriggeredFileURL.path)
+        let protection = attributes[.protectionKey] as? FileProtectionType
+
+        // The iOS Simulator does not enforce or report Data Protection, so the attribute is nil there.
+        // Assert only where it is reported (real device); skip otherwise so CI stays green.
+        try XCTSkipUnless(protection != nil, "Data Protection is not reported on this environment (simulator)")
+        XCTAssertEqual(protection, .completeUntilFirstUserAuthentication)
     }
 
     // MARK: - Tests for clear

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
@@ -49,10 +49,10 @@ class RealTimeEventStoreFileTest: XCTestCase {
     }
 
     override func tearDown() {
-        // Cancel any in-flight debounce so a pending write cannot fire after the test ends.
-        sut.cancelPendingWorkForTesting()
         sut.clear()
         sut = nil
+        // Per-test unique files (see setUp) keep each case isolated, so a debounced write left
+        // in flight lands in this test's own file and cannot leak into the next.
         try? FileManager.default.removeItem(at: triggeredFileURL)
         try? FileManager.default.removeItem(at: untriggeredFileURL)
         triggeredFileURL = nil

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnPendingEventStore.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnPendingEventStore.swift
@@ -87,6 +87,19 @@ final class TestTxnPendingEventStore: XCTestCase {
         XCTAssertEqual(drained.last?.first?.instanceId, "batch-9")
     }
 
+    func test_persist_writesFileWithDataProtection() throws {
+        let store = makeStore()
+        store.persist(events: batch("a"))
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let protection = attributes[.protectionKey] as? FileProtectionType
+
+        // The iOS Simulator does not enforce or report Data Protection, so the attribute is nil there.
+        // Assert only where it is reported (real device); skip otherwise so CI stays green.
+        try XCTSkipUnless(protection != nil, "Data Protection is not reported on this environment (simulator)")
+        XCTAssertEqual(protection, .completeUntilFirstUserAuthentication)
+    }
+
     func test_expiredBatchesDoNotConsumeCapacity() {
         let store = makeStore()
         store.persist(events: batch("stale"))


### PR DESCRIPTION
## Background

PR #255 review comment [swift-file-no-protection-010](https://github.com/ROKT/rokt-sdk-ios/pull/255#discussion_r3606427361) flagged that `TxnPendingEventStore` writes serialized transaction-event batches to the Caches directory with `.atomic` only and **no iOS Data Protection class**, leaving the file decryptable while the device is locked. `RealTimeEventStoreFile` has the identical unprotected write, so both are fixed here.

## What Has Changed

- **Data Protection on both event-store writes** — added `.completeFileProtectionUntilFirstUserAuthentication` to the `Data.write` options in `TxnPendingEventStore.save(_:to:)` and `RealTimeEventStoreFile.save(_:to:)`. This encrypts the data at rest before first unlock after boot while remaining writable during normal app runtime.
  - `.completeFileProtection` was **deliberately not used**: both stores persist from callbacks that can fire while the app is backgrounded and the device is locked (best-effort `try?` writes). The stricter class would make those writes fail silently and drop events, defeating the replay/store purpose.
- **Fixed pre-existing test flakiness** in `RealTimeEventStoreFileTest` (surfaced during verification, unrelated to the security change): the store hardcoded shared document-directory files, so the 0.5s debounce timer in `markAsTriggered` could leak a triggered event into the next test.
  - `RealTimeEventStoreFile` file paths are now **injectable** (production keeps the document-directory defaults via `RealTimeEventStoreFile()`), so each test is isolated to its own unique temp files. This isolation alone makes the suite deterministic.
- **Added device-aware unit tests** asserting the file's `.protectionKey` is `.completeUntilFirstUserAuthentication`. They assert on a real device and skip via `XCTSkipUnless` on the simulator, which does not report Data Protection.

## How Has This Been Tested

### Simulator (matches CI: iPhone 17 Pro, scheme `Rokt-Widget`)

- `TestTxnPendingEventStore` — 8 tests pass (protection test skips on simulator).
- `RealTimeEventStoreFileTest` — full suite run **10× consecutively, all green** (previously intermittently failed on `test_markAsTriggered_singleMatch_eventIsTriggered`).
- `RealTimeEventManagerTest` (12) and `RealTimeEventStoreMemoryTest` (16) — pass, confirming the injectable-init change is backward compatible.

Because the iOS Simulator does not implement Data Protection, `.protectionKey` is `nil` there and the protection assertions skip — the simulator can only confirm the functional path, never the at-rest encryption itself.

### Physical device (real at-rest verification)

To actually verify the protection class, equivalent app-hosted tests were run on a physical **iPhone 16 Pro (iOS 26.5.2)** via the Example app's `rokt_Tests` target (the SPM test bundle cannot be tool-hosted on a device). Each test constructs the store, writes a batch, then reads back `FileManager.attributesOfItem(...)[.protectionKey]`:

- `testTxnPendingEventStore_writesFileWithDataProtection` — **passed**, assertion executed (not skipped).
- `testRealTimeEventStore_writesFileWithDataProtection` — **passed**, assertion executed (not skipped).

Both confirmed the written file has protection class `completeUntilFirstUserAuthentication` on-device. These device tests were verification-only and are **not committed** — the Example target is not part of the SPM CI job, so they would never run there; the committed SPM tests are the CI-facing coverage.

## Notes

The chosen protection level is iOS's default class, so behavior is unchanged for existing files; the change only makes the intent explicit and satisfies the scanner rule without sacrificing replay reliability.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)