### PR TITLE
fix: Populate interaction type for user interactions

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventMapper.swift
@@ -113,6 +113,10 @@ internal enum TxnEventMapper {
             for (key, value) in objectData { data[key] = .string(value) }
         }
 
+        if eventType == .SignalUserInteraction, let action = objectData?["action"] {
+            data["interactionType"] = .string(action)
+        }
+
         // Written last so these win over any colliding partner attribute.
         data["parent_id"] = .string(parentGuid)
         data["token"] = .string(token)

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventMapper.swift
@@ -57,10 +57,32 @@ final class TestTxnEventMapper: XCTestCase {
     }
 
     func test_activation_mapsToUserInteractionWithType() {
-        let event = TxnEventMapper.event(from: makeRequest(eventType: .SignalActivation))
+        let event = TxnEventMapper.event(from: makeRequest(
+            eventType: .SignalActivation,
+            objectData: [
+                "action": "MainImageScrollIconRightClick",
+                "interactionType": "stale"
+            ]
+        ))
 
         XCTAssertEqual(event?.eventType, "user_interaction")
         XCTAssertEqual(event?.data?["interactionType"], .string("activation"))
+    }
+
+    func test_userInteraction_mirrorsActionToInteractionType() {
+        let event = TxnEventMapper.event(from: makeRequest(
+            eventType: .SignalUserInteraction,
+            objectData: [
+                "action": "MainImageScrollIconRightClick",
+                "context": "CatalogImageGallery",
+                "interactionType": "stale"
+            ]
+        ))
+
+        XCTAssertEqual(event?.eventType, "user_interaction")
+        XCTAssertEqual(event?.data?["action"], .string("MainImageScrollIconRightClick"))
+        XCTAssertEqual(event?.data?["context"], .string("CatalogImageGallery"))
+        XCTAssertEqual(event?.data?["interactionType"], .string("MainImageScrollIconRightClick"))
     }
 
     func test_diagnostic_isDropped() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Specific user interactions retain their `action` and `context` in v2 event data, but do not populate the canonical `interactionType` field expected by downstream event consumers. This restores the interaction classification while preserving the existing payload fields.

## What Has Changed

- Mirror `SignalUserInteraction` actions into `interactionType`.
- Preserve the existing flattened `action` and `context` fields.
- Keep the explicit `SignalActivation` value authoritative.
- Add regression coverage for user-interaction and activation precedence.

## How Has This Been Tested

- `trunk check`
- `xcodebuild build -project Example/rokt.xcodeproj -scheme rokt-Example ...`
- `xcodebuild test -scheme Rokt-Widget ...`
- `periphery scan`
- `Tests/SizeReport/measure_size.sh` (4,676 KB measured SDK app-bundle impact)

## Notes

The Example app test host was also attempted on iOS 18.5 and iOS 26.3, but stalled before test execution while loading existing duplicate Stripe runtime classes. The full SDK package test suite passes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.