### PR TITLE
fix: send partner app version on v2/init request

### DIFF
--- a/Sources/Rokt_Widget/Networking/TxnInitClient.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitClient.swift
@@ -5,17 +5,20 @@ internal struct TxnInitClient {
     let accountId: String
     let sdkVersion: String
     let httpClient: HTTPClientAdapter
+    let deviceHeaders: [String: String]
 
     init(
         baseURL: URL,
         accountId: String,
         sdkVersion: String,
-        httpClient: HTTPClientAdapter = RoktHTTPClient()
+        httpClient: HTTPClientAdapter = RoktHTTPClient(),
+        deviceHeaders: [String: String] = [:]
     ) {
         self.baseURL = baseURL
         self.accountId = accountId
         self.sdkVersion = sdkVersion
         self.httpClient = httpClient
+        self.deviceHeaders = deviceHeaders
     }
 
     /// Fetches init config (headers only, no session in the response).
@@ -27,13 +30,15 @@ internal struct TxnInitClient {
             .appendingPathComponent("v2")
             .appendingPathComponent("init")
 
-        let headers: RoktHTTPHeaders = [
-            "rokt-account-id": accountId,
-            "rokt-os-type": operating_system,
-            "rokt-sdk-version": sdkVersion,
-            "rokt-layout-schema-version": layout_schema_version,
-            "x-request-id": UUID().uuidString
-        ]
+        // Device/app context headers (incl. rokt-package-name / rokt-package-version)
+        // ride in via NetworkingHelper.txnDeviceHeaders, matching offers/events. The
+        // explicit init headers below take precedence for any shared key.
+        var headers: RoktHTTPHeaders = deviceHeaders
+        headers["rokt-account-id"] = accountId
+        headers["rokt-os-type"] = operating_system
+        headers["rokt-sdk-version"] = sdkVersion
+        headers["rokt-layout-schema-version"] = layout_schema_version
+        headers["x-request-id"] = UUID().uuidString
 
         return try await withCheckedThrowingContinuation { continuation in
             httpClient.startRequestWith(

--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -17,6 +17,7 @@ internal struct TxnInitService {
     let sdkVersion: String
     let layoutSchemaVersion: String
     let httpClient: HTTPClientAdapter
+    let deviceHeaders: [String: String]
     let maxRetries: Int
     let requestTimeout: TimeInterval
     let baseBackoff: TimeInterval
@@ -28,6 +29,7 @@ internal struct TxnInitService {
         sdkVersion: String,
         layoutSchemaVersion: String,
         httpClient: HTTPClientAdapter = RoktHTTPClient(),
+        deviceHeaders: [String: String] = [:],
         maxRetries: Int = 3,
         requestTimeout: TimeInterval = 7,
         baseBackoff: TimeInterval = 0.2,
@@ -40,6 +42,7 @@ internal struct TxnInitService {
         self.sdkVersion = sdkVersion
         self.layoutSchemaVersion = layoutSchemaVersion
         self.httpClient = httpClient
+        self.deviceHeaders = deviceHeaders
         self.maxRetries = maxRetries
         self.requestTimeout = requestTimeout
         self.baseBackoff = baseBackoff
@@ -57,7 +60,8 @@ internal struct TxnInitService {
             baseURL: baseURL,
             accountId: accountId,
             sdkVersion: sdkVersion,
-            httpClient: httpClient
+            httpClient: httpClient,
+            deviceHeaders: deviceHeaders
         )
 
         var attempt = 0

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -939,7 +939,8 @@ class RoktInternalImplementation {
             accountId: roktTagId,
             sdkVersion: libraryVersion,
             layoutSchemaVersion: Self.txnLayoutSchemaVersion,
-            httpClient: httpClient
+            httpClient: httpClient,
+            deviceHeaders: NetworkingHelper.txnDeviceHeaders()
         )
     }
 


### PR DESCRIPTION
## Background
On `main`, the v2 offers (`/v2/sessions/offers`) and events (`/v2/sessions/events`) calls already merge `NetworkingHelper.txnDeviceHeaders()`, so they send `rokt-package-version` (partner app version) and `rokt-package-name`. The **`v2/init` preflight (`TxnInitClient`)** built a bare header literal and omitted the device headers — so partner app version was not captured on init.

This is the client-side gap raised by @jamesnrokt on ROKT/transactions#2623 (adds `sdk_version` + `operating_system` tags): "we were previously capturing partner App version too?". Backend is already ready — the gateway maps `rokt-package-version` → `rokt.nativemobile.package_version`, and the `package_version_derive` enrichment rule lifts it to `enriched.device.package_version`. No transactions change is needed.

## What changed
- Thread `deviceHeaders` through `TxnInitService` → `TxnInitClient` (default `[:]` so existing callers/tests are unaffected).
- `TxnInitClient.initSession` merges `deviceHeaders` first, then applies the explicit init headers so shared keys (e.g. `rokt-os-type`) keep their existing values.
- The DI site (`RoktInternalImplementation.defaultTxnInitService`) passes `NetworkingHelper.txnDeviceHeaders()` — same source offers/events use.

Net: `/v2/init` now sends `rokt-package-name` + `rokt-package-version`, matching offers/events. Android already sends these on all `v2/sessions/*` via its txn `HeadersInterceptor`.

## E2E verification
Built `rokt-Example` on iPhone 16 Pro (iOS 18.5), env = Prod, drove Initialize → Pay (`MSDKOverlayLayout`). Captured outbound requests:

```
init   url=https://apps.rokt.com/v2/init            pkg-version=4.0.0 pkg-name=com.rokt.ios-example
offers url=https://apps.rokt.com/v2/sessions/offers pkg-version=4.0.0 pkg-name=com.rokt.ios-example
```

`/v2/init` now carries the package headers, and the placement overlay renders (no regression).

## Notes
- Draft: unit tests for the init header assembly still to add.
- Android needs no change (already sends both on v2). Heads-up: the in-flight Android v2 refactor branch (`determined-black-440b55`) uses a `RoktHeadersNetworkInterceptor` that only adds `rokt-package-name` — worth confirming it doesn't drop `rokt-package-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)