### PR TITLE
test(pact): assert partner app headers on txn endpoints

### DIFF
--- a/Tests/ContractTests/OffersClientPactSpec.swift
+++ b/Tests/ContractTests/OffersClientPactSpec.swift
@@ -27,9 +27,14 @@ import PactSwift
 /// Per-runtime values (account id, auth token, request id, page identifier,
 /// etc.) stay as `SomethingLike` because they legitimately vary per call.
 /// Device headers from `NetworkingHelper.txnDeviceHeaders` are sent on the live
-/// request; only `rokt-package-name` (it gates page detection) is asserted here,
-/// supplied via `deviceHeaders` below.
+/// request; `rokt-package-name` (it gates page detection) and `rokt-package-version`
+/// are asserted here, supplied via `deviceHeaders` below.
 class OffersClientPactSpec: XCTestCase {
+    private static let pactDeviceHeaders = [
+        "rokt-package-name": "com.rokt.example",
+        "rokt-package-version": "4.0.0"
+    ]
+
     static var mockService: MockService!
 
     override class func setUp() {
@@ -61,6 +66,7 @@ class OffersClientPactSpec: XCTestCase {
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
                     "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    "rokt-package-version": Matcher.SomethingLike("4.0.0"),
                     // Pins the layout-schema-version negotiation: the provider must receive the
                     // version the client can render, else it serves an unparseable legacy layout.
                     "rokt-layout-schema-version": Matcher.SomethingLike("2.8"),
@@ -132,7 +138,7 @@ class OffersClientPactSpec: XCTestCase {
                         sdkVersion: "5.2.2",
                         layoutSchemaVersion: "2.8",
                         pageInstanceGuid: "page-instance-guid-123",
-                        deviceHeaders: ["rokt-package-name": "com.rokt.example"]
+                        deviceHeaders: Self.pactDeviceHeaders
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",
@@ -172,6 +178,7 @@ class OffersClientPactSpec: XCTestCase {
                     "x-request-id": Matcher.SomethingLike("request-id-123"),
                     "rokt-page-instance-guid": Matcher.SomethingLike("page-instance-guid-123"),
                     "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    "rokt-package-version": Matcher.SomethingLike("4.0.0"),
                     // Pins the layout-schema-version negotiation: the provider must receive the
                     // version the client can render, else it serves an unparseable legacy layout.
                     "rokt-layout-schema-version": Matcher.SomethingLike("2.8"),
@@ -233,7 +240,7 @@ class OffersClientPactSpec: XCTestCase {
                         sdkVersion: "5.2.2",
                         layoutSchemaVersion: "2.8",
                         pageInstanceGuid: "page-instance-guid-123",
-                        deviceHeaders: ["rokt-package-name": "com.rokt.example"]
+                        deviceHeaders: Self.pactDeviceHeaders
                     )
                     let input = OffersInput(
                         requestId: "request-id-123",

--- a/Tests/ContractTests/TxnEventsClientPactSpec.swift
+++ b/Tests/ContractTests/TxnEventsClientPactSpec.swift
@@ -12,7 +12,16 @@ import PactSwift
 /// Mirrors OffersClientPactSpec — see that file's docstring for the
 /// matcher policy (exact-match for hardcoded constants, `SomethingLike`
 /// for per-runtime values).
+///
+/// Device headers from `NetworkingHelper.txnDeviceHeaders` are sent on the live
+/// request; `rokt-package-name` and `rokt-package-version` are asserted here,
+/// supplied via `deviceHeaders` below.
 class TxnEventsClientPactSpec: XCTestCase {
+    private static let pactDeviceHeaders = [
+        "rokt-package-name": "com.rokt.example",
+        "rokt-package-version": "4.0.0"
+    ]
+
     static var mockService: MockService!
 
     override class func setUp() {
@@ -39,6 +48,8 @@ class TxnEventsClientPactSpec: XCTestCase {
                 headers: [
                     "rokt-account-id": Matcher.SomethingLike("account-456"),
                     "Authorization": Matcher.SomethingLike("Bearer session-token-abc"),
+                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    "rokt-package-version": Matcher.SomethingLike("4.0.0"),
                     "Content-Type": "application/json"
                 ],
                 body: [
@@ -91,7 +102,8 @@ class TxnEventsClientPactSpec: XCTestCase {
                     let client = TxnEventsClient(
                         baseURL: url,
                         accountId: "account-456",
-                        sdkVersion: "5.2.2"
+                        sdkVersion: "5.2.2",
+                        deviceHeaders: Self.pactDeviceHeaders
                     )
                     let event = TxnEvent(
                         eventType: "impression",

--- a/Tests/ContractTests/TxnInitClientPactSpec.swift
+++ b/Tests/ContractTests/TxnInitClientPactSpec.swift
@@ -3,7 +3,15 @@ import PactSwift
 @testable import Rokt_Widget
 
 /// Consumer-driven pact spec for the config-only `GET /v2/init`.
+///
+/// Device headers from `NetworkingHelper.txnDeviceHeaders` are sent in production;
+/// `rokt-package-name` and `rokt-package-version` are asserted here and supplied
+/// via `deviceHeaders` below because they are load-bearing for backend enrichment.
 class TxnInitClientPactSpec: XCTestCase {
+    private static let pactDeviceHeaders = [
+        "rokt-package-name": "com.rokt.example",
+        "rokt-package-version": "4.0.0"
+    ]
     static var mockService: MockService!
 
     override class func setUp() {
@@ -32,6 +40,8 @@ class TxnInitClientPactSpec: XCTestCase {
                     "rokt-os-type": "ios",
                     "rokt-sdk-version": Matcher.SomethingLike("5.2.2"),
                     "rokt-layout-schema-version": Matcher.SomethingLike("2.1.0"),
+                    "rokt-package-name": Matcher.SomethingLike("com.rokt.example"),
+                    "rokt-package-version": Matcher.SomethingLike("4.0.0"),
                     "x-request-id": Matcher.RegexLike("request-id-123", term: #".+"#)
                 ]
             )
@@ -70,7 +80,8 @@ class TxnInitClientPactSpec: XCTestCase {
                     let client = TxnInitClient(
                         baseURL: url,
                         accountId: "account-456",
-                        sdkVersion: "5.2.2"
+                        sdkVersion: "5.2.2",
+                        deviceHeaders: Self.pactDeviceHeaders
                     )
                     let (_, httpResponse) = try await client.initSession(
                         operating_system: "ios",

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestOffersService.swift
@@ -224,7 +224,8 @@ final class TestOffersService: XCTestCase {
         let stub = StubHTTPClient(responseData: Data(offersResponse.utf8), statusCode: 200)
         let service = makeService(stub, deviceHeaders: [
             "rokt-os-type": "iOS",
-            "rokt-package-name": "com.rokt.test"
+            "rokt-package-name": "com.rokt.test",
+            "rokt-package-version": "1.2.3"
         ])
 
         let completed = expectation(description: "offers experience returned")
@@ -235,9 +236,10 @@ final class TestOffersService: XCTestCase {
         })
 
         wait(for: [completed], timeout: 5)
-        // Device headers (incl. the load-bearing rokt-package-name) reach the request.
+        // Device headers (incl. partner app identity) reach the request.
         XCTAssertEqual(stub.lastHeaders?["rokt-os-type"], "iOS")
         XCTAssertEqual(stub.lastHeaders?["rokt-package-name"], "com.rokt.test")
+        XCTAssertEqual(stub.lastHeaders?["rokt-package-version"], "1.2.3")
         // rokt-txn-shadow is no longer sent; mobile shadow routing is session-id-shape driven.
         XCTAssertNil(stub.lastHeaders?["rokt-txn-shadow"])
     }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnEventService.swift
@@ -78,11 +78,17 @@ final class TestTxnEventService: XCTestCase {
         await storeValidToken()
         httpClient.results = [.success(status: 202, data: rotatedResponse())]
 
-        try await makeService().send(events: sampleEvents())
+        try await makeService(deviceHeaders: [
+            "rokt-os-type": "iOS",
+            "rokt-package-name": "com.rokt.test",
+            "rokt-package-version": "1.2.3"
+        ]).send(events: sampleEvents())
 
         XCTAssertEqual(httpClient.capturedHeaders.first?["Authorization"], "Bearer stored-jwt")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-account-id"], "account-1")
         XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-os-type"], "iOS")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-package-name"], "com.rokt.test")
+        XCTAssertEqual(httpClient.capturedHeaders.first?["rokt-package-version"], "1.2.3")
         XCTAssertNil(httpClient.capturedHeaders.first?["rokt-txn-shadow"])
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestTxnInitService.swift
@@ -15,13 +15,18 @@ final class TestTxnInitService: XCTestCase {
         super.tearDown()
     }
 
-    private func makeService(environment: Environment = .Prod, maxRetries: Int = 3) -> TxnInitService {
+    private func makeService(
+        environment: Environment = .Prod,
+        maxRetries: Int = 3,
+        deviceHeaders: [String: String] = [:]
+    ) -> TxnInitService {
         TxnInitService(
             environment: environment,
             accountId: "account-1",
             sdkVersion: "5.2.2",
             layoutSchemaVersion: "2.3",
             httpClient: httpClient,
+            deviceHeaders: deviceHeaders,
             maxRetries: maxRetries,
             baseBackoff: 0,
             sleep: { _ in }
@@ -67,6 +72,21 @@ final class TestTxnInitService: XCTestCase {
         XCTAssertEqual(headers?["rokt-layout-schema-version"], "2.3")
         // Never send Authorization.
         XCTAssertNil(headers?["Authorization"])
+    }
+
+    func test_initSession_forwardsDeviceHeaders() async throws {
+        httpClient.results = [.success(data: successJSON())]
+
+        _ = try await makeService(deviceHeaders: [
+            "rokt-package-name": "com.rokt.test",
+            "rokt-package-version": "1.2.3"
+        ]).initSession()
+
+        let headers = httpClient.capturedHeaders.first
+        XCTAssertEqual(headers?["rokt-package-name"], "com.rokt.test")
+        XCTAssertEqual(headers?["rokt-package-version"], "1.2.3")
+        // Explicit init headers still win on shared keys.
+        XCTAssertEqual(headers?["rokt-os-type"], "ios")
     }
 
     func test_initSession_retriesOnTransient5xx_thenSucceeds() async throws {


### PR DESCRIPTION
## Summary
- Add `rokt-package-name` and `rokt-package-version` to consumer pact contracts for `/v2/init`, `/v2/sessions/offers`, and `/v2/sessions/events`
- Inject `deviceHeaders` in pact specs so the mock server validates the same wire shape production sends via `NetworkingHelper.txnDeviceHeaders()`
- Extend init, offers, and events unit tests to assert partner app headers are forwarded on the request

## Context
PR #265 wired partner app version headers onto `/v2/init`, but the pact contract still described the old header set. Offers already asserted `rokt-package-name` but not `rokt-package-version`; events asserted neither. This aligns all three txn endpoint contracts with production behavior.

## Test plan
- [x] `TxnInitClientPactSpec` passes
- [x] `OffersClientPactSpec` passes (both interactions)
- [x] `TxnEventsClientPactSpec` passes
- [x] `TestTxnInitService.test_initSession_forwardsDeviceHeaders` passes
- [x] `TestOffersService.test_getExperienceData_forwardsDeviceHeaders` passes
- [x] `TestTxnEventService.test_send_withValidToken_attachesAuthorizationAndDeviceHeaders` passes
- [ ] Pact consumer CI publishes updated contract to broker
- [ ] Provider re-verifies against new `rokt-package-version` header expectation


Made with [Cursor](https://cursor.com)