### PR TITLE
fix(ci): stop UI Tests job stalling to the 25-min timeout

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -227,6 +227,12 @@ jobs:
           xcode-version: "26.3"
 
       - name: Run UI tests
+        # Per-test timeouts bound any single test that hangs on a polling
+        # (`toEventually`) assertion, and we do NOT retry on failure here:
+        # these UI tests use long polling waits, so retrying every failure up
+        # to 3x turns a fast failing run (~6 min) into a >25 min job that GitHub
+        # kills as "cancelled" with no result bundle and broken coverage. Failing
+        # fast surfaces a real .xcresult and failure list instead of a timeout.
         run: |
           xcodebuild test \
             -project Example/rokt.xcodeproj \
@@ -235,7 +241,9 @@ jobs:
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
-            -retry-tests-on-failure
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 60 \
+            -maximum-test-execution-time-allowance 120
 
       - name: Install xcresultparser
         if: always()


### PR DESCRIPTION
## Problem

The **UI Tests** job hits its 25-minute `timeout-minutes` cap on every PR and every push to `main`, and is killed as `cancelled` — with **no `.xcresult` artifact and a failing coverage step**, so it produces no usable signal. This has been happening on every run since the v2 transactions merge ([#255](https://github.com/ROKT/rokt-sdk-ios/pull/255)); UI Tests last completed green on 2026-07-08 (~5.5 min).

## Root cause

Two things compound:

1. **Deterministic test failures** — several MOCK UI tests (`ValidLayoutEmbedded`, `ValidLayoutBottomSheetTests`, `RoktExperienceCacheExecuteTests`) now fail because captured events come back `nil`/`0`. Each failing test burns its **full `toEventually` polling budget** (10–134 s per run).
2. **`-retry-tests-on-failure`** re-runs every failing test **up to 3×**. Across 15+ failing tests, a suite that runs green in ~5.5 min balloons well past 25 min, so GitHub terminates the job before `xcodebuild` can emit a result.

Net effect: 25 min of `macos-latest-xlarge` runner time wasted per run, no failure list, broken coverage upload.

## Fix (scoped to the `ui-test` job only)

- **Drop `-retry-tests-on-failure`.** Retrying deterministic failures 3× adds no value and is the primary stall multiplier. The unit-test and package-test jobs keep their retry behaviour.
- **Add per-test timeouts:** `-test-timeouts-enabled YES` with `-default-test-execution-time-allowance 60` / `-maximum-test-execution-time-allowance 120`, so no single test can hang the job.

**Effect:** the job now fails fast (~6 min) with a real `.xcresult` and an actionable failure list instead of an opaque 25-min timeout, and releases the xlarge runner far sooner.

## Out of scope / follow-up

This does **not** fix the underlying test failures introduced by #255 (events not captured in the MOCK example app). That is a separate SDK/test-harness fix. This PR's goal is solely to stop the stall and restore a fast, useful CI signal.

## Validation

- YAML validated (`ruby -ryaml`).
- All flags are standard `xcodebuild` options (Xcode 26.3): `-test-timeouts-enabled`, `-default-test-execution-time-allowance`, `-maximum-test-execution-time-allowance`.
- Expected result on this PR: **UI Tests goes red quickly** (surfacing the #255 failures) rather than timing out — that is the intended, improved behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)