### PR TITLE
fix: restore MOCK UI tests (fail-fast job + network wiring + per-execute event de-dup)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -227,6 +227,12 @@ jobs:
           xcode-version: "26.3"
 
       - name: Run UI tests
+        # Per-test timeouts bound any single test that hangs on a polling
+        # (`toEventually`) assertion, and we do NOT retry on failure here:
+        # these UI tests use long polling waits, so retrying every failure up
+        # to 3x turns a fast failing run (~6 min) into a >25 min job that GitHub
+        # kills as "cancelled" with no result bundle and broken coverage. Failing
+        # fast surfaces a real .xcresult and failure list instead of a timeout.
         run: |
           xcodebuild test \
             -project Example/rokt.xcodeproj \
@@ -235,7 +241,9 @@ jobs:
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath UiTestResult.xcresult \
-            -retry-tests-on-failure
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 60 \
+            -maximum-test-execution-time-allowance 120
 
       - name: Install xcresultparser
         if: always()

--- a/Example/Tests/NetworkMock/MockResponse.swift
+++ b/Example/Tests/NetworkMock/MockResponse.swift
@@ -16,6 +16,20 @@ var txnEventResourceURL: String {
     config.environment.gatewayBaseURL + "/v2/sessions/events"
 }
 
+// The UI test harness drives the SDK through Mocker-intercepted network calls. In the
+// `.Mock` environment the SDK swaps in offline transports (init/offers/events) that never
+// touch the network, and diagnostics/timings short-circuit via `RoktAPIHelper.isMock()` —
+// so none of the registered stubs would fire and nothing would render or be captured.
+// Pin a networked environment so every call flows through the stubbed URLs. Both the stub
+// URLs and the SDK's request URLs derive from `config.environment`, so they stay in lockstep.
+//
+// Also clear mocks left over from a previous spec (mocks are global to the process) so each
+// spec starts from its own freshly-registered stubs rather than an earlier spec's.
+func useNetworkedMockEnvironment() {
+    config.environment = .Prod
+    Mocker.removeAll()
+}
+
 // Reverse of TxnEventMapper's vocabulary so the v2 events stub can surface legacy EventModel names.
 let txnEventTypeToLegacyName: [String: String] = [
     "impression": "SignalImpression",
@@ -189,7 +203,10 @@ extension StubMethodsProvider {
     func registerTxnInitStub(legacyData: Data?, statusCode: Int) {
         guard let url = URL(string: txnInitResourceURL) else { return }
         let v2Data = legacyData.flatMap(makeTxnInitData(fromLegacy:)) ?? Data()
-        Mock(url: url, dataType: .json, statusCode: statusCode, data: [.post: v2Data]).register()
+        // The v2 init endpoint is a GET (see TxnInitClient), so the mock must be
+        // registered for .get — a .post mock never matches and the request falls
+        // through to the real network.
+        Mock(url: url, dataType: .json, statusCode: statusCode, data: [.get: v2Data]).register()
     }
 
     // Mirrors the legacy events stub for the v2 endpoint, translating the wire shape back into EventModel
@@ -217,6 +234,7 @@ extension StubMethodsProvider {
     }
 
     func stubInit(fileName: String = validInitFilename) {
+        useNetworkedMockEnvironment()
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self] + (configuration.protocolClasses ?? [])
         NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
@@ -231,6 +249,7 @@ extension StubMethodsProvider {
     }
 
     func stubInit(_ widgetFileName: String) {
+        useNetworkedMockEnvironment()
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self] + (configuration.protocolClasses ?? [])
         NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
@@ -355,6 +374,7 @@ extension XCTestCase: StubMethodsProvider {
     }
 
     func stubInit(fileName: String = validInitFilename) {
+        useNetworkedMockEnvironment()
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self] + (configuration.protocolClasses ?? [])
         NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
@@ -370,6 +390,7 @@ extension XCTestCase: StubMethodsProvider {
     }
 
     func stubInit(_ widgetFileName: String) {
+        useNetworkedMockEnvironment()
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self] + (configuration.protocolClasses ?? [])
         NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1264,6 +1264,13 @@ class RoktInternalImplementation {
             return LayoutPageExecutePayload(pageModel: pageModel,
                                             cacheProperties: cacheProperties)
         } else {
+            // No cache: scope event de-duplication to this execute. The cache branch above
+            // seeds `sentEventHashes` per view; without a reset here the set is only ever
+            // (re)initialised on the cache path, so for non-cached executes it accumulates
+            // hashes for the whole process lifetime — growing unbounded and, when an event
+            // hash repeats across executes (e.g. a reused session id), silently dropping
+            // events that were already "sent" by an earlier, unrelated execute.
+            sentEventHashes = ThreadSafeSet()
             return LayoutPageExecutePayload(pageModel: pageModel,
                                             cacheProperties: nil)
         }


### PR DESCRIPTION
Restores the Example MOCK UI tests, which had been failing/stalling since the v2 transactions merge ([#255](https://github.com/ROKT/rokt-sdk-ios/pull/255)). Three related fixes; the full Example UI suite now passes **40/40 locally in ~87s** (previously stalled to the 25-min CI timeout). Supersedes #263.

## 1. CI: stop the UI Tests job stalling to the 25-min timeout (`pull-request.yml`)
Failing tests each burned their full `toEventually` budget and `-retry-tests-on-failure` re-ran every failure 3×, pushing the job past its 25-min cap so it was killed as `cancelled` with no `.xcresult`. Drop `-retry-tests-on-failure` for the ui-test job and add `-test-timeouts-enabled YES` (60s default / 120s max per test). The job now fails fast with a real result instead of an opaque timeout. (unit/package jobs keep their retry.)

## 2. Test harness: route MOCK UI tests through the intercepted network path (`MockResponse.swift`)
The tests drive the SDK via `Mocker`-intercepted stubs, but #255 made `.Mock` swap in offline transports (init/offers/events) that never hit the network, and the v2 init endpoint is a **`GET`** while the init stub registered `.post`. Pin `config.environment = .Prod` in the stub setup (bypassing the offline swap; stub + request URLs both derive from `config.environment`), register the init stub for `.get`, and clear leftover `Mocker` state per spec. The `.Mock` offline transports remain intact for the interactive demo app.

## 3. Product: reset event de-dup hashes per execute on the non-cache path (`RoktInternalImplementation.swift`)
`sentEventHashes` (a process-global set on the shared implementation) gates event sending — an event whose hash is already present is dropped as a duplicate. It was only ever reset inside the cache-enabled branch, so on the **non-cache** path it accumulated for the whole app-process lifetime: unbounded growth, and — when an event hash repeats across executes (same type + parent/page guid + **session id**) — later events silently dropped as "already sent" by an earlier, unrelated execute.

Latent in production (real sessions have distinct session ids → distinct hashes), but it broke the UI tests hard: the mock init returns a **fixed** session id and several specs reuse the same layout fixture, so once one spec sent its events, later specs in the same process had all their events de-duplicated away — captured `events` stayed empty and `*_with_events` assertions timed out. (Each spec passed in isolation; only combinations failed.) Fix: reset `sentEventHashes` to empty on the non-cache branch, scoping de-dup to the current execute (the analogue of the cache path's per-view seeding). Within-execute duplicate suppression is unchanged.

> Note: the cross-class failure was initially suspected to be in `RoktUXHelper`, but runtime probing confirmed `RoktUXHelper` delivers platform events correctly across executes — the bug was entirely msdk-side (#3 above). **No `RoktUXHelper` change is needed.**

## Verification
Full Example UI suite (`rokt-Example-MOCK`, all classes together): **40 tests, 0 failures, ~87s.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)