### PR TITLE
refactor(fonts): isolate font download batch state in an actor

### DIFF
--- a/Sources/Rokt_Widget/Networking/HTTPClient/RoktHTTPClient.swift
+++ b/Sources/Rokt_Widget/Networking/HTTPClient/RoktHTTPClient.swift
@@ -70,16 +70,40 @@ internal final class RoktHTTPClient: HTTPClientAdapter {
     private(set) var downloadSession: URLSession = .shared
     private(set) var encoders: [RoktHTTPParameterEncoder] = []
 
+    /// Ceiling on an entire download, as opposed to the per-request budget, which only has to
+    /// cover idle time. Deliberately far larger than the API client timeout: it exists to stop
+    /// a pathological trickle running forever, not to bound a healthy transfer.
+    static let downloadResourceTimeout: TimeInterval = 300
+
     init(
         sessionConfiguration: URLSessionConfiguration = .default,
         encoders: [RoktHTTPParameterEncoder] = [RoktHTTPURLEncoder(), RoktHTTPBodyEncoder()]
     ) {
         self.session = URLSession(configuration: sessionConfiguration)
-        self.downloadSession = URLSession(configuration: sessionConfiguration)
+        self.downloadSession = URLSession(
+            configuration: Self.downloadConfiguration(from: sessionConfiguration)
+        )
 
         self.encoders = encoders
     }
 
+    /// `timeoutIntervalForResource` caps a whole transfer rather than idle time, so applying
+    /// the API client timeout to it cancels any download that cannot finish inside that
+    /// budget no matter how healthy the connection is. Font files are orders of magnitude
+    /// larger than API payloads, so downloads get their own session and are bounded by the
+    /// per-request idle timeout instead. Derived from the caller's configuration so injected
+    /// protocol classes still apply.
+    private static func downloadConfiguration(
+        from configuration: URLSessionConfiguration
+    ) -> URLSessionConfiguration {
+        let downloadConfiguration = (configuration.copy() as? URLSessionConfiguration) ?? configuration
+        downloadConfiguration.timeoutIntervalForResource = downloadResourceTimeout
+
+        return downloadConfiguration
+    }
+
+    /// Applies to API requests only. Downloads keep their own budget, since the client timeout
+    /// is sized for small JSON payloads and would cancel large files mid-transfer.
     func updateTimeout(timeout: Double) {
         let currentConfiguration = session.configuration
 
@@ -272,7 +296,7 @@ extension RoktHTTPClient {
             return
         }
 
-        session.downloadTask(with: downloadRequest) { [weak self] temporaryURL, downloadResponse, downloadError in
+        downloadSession.downloadTask(with: downloadRequest) { [weak self] temporaryURL, downloadResponse, downloadError in
             guard let self else { return }
 
             if let downloadError {

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -16,7 +16,7 @@ internal class RoktAPIHelper {
     /// - Parameters:
     ///   - fonts: The fonts that should be downloaded and installed to be used in the widget
     ///   - onFontDownloadComplete - Callback to notify when the font download finishes
-    class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping () -> Void) {
+    class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping @Sendable () -> Void) {
         FontManager.downloadFonts(fonts, onFontDownloadComplete)
     }
 

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -40,14 +40,13 @@ internal class RoktNetWorkAPI {
     /// - Parameters:
     ///   - font: The font file that should be downloaded and installed to be used in the widget
     ///   - destination: URL to the file's intended location on the device
-    ///   - isLastFont: if `true`, sends a local Notification that all fonts have been downloaded
-    ///   - onDownloadComplete: Callback to trigger when the download is complete
+    ///   - onDownloadComplete: Callback to trigger once the download has settled, whether
+    ///     it succeeded or failed. Retries settle only after the final attempt.
     ///   - retryCount: number of times that the download request has been attempted
     class func downloadFont(
         font: FontModel,
         destinationURL: URL,
-        isLastFont: Bool,
-        onDownloadComplete: @escaping ((_ isLastFont: Bool) -> Void),
+        onDownloadComplete: @escaping () -> Void,
         retryCount: Int = 0
     ) {
         NetworkingHelper.shared.downloadFile(
@@ -61,40 +60,35 @@ internal class RoktNetWorkAPI {
                     fontLogId: fullFontLogCode3)
 
                 FontManager.registerFont(font: font, fileUrl: downloadedFileLocalURL, isDownloaded: true)
-                onDownloadComplete(isLastFont)
-            } else if let downloadError = downloadResponse.downloadError {
-                if retryCount < maxRetries && NetworkingHelper.retriableResponse(
-                    error: downloadError,
-                    code: downloadResponse.httpURLResponse?.statusCode) {
+            } else if let downloadError = downloadResponse.downloadError,
+                      retryCount < maxRetries,
+                      NetworkingHelper.retriableResponse(
+                          error: downloadError,
+                          code: downloadResponse.httpURLResponse?.statusCode) {
 
-                    // Log FFL4
-                    FontManager.sendFullFontLogs(
-                        "Retry for font file \(destinationURL) error on download \(downloadError)",
-                        fontLogId: fullFontLogCode4)
+                // Log FFL4
+                FontManager.sendFullFontLogs(
+                    "Retry for font file \(destinationURL) error on download \(downloadError)",
+                    fontLogId: fullFontLogCode4)
 
-                    downloadFont(
-                        font: font,
-                        destinationURL: destinationURL,
-                        isLastFont: isLastFont,
-                        onDownloadComplete: onDownloadComplete,
-                        retryCount: retryCount + 1)
+                downloadFont(
+                    font: font,
+                    destinationURL: destinationURL,
+                    onDownloadComplete: onDownloadComplete,
+                    retryCount: retryCount + 1)
 
-                    return
-                } else {
-                    // Best-effort: mark for diagnostics, don't un-initialise.
-                    Rokt.shared.roktImplementation.isInitFailedForFont = true
-                    let callstack = "\(fontErrorMessage) \(font.url), " +
-                        "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
+                return
+            } else {
+                // Best-effort: mark for diagnostics, don't un-initialise.
+                Rokt.shared.roktImplementation.isInitFailedForFont = true
+                let callstack = "\(fontErrorMessage) \(font.url), " +
+                    "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
 
-                    RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
-                    RoktLogger.shared.verbose(callstack)
-                    onDownloadComplete(isLastFont)
-                }
+                RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
+                RoktLogger.shared.verbose(callstack)
             }
 
-            if isLastFont {
-                NotificationCenter.default.post(Notification(name: Notification.Name(finishedDownloadingFonts)))
-            }
+            onDownloadComplete()
         }
     }
 

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -30,6 +30,7 @@ internal class RoktNetWorkAPI {
     private static let headerTagIdKey = "rokt-tag-id"
     private static let headerSdkFrameworkType = "rokt-sdk-framework-type"
     private static let fontErrorMessage = "Error downloading font: "
+    private static let fontResponseIncompleteMessage = "Font download response missing both error and file: "
     private static let timingsDiagnosticCode = "[TIMINGS]"
     private static let timingsSdkType = "msdk"
     private static let fullFontLogCode3 = "[FFL003]"
@@ -53,43 +54,72 @@ internal class RoktNetWorkAPI {
             source: font.url,
             destinationURL: destinationURL,
             requestTimeout: TimeInterval(exactly: RoktInternalImplementation.defaultFontTimeout)!) { downloadResponse in
-            if downloadResponse.downloadError == nil,
-               let downloadedFileLocalURL = downloadResponse.downloadedFileLocalURL {
-                FontManager.sendFullFontLogs(
-                    "Font downloaded to \(downloadedFileLocalURL)",
-                    fontLogId: fullFontLogCode3)
-
-                FontManager.registerFont(font: font, fileUrl: downloadedFileLocalURL, isDownloaded: true)
-            } else if let downloadError = downloadResponse.downloadError,
-                      retryCount < maxRetries,
-                      NetworkingHelper.retriableResponse(
-                          error: downloadError,
-                          code: downloadResponse.httpURLResponse?.statusCode) {
-
-                // Log FFL4
-                FontManager.sendFullFontLogs(
-                    "Retry for font file \(destinationURL) error on download \(downloadError)",
-                    fontLogId: fullFontLogCode4)
-
-                downloadFont(
-                    font: font,
-                    destinationURL: destinationURL,
-                    onDownloadComplete: onDownloadComplete,
-                    retryCount: retryCount + 1)
-
-                return
-            } else {
-                // Best-effort: mark for diagnostics, don't un-initialise.
-                Rokt.shared.roktImplementation.isInitFailedForFont = true
-                let callstack = "\(fontErrorMessage) \(font.url), " +
-                    "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
-
-                RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
-                RoktLogger.shared.verbose(callstack)
-            }
-
-            onDownloadComplete()
+            handleFontDownloadResponse(
+                font: font,
+                destinationURL: destinationURL,
+                downloadResponse: downloadResponse,
+                onDownloadComplete: onDownloadComplete,
+                retryCount: retryCount)
         }
+    }
+
+    /// Split out of `downloadFont` so each response shape can be driven directly.
+    /// `RoktHTTPClient` is `final` and `downloadFile` only accepts it, so there is no
+    /// other seam for the responses it never produces itself.
+    internal class func handleFontDownloadResponse(
+        font: FontModel,
+        destinationURL: URL,
+        downloadResponse: RoktDownloadResult,
+        onDownloadComplete: @escaping () -> Void,
+        retryCount: Int = 0
+    ) {
+        if downloadResponse.downloadError == nil,
+           let downloadedFileLocalURL = downloadResponse.downloadedFileLocalURL {
+            FontManager.sendFullFontLogs(
+                "Font downloaded to \(downloadedFileLocalURL)",
+                fontLogId: fullFontLogCode3)
+
+            FontManager.registerFont(font: font, fileUrl: downloadedFileLocalURL, isDownloaded: true)
+        } else if let downloadError = downloadResponse.downloadError,
+                  retryCount < maxRetries,
+                  NetworkingHelper.retriableResponse(
+                      error: downloadError,
+                      code: downloadResponse.httpURLResponse?.statusCode) {
+
+            // Log FFL4
+            FontManager.sendFullFontLogs(
+                "Retry for font file \(destinationURL) error on download \(downloadError)",
+                fontLogId: fullFontLogCode4)
+
+            downloadFont(
+                font: font,
+                destinationURL: destinationURL,
+                onDownloadComplete: onDownloadComplete,
+                retryCount: retryCount + 1)
+
+            return
+        } else if downloadResponse.downloadError != nil {
+            // Terminal download failure: not retriable, or the retry budget is spent.
+            // Best-effort: mark for diagnostics, don't un-initialise.
+            Rokt.shared.roktImplementation.isInitFailedForFont = true
+            let callstack = "\(fontErrorMessage) \(font.url), " +
+                "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
+
+            RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
+            RoktLogger.shared.verbose(callstack)
+        } else {
+            // Neither an error nor a file came back, so there is nothing to register and
+            // nothing to retry. Reported on its own line rather than as a download failure
+            // carrying a nil error, which is unreadable next to the real ones.
+            Rokt.shared.roktImplementation.isInitFailedForFont = true
+            let callstack = "\(fontResponseIncompleteMessage)\(font.url), " +
+                "status: \(downloadResponse.httpURLResponse?.statusCode.description ?? "none")"
+
+            RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
+            RoktLogger.shared.verbose(callstack)
+        }
+
+        onDownloadComplete()
     }
 
     /// Rokt diagnostics API call

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -848,6 +848,7 @@ class RoktInternalImplementation {
         self.roktTagId = roktTagId
         sessionManager.storedTagId = roktTagId
         isInitFailedForFont = false
+        FontManager.resetFontRecoveryState()
         stateManager = StateBagManager()
 
         RoktLogger.shared.debug("Starting API initialization request")

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -319,15 +319,22 @@ internal class FontManager {
         }
     }
 
-    /// Removes the cached file and its metadata so `isDownloadingFontRequired` reports
-    /// the font as missing on the next pass.
+    /// Removes the cached file and both metadata records so `isDownloadingFontRequired`
+    /// reports the font as missing on the next pass.
+    ///
+    /// Dropping the detail alone would be enough to trigger a re-download, but it would
+    /// strand the URL entry: `removeFont` reads the detail first and returns early when it
+    /// is absent, so `removeUnusedFonts` could never clean the entry up afterwards. A
+    /// successful re-download re-adds both records.
     internal static func invalidateCachedFont(_ font: FontModel, completion: (() -> Void)? = nil) {
         if let fileUrl = getFileUrl(name: font.postScriptName ?? font.name),
            FileManager.default.fileExists(atPath: fileUrl.path) {
             try? FileManager.default.removeItem(at: fileUrl)
         }
 
-        FontRepository.removeFontDetail(key: font.url) { completion?() }
+        FontRepository.removeFontDetail(key: font.url) {
+            FontRepository.removeFontUrl(key: font.url) { completion?() }
+        }
     }
 
     #if DEBUG

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -9,7 +9,6 @@ internal class FontManager {
     static let downloadingFonts = "downloadingFonts"
     private static let fullFontLogDiagnosticCode = "[FULLFONTLOGS]"
     private static let fullFontLogCode1 = "[FFL001]"
-    private static let fullFontLogCode2 = "[FFL002]"
     private static let fullFontLogCode5 = "[FFL005]"
     private static let fullFontLogCode6 = "[FFL006]"
     private static let fullFontLogCode7 = "[FFL007]"
@@ -64,76 +63,53 @@ internal class FontManager {
 
     class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping () -> Void) {
         getExistingFontsByPostScriptName()
-        var fontDownloadInProgress = false
 
-        if !fonts.isEmpty {
-            NotificationCenter.default.post(Notification(name: Notification.Name(downloadingFonts)))
-            var downloadedFonts = 0
-
-            for font in fonts {
-                let registeredFontName = font.postScriptName ?? font.name
-
-                guard !isSystemFont(font: font) else {
-                    // Log FFL001
-                    sendFullFontLogs("Font retrieved from system \(registeredFontName)", fontLogId: fullFontLogCode1)
-                    downloadedFonts += 1
-
-                    if downloadedFonts == fonts.count {
-                        NotificationCenter.default.post(Notification(name:
-                                                                        Notification.Name(finishedDownloadingFonts)))
-                    }
-
-                    continue
-                }
-
-                // additional check if font can be created in local caches directory
-                guard let fileUrl = getFileUrl(name: registeredFontName) else {
-                    // Best-effort: mark for diagnostics, don't un-initialise.
-                    Rokt.shared.roktImplementation.isInitFailedForFont = true
-                    RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
-                                                  callStack: "font: \(font.url), error: FileManager default urls")
-                    RoktLogger.shared.error("Error in font fileManager url for: \(font.url)")
-                    NotificationCenter.default.post(Notification(name:
-                                                                    Notification.Name(finishedDownloadingFonts)))
-                    return
-                }
-
-                if isSystemFont(font: font) {
-                    // Log FFL002
-                    sendFullFontLogs("Font retrieved from system \(registeredFontName)", fontLogId: fullFontLogCode2)
-                    downloadedFonts += 1
-                    if downloadedFonts == fonts.count {
-                        NotificationCenter.default.post(Notification(name:
-                                                                        Notification.Name(finishedDownloadingFonts)))
-                    }
-                } else if FontManager.isDownloadingFontRequired(font: font) {
-                    downloadedFonts += 1
-
-                    fontDownloadInProgress = true
-                    RoktNetWorkAPI.downloadFont(
-                        font: font,
-                        destinationURL: fileUrl,
-                        isLastFont: downloadedFonts == fonts.count
-                    ) { isLastFont in
-                        if isLastFont {
-                            onFontDownloadComplete()
-                        }
-                    }
-                } else {
-                    registerFont(font: font, fileUrl: fileUrl)
-                    downloadedFonts += 1
-                    if downloadedFonts == fonts.count {
-                        NotificationCenter.default.post(Notification(name:
-                                                                        Notification.Name(finishedDownloadingFonts)))
-                    }
-                }
-            }
+        guard !fonts.isEmpty else {
+            onFontDownloadComplete()
+            return
         }
 
-        if !fontDownloadInProgress {
+        NotificationCenter.default.post(Notification(name: Notification.Name(downloadingFonts)))
+
+        // Each font settles exactly once, whether it was downloaded, loaded from cache,
+        // skipped as a system font, or failed outright. Completion is driven by that
+        // count so it can never depend on a font's position in `fonts`.
+        let batch = FontDownloadBatch(expected: fonts.count) {
+            getExistingFontsByPostScriptName()
+            NotificationCenter.default.post(Notification(name: Notification.Name(finishedDownloadingFonts)))
             onFontDownloadComplete()
         }
-        getExistingFontsByPostScriptName()
+
+        for font in fonts {
+            let registeredFontName = font.postScriptName ?? font.name
+
+            guard !isSystemFont(font: font) else {
+                // Log FFL001
+                sendFullFontLogs("Font retrieved from system \(registeredFontName)", fontLogId: fullFontLogCode1)
+                batch.settle()
+                continue
+            }
+
+            // additional check if font can be created in local caches directory
+            guard let fileUrl = getFileUrl(name: registeredFontName) else {
+                // Best-effort: mark for diagnostics, don't un-initialise.
+                Rokt.shared.roktImplementation.isInitFailedForFont = true
+                RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
+                                              callStack: "font: \(font.url), error: FileManager default urls")
+                RoktLogger.shared.error("Error in font fileManager url for: \(font.url)")
+                batch.settle()
+                continue
+            }
+
+            if FontManager.isDownloadingFontRequired(font: font) {
+                RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {
+                    batch.settle()
+                }
+            } else {
+                registerFont(font: font, fileUrl: fileUrl)
+                batch.settle()
+            }
+        }
     }
 
     class func registerFont(font: FontModel, fileUrl: URL, isDownloaded: Bool = false) {
@@ -154,20 +130,41 @@ internal class FontManager {
                 if isDownloaded {
                     saveFontDetails(font: font)
                 }
+
+                clearRecoveryState(for: font)
             } else {
-                // Best-effort: mark for diagnostics, don't un-initialise.
-                Rokt.shared.roktImplementation.isInitFailedForFont = true
-                RoktLogger.shared.error("Error registering font on device: \(font.url)")
-                RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
-                                              callStack: "font: \(font.url), error: registering font on device")
+                handleRegistrationFailure(font: font,
+                                          isDownloaded: isDownloaded,
+                                          reason: "registering font on device",
+                                          logMessage: "Error registering font on device: \(font.url)")
             }
         } else {
-            // Best-effort: mark for diagnostics, don't un-initialise.
-            Rokt.shared.roktImplementation.isInitFailedForFont = true
-            RoktLogger.shared.error("Error reading font data: \(font.url)")
-            RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
-                                          callStack: "font: \(font.url), error: reading font data")
+            handleRegistrationFailure(font: font,
+                                      isDownloaded: isDownloaded,
+                                      reason: "reading font data",
+                                      logMessage: "Error reading font data: \(font.url)")
         }
+    }
+
+    private static func handleRegistrationFailure(font: FontModel,
+                                                  isDownloaded: Bool,
+                                                  reason: String,
+                                                  logMessage: String) {
+        // Best-effort: mark for diagnostics, don't un-initialise.
+        Rokt.shared.roktImplementation.isInitFailedForFont = true
+        RoktLogger.shared.error(logMessage)
+        RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
+                                      callStack: "font: \(font.url), error: \(reason)")
+
+        // A file that has just been fetched and still will not register points at the
+        // asset rather than the cache, so re-fetching it would fail the same way. Drop
+        // it anyway so a poisoned file is not left behind for the next launch to read.
+        guard !isDownloaded else {
+            invalidateCachedFont(font)
+            return
+        }
+
+        recoverCachedFont(font, reason: reason)
     }
 
     internal static func registerGraphicFont(cgFont: CGFont, fontUrlString: String, logLoadType: String) {
@@ -271,6 +268,68 @@ internal class FontManager {
         }
     }
 
+    // MARK: - Cache recovery
+
+    /// Fonts live in `Library/Caches`, which the OS may purge at any time, and a purge
+    /// can leave a partially written file behind. Because `isDownloadingFontRequired`
+    /// treats any present file as usable, an unreadable one would otherwise be re-read
+    /// and re-rejected on every render, pinning the layout to the fallback font for the
+    /// life of the install. Dropping the cache entry lets the next pass re-fetch it.
+    ///
+    /// Attempts are capped per font per process so a permanently bad asset cannot loop,
+    /// and the re-fetch is always asynchronous so it never delays a render.
+    static var maxFontRecoveryAttempts = 2
+    static var fontRecoveryBackoff: DispatchTimeInterval = .seconds(1)
+
+    private static let recoveryLock = NSLock()
+    private static var fontRecoveryAttempts: [String: Int] = [:]
+
+    static func resetFontRecoveryState() {
+        recoveryLock.lock()
+        fontRecoveryAttempts.removeAll()
+        recoveryLock.unlock()
+    }
+
+    private static func clearRecoveryState(for font: FontModel) {
+        recoveryLock.lock()
+        fontRecoveryAttempts[font.url] = nil
+        recoveryLock.unlock()
+    }
+
+    private static func recoverCachedFont(_ font: FontModel, reason: String) {
+        recoveryLock.lock()
+        let attempt = (fontRecoveryAttempts[font.url] ?? 0) + 1
+        fontRecoveryAttempts[font.url] = attempt
+        recoveryLock.unlock()
+
+        guard attempt <= maxFontRecoveryAttempts else {
+            RoktAPIHelper.sendDiagnostics(
+                message: fontDiagnosticCode,
+                callStack: "font: \(font.url), error: font recovery exhausted after " +
+                    "\(maxFontRecoveryAttempts) attempt(s), \(reason)"
+            )
+            return
+        }
+
+        invalidateCachedFont(font)
+
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + fontRecoveryBackoff) {
+            guard let fileUrl = getFileUrl(name: font.postScriptName ?? font.name) else { return }
+            RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {}
+        }
+    }
+
+    /// Removes the cached file and its metadata so `isDownloadingFontRequired` reports
+    /// the font as missing on the next pass.
+    internal static func invalidateCachedFont(_ font: FontModel, completion: (() -> Void)? = nil) {
+        if let fileUrl = getFileUrl(name: font.postScriptName ?? font.name),
+           FileManager.default.fileExists(atPath: fileUrl.path) {
+            try? FileManager.default.removeItem(at: fileUrl)
+        }
+
+        FontRepository.removeFontDetail(key: font.url) { completion?() }
+    }
+
     internal static func getFileUrl(name: String) -> URL? {
         guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
             // Log FFL009
@@ -309,5 +368,33 @@ internal class FontManager {
         RoktAPIHelper.sendDiagnostics(message: fullFontLogDiagnosticCode,
                                       callStack: "\(fontLogId) \(msg)",
                                       severity: .info)
+    }
+}
+
+/// Counts fonts as they settle and fires `onComplete` exactly once, on whichever thread
+/// settles the last one. Fonts settle out of order, so a positional check cannot be used.
+private final class FontDownloadBatch {
+    private let lock = NSLock()
+    private let expected: Int
+    private var settled = 0
+    private var hasCompleted = false
+    private let onComplete: () -> Void
+
+    init(expected: Int, onComplete: @escaping () -> Void) {
+        self.expected = expected
+        self.onComplete = onComplete
+    }
+
+    func settle() {
+        lock.lock()
+        settled += 1
+        let shouldComplete = !hasCompleted && settled >= expected
+        if shouldComplete {
+            hasCompleted = true
+        }
+        lock.unlock()
+
+        guard shouldComplete else { return }
+        onComplete()
     }
 }

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -61,7 +61,7 @@ internal class FontManager {
         completionHandler?()
     }
 
-    class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping () -> Void) {
+    class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping @Sendable () -> Void) {
         getExistingFontsByPostScriptName()
 
         guard !fonts.isEmpty else {
@@ -74,10 +74,13 @@ internal class FontManager {
         // Each font settles exactly once, whether it was downloaded, loaded from cache,
         // skipped as a system font, or failed outright. Completion is driven by that
         // count so it can never depend on a font's position in `fonts`.
-        let batch = FontDownloadBatch(expected: fonts.count) {
-            getExistingFontsByPostScriptName()
-            NotificationCenter.default.post(Notification(name: Notification.Name(finishedDownloadingFonts)))
-            onFontDownloadComplete()
+        let batch = FontDownloadBatch(expected: fonts.count)
+        let settle = {
+            finish(batch) {
+                getExistingFontsByPostScriptName()
+                NotificationCenter.default.post(Notification(name: Notification.Name(finishedDownloadingFonts)))
+                onFontDownloadComplete()
+            }
         }
 
         for font in fonts {
@@ -86,7 +89,7 @@ internal class FontManager {
             guard !isSystemFont(font: font) else {
                 // Log FFL001
                 sendFullFontLogs("Font retrieved from system \(registeredFontName)", fontLogId: fullFontLogCode1)
-                batch.settle()
+                settle()
                 continue
             }
 
@@ -97,18 +100,30 @@ internal class FontManager {
                 RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode,
                                               callStack: "font: \(font.url), error: FileManager default urls")
                 RoktLogger.shared.error("Error in font fileManager url for: \(font.url)")
-                batch.settle()
+                settle()
                 continue
             }
 
             if FontManager.isDownloadingFontRequired(font: font) {
                 RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {
-                    batch.settle()
+                    settle()
                 }
             } else {
                 registerFont(font: font, fileUrl: fileUrl)
-                batch.settle()
+                settle()
             }
+        }
+    }
+
+    /// Settles one font against `batch` and, for whichever call completes it, runs
+    /// `complete` on the main queue. Download callbacks already land there, so keeping the
+    /// batch completion on main leaves `finishedDownloadingFonts` observers where they were
+    /// and keeps the barrier in `getExistingFontsByPostScriptName` off the cooperative pool.
+    private static func finish(_ batch: FontDownloadBatch, then complete: @escaping @Sendable () -> Void) {
+        Task {
+            guard await batch.settle() else { return }
+
+            DispatchQueue.main.async(execute: complete)
         }
     }
 
@@ -131,7 +146,7 @@ internal class FontManager {
                     saveFontDetails(font: font)
                 }
 
-                clearRecoveryState(for: font)
+                recoveryLedger.clear(font.url)
             } else {
                 handleRegistrationFailure(font: font,
                                           isDownloaded: isDownloaded,
@@ -281,26 +296,14 @@ internal class FontManager {
     static var maxFontRecoveryAttempts = 2
     static var fontRecoveryBackoff: DispatchTimeInterval = .seconds(1)
 
-    private static let recoveryLock = NSLock()
-    private static var fontRecoveryAttempts: [String: Int] = [:]
+    private static let recoveryLedger = FontRecoveryLedger()
 
     static func resetFontRecoveryState() {
-        recoveryLock.lock()
-        fontRecoveryAttempts.removeAll()
-        recoveryLock.unlock()
-    }
-
-    private static func clearRecoveryState(for font: FontModel) {
-        recoveryLock.lock()
-        fontRecoveryAttempts[font.url] = nil
-        recoveryLock.unlock()
+        recoveryLedger.reset()
     }
 
     private static func recoverCachedFont(_ font: FontModel, reason: String) {
-        recoveryLock.lock()
-        let attempt = (fontRecoveryAttempts[font.url] ?? 0) + 1
-        fontRecoveryAttempts[font.url] = attempt
-        recoveryLock.unlock()
+        let attempt = recoveryLedger.recordAttempt(for: font.url)
 
         guard attempt <= maxFontRecoveryAttempts else {
             RoktAPIHelper.sendDiagnostics(
@@ -391,30 +394,61 @@ internal class FontManager {
     }
 }
 
-/// Counts fonts as they settle and fires `onComplete` exactly once, on whichever thread
-/// settles the last one. Fonts settle out of order, so a positional check cannot be used.
-private final class FontDownloadBatch {
+/// Per-font recovery budget for the life of the process.
+///
+/// Deliberately synchronous, and so lock-guarded rather than actor-isolated: the budget is
+/// read and written from `registerFont`, which `reRegisterFonts` calls on the render path.
+/// Isolating it would make that path `async` and defer the execute continuation that drives
+/// the cache lookup and presentation. The lock is owned here so no call site handles one.
+private final class FontRecoveryLedger {
     private let lock = NSLock()
+    private var attempts: [String: Int] = [:]
+
+    func reset() {
+        withLock { $0.removeAll() }
+    }
+
+    func clear(_ fontUrl: String) {
+        withLock { $0[fontUrl] = nil }
+    }
+
+    /// Records an attempt for `fontUrl` and returns its 1-based number.
+    func recordAttempt(for fontUrl: String) -> Int {
+        withLock {
+            let attempt = ($0[fontUrl] ?? 0) + 1
+            $0[fontUrl] = attempt
+            return attempt
+        }
+    }
+
+    private func withLock<T>(_ body: (inout [String: Int]) -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&attempts)
+    }
+}
+
+/// Counts fonts as they settle. Fonts settle out of order and from whichever thread their
+/// download callback lands on, so a positional check cannot be used and the count needs
+/// serialising; actor isolation lets the compiler enforce that rather than a hand-held lock.
+private actor FontDownloadBatch {
     private let expected: Int
     private var settled = 0
     private var hasCompleted = false
-    private let onComplete: () -> Void
 
-    init(expected: Int, onComplete: @escaping () -> Void) {
+    init(expected: Int) {
         self.expected = expected
-        self.onComplete = onComplete
     }
 
-    func settle() {
-        lock.lock()
+    /// Records one settled font. Returns `true` for the single call that settles the last
+    /// outstanding font and `false` for every other call, so completion work runs off the
+    /// actor and cannot be triggered twice.
+    func settle() -> Bool {
         settled += 1
-        let shouldComplete = !hasCompleted && settled >= expected
-        if shouldComplete {
-            hasCompleted = true
-        }
-        lock.unlock()
 
-        guard shouldComplete else { return }
-        onComplete()
+        guard !hasCompleted, settled >= expected else { return false }
+
+        hasCompleted = true
+        return true
     }
 }

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -330,7 +330,20 @@ internal class FontManager {
         FontRepository.removeFontDetail(key: font.url) { completion?() }
     }
 
+    #if DEBUG
+    /// `FileManager` always reports a caches directory on a real device, so the
+    /// unresolvable-path branch can only be exercised through this seam. Compiled out of
+    /// release builds so it never ships.
+    internal static var fileUrlResolverOverride: ((String) -> URL?)?
+    #endif
+
     internal static func getFileUrl(name: String) -> URL? {
+        #if DEBUG
+        if let fileUrlResolverOverride {
+            return fileUrlResolverOverride(name)
+        }
+        #endif
+
         guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
             // Log FFL009
             sendFullFontLogs("File Manager failed to read caches directory in user home", fontLogId: fullFontLogCode9)

--- a/Tests/Rokt_WidgetTests/Shared/Mocks/MockResponse.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Mocks/MockResponse.swift
@@ -108,12 +108,20 @@ extension XCTestCase {
         mock.register()
     }
 
-    func stubFontFileUrl(_ fontUrl: String) {
+    func stubFontFileUrl(_ fontUrl: String,
+                         statusCode: Int = 200,
+                         data: Data = Data(),
+                         onRequest: (() -> Void)? = nil) {
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockingURLProtocol.self] + (configuration.protocolClasses ?? [])
         NetworkingHelper.shared.httpClient = RoktHTTPClient(sessionConfiguration: configuration)
 
-        let mock = Mock(url: URL(string: fontUrl)!, dataType: .zip, statusCode: 200, data: [.get: Data()])
+        var mock = Mock(url: URL(string: fontUrl)!, dataType: .zip, statusCode: statusCode, data: [.get: data])
+
+        if let onRequest {
+            mock.onRequest = { _, _ in onRequest() }
+        }
+
         mock.register()
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
@@ -35,6 +35,78 @@ final class RoktHTTPClientTests: XCTestCase {
         XCTAssertEqual(sut.session.configuration.timeoutIntervalForResource, 123, accuracy: 0.1)
     }
 
+    // MARK: - Downloads are not bound by the API client timeout
+
+    func test_updateTimeout_leavesTheDownloadResourceBudgetAlone() {
+        // `timeoutIntervalForResource` bounds a whole transfer, not idle time, so applying the
+        // client timeout to downloads cancels any file too large to arrive inside it. A font of
+        // a few MB on a slow connection cannot, which is what this guards against.
+        let sut = RoktHTTPClient(sessionConfiguration: URLSessionConfiguration.default)
+
+        sut.updateTimeout(timeout: 9)
+
+        XCTAssertEqual(sut.session.configuration.timeoutIntervalForResource, 9, accuracy: 0.1)
+        XCTAssertEqual(sut.downloadSession.configuration.timeoutIntervalForResource,
+                       RoktHTTPClient.downloadResourceTimeout,
+                       accuracy: 0.1)
+        XCTAssertGreaterThan(sut.downloadSession.configuration.timeoutIntervalForResource,
+                             sut.session.configuration.timeoutIntervalForResource)
+    }
+
+    func test_downloadSession_inheritsTheInjectedConfiguration() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RoktHTTPUrlProtocolStub.self]
+
+        let sut = RoktHTTPClient(sessionConfiguration: configuration)
+
+        XCTAssertEqual(sut.downloadSession.configuration.protocolClasses?.count,
+                       configuration.protocolClasses?.count)
+        // The caller's configuration is copied rather than mutated, so the API session keeps
+        // the resource timeout it was handed.
+        XCTAssertEqual(configuration.timeoutIntervalForResource, 7 * 24 * 60 * 60, accuracy: 0.1)
+    }
+
+    func test_downloadFile_runsOnTheDownloadSessionRatherThanTheApiSession() {
+        let destinationURL = FileManager.testDirectoryURL.appendingPathComponent("font.ttf")
+        RoktHTTPUrlProtocolStub.stub(data: Data("a font".utf8), response: anyHTTPURLResponse(), error: nil)
+
+        let sut = makeSUT()
+        // Cancelling the API session is the only externally visible difference between the two,
+        // so a download that still completes can only have been issued on the download session.
+        sut.session.invalidateAndCancel()
+
+        let exp = expectation(description: "Wait for completion")
+        var receivedResult: RoktDownloadResult!
+        sut.downloadFile(source: anyURLString(), destinationURL: destinationURL) { downloadResult in
+            receivedResult = downloadResult
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+
+        XCTAssertNil(receivedResult.downloadError)
+        XCTAssertNotNil(receivedResult.downloadedFileLocalURL)
+    }
+
+    func test_downloadFile_succeedsAfterTheClientTimeoutHasBeenTightened() {
+        let destinationURL = FileManager.testDirectoryURL.appendingPathComponent("font.ttf")
+        let data = Data("a font".utf8)
+        RoktHTTPUrlProtocolStub.stub(data: data, response: anyHTTPURLResponse(), error: nil)
+
+        let sut = makeSUT()
+        sut.updateTimeout(timeout: 9)
+
+        let exp = expectation(description: "Wait for completion")
+        var receivedResult: RoktDownloadResult!
+        sut.downloadFile(source: anyURLString(), destinationURL: destinationURL) { downloadResult in
+            receivedResult = downloadResult
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+
+        XCTAssertNil(receivedResult.downloadError)
+        XCTAssertNotNil(receivedResult.downloadedFileLocalURL)
+    }
+
     func test_startRequest_performsGETRequestWithURL() {
         let url = anyURL()
         let exp = expectation(description: "Wait for request")

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -3,7 +3,7 @@ import CoreText
 @testable import Rokt_Widget
 
 /// Mocker invokes request hooks off the test thread, so attempt counts are guarded.
-private final class Counter {
+private final class Counter: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
 
@@ -21,7 +21,7 @@ private final class Counter {
 }
 
 /// Diagnostics are delivered off the test thread, so captured call stacks are guarded.
-private final class Traces {
+private final class Traces: @unchecked Sendable {
     private let lock = NSLock()
     private var values: [String] = []
 
@@ -338,17 +338,17 @@ class TestFontManager: XCTestCase {
         let fonts: [FontModel] = [FontModel(name: "some font", url: fontUrl), FontModel(name: "some other font", url: fontUrl)]
         let expectation = XCTestExpectation(description: "Download complete")
         self.stubFontFileUrl(fontUrl)
-        var callbackCount = 0
+        let callbackCount = Counter()
 
         // Act
         FontManager.downloadFonts(fonts) {
             expectation.fulfill()
-            callbackCount += 1
+            callbackCount.increment()
         }
 
         // Assert
         wait(for: [expectation], timeout: 5)
-        XCTAssertEqual(1, callbackCount)
+        XCTAssertEqual(1, callbackCount.value)
     }
 
     // MARK: - Completion is driven by settled count, not font order

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -20,6 +20,24 @@ private final class Counter {
     }
 }
 
+/// Diagnostics are delivered off the test thread, so captured call stacks are guarded.
+private final class Traces {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    func append(_ value: String) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    func contains(_ predicate: (String) -> Bool) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.contains(where: predicate)
+    }
+}
+
 class TestFontManager: XCTestCase {
     var hasFetched = false
     var errors = [String]()
@@ -420,7 +438,92 @@ class TestFontManager: XCTestCase {
                        "the initial attempt plus every retry should be issued before settling")
     }
 
+    func test_handleFontDownloadResponse_whenResponseHasNeitherErrorNorFile_isReportedSeparately() throws {
+        // This response shape used to fall through every branch and never settle. It now
+        // settles, but it must not be logged as a download failure carrying a nil error.
+        let traces = captureDiagnosticStackTraces()
+
+        let font = FontModel(name: "incomplete-response-font", url: "https://font.test/incomplete.ttf")
+        let settled = expectation(description: "settled")
+
+        RoktNetWorkAPI.handleFontDownloadResponse(
+            font: font,
+            destinationURL: try XCTUnwrap(FontManager.getFileUrl(name: font.name)),
+            downloadResponse: RoktDownloadResult(
+                httpURLResponse: nil,
+                downloadedFileLocalURL: nil,
+                downloadError: nil
+            ),
+            onDownloadComplete: { settled.fulfill() }
+        )
+
+        wait(for: [settled], timeout: 15)
+
+        XCTAssertTrue(waitUntil { traces.contains { $0.contains("missing both error and file") } },
+                      "a malformed response should be reported on its own line")
+        XCTAssertFalse(traces.contains { $0.contains("Error downloading font") },
+                       "it should not masquerade as a download failure with a nil error")
+    }
+
+    func test_handleFontDownloadResponse_withTerminalDownloadError_keepsTheExistingDiagnosticShape() throws {
+        // The `[FONT]` rows for real download failures are already monitored, so splitting
+        // the malformed case out must not change how a genuine failure reads.
+        let traces = captureDiagnosticStackTraces()
+
+        let font = FontModel(name: "terminal-error-font", url: "https://font.test/terminal.ttf")
+        let settled = expectation(description: "settled")
+
+        RoktNetWorkAPI.handleFontDownloadResponse(
+            font: font,
+            destinationURL: try XCTUnwrap(FontManager.getFileUrl(name: font.name)),
+            downloadResponse: RoktDownloadResult(
+                httpURLResponse: nil,
+                downloadedFileLocalURL: nil,
+                downloadError: NSError(domain: "Custom", code: 1)
+            ),
+            onDownloadComplete: { settled.fulfill() },
+            retryCount: maxRetries
+        )
+
+        wait(for: [settled], timeout: 15)
+
+        XCTAssertTrue(waitUntil { traces.contains { $0.contains("Error downloading font") } },
+                      "a genuine download failure should keep its existing diagnostic shape")
+        XCTAssertFalse(traces.contains { $0.contains("missing both error and file") },
+                       "a real error should not be reported as a malformed response")
+    }
+
     // MARK: - Cache recovery
+
+    func test_invalidateCachedFont_alsoRemovesTheDownloadedUrlEntry() throws {
+        // `removeFont` reads the detail before removing the URL entry, so an invalidation
+        // that drops only the detail strands the entry where nothing can clean it up.
+        let name = "invalidated-font"
+        let url = "https://font.test/invalidated.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: name) }
+
+        let urlSaved = expectation(description: "font url saved")
+        FontRepository.saveFontUrl(key: url) { urlSaved.fulfill() }
+        wait(for: [urlSaved], timeout: 15)
+        try seedCachedFont(name: name, url: url)
+
+        let invalidated = expectation(description: "font invalidated")
+        FontManager.invalidateCachedFont(FontModel(name: name, url: url)) { invalidated.fulfill() }
+        wait(for: [invalidated], timeout: 15)
+
+        XCTAssertFalse(FontManager.isFontFileExist(name: name))
+        XCTAssertNil(FontRepository.loadFontDetail(key: url))
+        XCTAssertFalse(FontRepository.loadAllFontURLs()?.contains(url) ?? false,
+                       "the URL entry has to go too, otherwise removeUnusedFonts can never reclaim it")
+    }
+
+    /// Replaces the default diagnostics stub so a test can read the call stacks rather
+    /// than just the error codes.
+    private func captureDiagnosticStackTraces() -> Traces {
+        let traces = Traces()
+        stubDiagnostics(onDiagnosticsModelReceive: { traces.append($0.stackTrace) })
+        return traces
+    }
 
     func test_registerFont_withUnregisterableCachedFont_invalidatesCacheForReDownload() throws {
         // Keep the re-fetch pending so the assertion sees only the invalidation.

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -1,5 +1,24 @@
 import XCTest
+import CoreText
 @testable import Rokt_Widget
+
+/// Mocker invokes request hooks off the test thread, so attempt counts are guarded.
+private final class Counter {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}
 
 class TestFontManager: XCTestCase {
     var hasFetched = false
@@ -13,6 +32,7 @@ class TestFontManager: XCTestCase {
             hasFetched = true
         }
         Rokt.shared.roktImplementation.roktTagId = "123"
+        Rokt.shared.roktImplementation.isInitFailedForFont = false
 
         self.stubDiagnostics(onDiagnosticsReceive: { (error) in
             self.errors.append(error)
@@ -34,6 +54,8 @@ class TestFontManager: XCTestCase {
         FontManager.resetFontRecoveryState()
         FontManager.maxFontRecoveryAttempts = 2
         FontManager.fontRecoveryBackoff = .seconds(1)
+        FontManager.fileUrlResolverOverride = nil
+        Rokt.shared.roktImplementation.isInitFailedForFont = false
 
         super.tearDown()
     }
@@ -354,6 +376,50 @@ class TestFontManager: XCTestCase {
         wait(for: [completion], timeout: 10)
     }
 
+    func test_downloadFonts_whenAFontPathCannotBeResolved_stillSettlesTheBatch() {
+        // An unresolvable path used to return early and abandon the whole batch, leaving
+        // init waiting forever on the fonts that came after it.
+        FontManager.fileUrlResolverOverride = { _ in nil }
+
+        let completion = expectation(description: "onFontDownloadComplete")
+
+        FontManager.downloadFonts([
+            FontModel(name: "unresolvable-font-a", url: "https://font.test/unresolvable-a.ttf"),
+            FontModel(name: "unresolvable-font-b", url: "https://font.test/unresolvable-b.ttf")
+        ]) {
+            completion.fulfill()
+        }
+
+        wait(for: [completion], timeout: 10)
+        XCTAssertTrue(Rokt.shared.roktImplementation.isInitFailedForFont,
+                      "the failure should still be recorded for diagnostics")
+    }
+
+    func test_downloadFont_whenEveryAttemptFailsRetriably_settlesOnceAfterRetriesAreExhausted() throws {
+        // A retrying font must still settle, otherwise the batch it belongs to never
+        // completes and init waits on a font that will never arrive.
+        let url = "https://font.test/always-500.ttf"
+        let attempts = Counter()
+
+        stubFontFileUrl(url, statusCode: 500) { attempts.increment() }
+
+        let font = FontModel(name: "always-500-font", url: url)
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: font.name))
+        let settled = expectation(description: "download settled")
+        var settleCount = 0
+
+        RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {
+            settleCount += 1
+            settled.fulfill()
+        }
+
+        wait(for: [settled], timeout: 15)
+
+        XCTAssertEqual(settleCount, 1, "the completion must fire exactly once, not once per attempt")
+        XCTAssertEqual(attempts.value, maxRetries + 1,
+                       "the initial attempt plus every retry should be issued before settling")
+    }
+
     // MARK: - Cache recovery
 
     func test_registerFont_withUnregisterableCachedFont_invalidatesCacheForReDownload() throws {
@@ -406,7 +472,82 @@ class TestFontManager: XCTestCase {
         )
     }
 
-    private func seedCachedFont(name: String, url: String) throws {
+    func test_registerFont_afterSuccessfulRegistration_restoresTheRecoveryBudget() throws {
+        // A font that recovers once must be recoverable again later in the same process,
+        // so a successful registration has to release the attempt it consumed.
+        FontManager.fontRecoveryBackoff = .seconds(60)
+        FontManager.maxFontRecoveryAttempts = 1
+
+        let name = "recovers-then-fails-font"
+        let url = "https://font.test/recovers-then-fails.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: name) }
+
+        let font = FontModel(name: name, url: url)
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: name))
+
+        try seedCachedFont(name: name, url: url)
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+        XCTAssertTrue(waitUntil { !FontManager.isFontFileExist(name: name) },
+                      "the first failure should spend the only recovery attempt")
+
+        try seedCachedFont(name: name, url: url, data: try Self.registerableFontData())
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        try seedCachedFont(name: name, url: url)
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        XCTAssertTrue(waitUntil { !FontManager.isFontFileExist(name: name) },
+                      "the successful registration should have restored the budget, letting " +
+                      "this later failure recover instead of being treated as exhausted")
+    }
+
+    func test_registerFont_withUnregisterableCachedFont_reDownloadsFontAfterBackoff() throws {
+        // The invalidation is only half the recovery; the re-fetch has to actually run,
+        // off the render path, for the font to come back.
+        FontManager.fontRecoveryBackoff = .milliseconds(10)
+
+        let name = "refetched-font"
+        let url = "https://font.test/refetched.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: name) }
+
+        let requested = expectation(description: "font re-requested")
+        requested.assertForOverFulfill = false
+        stubFontFileUrl(url, data: try Self.registerableFontData()) { requested.fulfill() }
+
+        let font = FontModel(name: name, url: url)
+        try seedCachedFont(name: name, url: url)
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: name))
+
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        wait(for: [requested], timeout: 15)
+        XCTAssertTrue(waitUntil { FontManager.isFontFileExist(name: name) },
+                      "the re-fetched font should be back in the cache and usable")
+    }
+
+    /// Registration only runs against genuine font bytes, and sourcing them from a font
+    /// already on the device avoids committing a binary fixture. Large collections such as
+    /// the emoji font are skipped to keep the read cheap.
+    private static func registerableFontData() throws -> Data {
+        for family in UIFont.familyNames {
+            for fontName in UIFont.fontNames(forFamilyName: family) {
+                let descriptor = CTFontCopyFontDescriptor(CTFontCreateWithName(fontName as CFString, 12, nil))
+
+                guard let fontUrl = CTFontDescriptorCopyAttribute(descriptor, kCTFontURLAttribute) as? URL,
+                      let data = try? Data(contentsOf: fontUrl),
+                      data.count < 200_000,
+                      let provider = CGDataProvider(data: data as CFData),
+                      CGFont(provider) != nil
+                else { continue }
+
+                return data
+            }
+        }
+
+        throw XCTSkip("no registerable font file is available on this device")
+    }
+
+    private func seedCachedFont(name: String, url: String, data: Data = Data([0x00])) throws {
         let saved = expectation(description: "font detail saved for \(name)")
 
         FontRepository.saveFontDetail(
@@ -421,7 +562,7 @@ class TestFontManager: XCTestCase {
 
         wait(for: [saved], timeout: 15)
 
-        try XCTestCase.writeFontFileToCache(named: name)
+        try XCTestCase.writeFontFileToCache(named: name, data: data)
         XCTAssertFalse(FontManager.isDownloadingFontRequired(font: FontModel(name: name, url: url)))
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -31,6 +31,9 @@ class TestFontManager: XCTestCase {
             shouldUseFontRegisterWithUrl: false,
             featureFlags: [:]
         )
+        FontManager.resetFontRecoveryState()
+        FontManager.maxFontRecoveryAttempts = 2
+        FontManager.fontRecoveryBackoff = .seconds(1)
 
         super.tearDown()
     }
@@ -306,6 +309,138 @@ class TestFontManager: XCTestCase {
         // Assert
         wait(for: [expectation], timeout: 5)
         XCTAssertEqual(1, callbackCount)
+    }
+
+    // MARK: - Completion is driven by settled count, not font order
+
+    func test_downloadFonts_callsCompletion_whenLastFontIsAlreadyCached() throws {
+        // Cache recovery is covered separately below. A stubbed font file cannot register,
+        // and letting it re-fetch here would only race with the assertion.
+        FontManager.maxFontRecoveryAttempts = 0
+
+        let downloadUrl = "https://font.test/needs-download.ttf"
+        let cachedName = "already-cached-font"
+        let cachedUrl = "https://font.test/already-cached.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: cachedName) }
+
+        stubFontFileUrl(downloadUrl)
+        try seedCachedFont(name: cachedName, url: cachedUrl)
+
+        let completion = expectation(description: "onFontDownloadComplete")
+
+        FontManager.downloadFonts([
+            FontModel(name: "needs-download-font", url: downloadUrl),
+            FontModel(name: cachedName, url: cachedUrl)
+        ]) {
+            completion.fulfill()
+        }
+
+        wait(for: [completion], timeout: 10)
+    }
+
+    func test_downloadFonts_callsCompletion_whenLastFontIsSystemFont() {
+        let downloadUrl = "https://font.test/needs-download.ttf"
+        stubFontFileUrl(downloadUrl)
+
+        let completion = expectation(description: "onFontDownloadComplete")
+
+        FontManager.downloadFonts([
+            FontModel(name: "needs-download-font", url: downloadUrl),
+            FontModel(name: "ArialMT", url: "")
+        ]) {
+            completion.fulfill()
+        }
+
+        wait(for: [completion], timeout: 10)
+    }
+
+    // MARK: - Cache recovery
+
+    func test_registerFont_withUnregisterableCachedFont_invalidatesCacheForReDownload() throws {
+        // Keep the re-fetch pending so the assertion sees only the invalidation.
+        FontManager.fontRecoveryBackoff = .seconds(60)
+
+        let name = "corrupt-cached-font"
+        let url = "https://font.test/corrupt.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: name) }
+
+        let font = FontModel(name: name, url: url)
+        try seedCachedFont(name: name, url: url)
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: name))
+
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        XCTAssertTrue(
+            waitUntil { FontManager.isDownloadingFontRequired(font: font) },
+            "an unregisterable cached font should be queued for download instead of " +
+            "resolving to the fallback font on every render"
+        )
+    }
+
+    func test_registerFont_withUnregisterableCachedFont_stopsRecoveringAtAttemptLimit() throws {
+        FontManager.fontRecoveryBackoff = .seconds(60)
+        FontManager.maxFontRecoveryAttempts = 1
+
+        let name = "repeatedly-bad-font"
+        let url = "https://font.test/repeatedly-bad.ttf"
+        addTeardownBlock { self.removeCachedFontFile(named: name) }
+
+        let font = FontModel(name: name, url: url)
+
+        try seedCachedFont(name: name, url: url)
+        let fileUrl = try XCTUnwrap(FontManager.getFileUrl(name: name))
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        XCTAssertTrue(
+            waitUntil { !FontManager.isFontFileExist(name: name) },
+            "the first failure should invalidate the cached file"
+        )
+
+        try seedCachedFont(name: name, url: url)
+        FontManager.registerFont(font: font, fileUrl: fileUrl)
+
+        XCTAssertTrue(
+            FontManager.isFontFileExist(name: name),
+            "once the attempt budget is spent the cache should be left alone rather than " +
+            "looping on a font that will not register"
+        )
+    }
+
+    private func seedCachedFont(name: String, url: String) throws {
+        let saved = expectation(description: "font detail saved for \(name)")
+
+        FontRepository.saveFontDetail(
+            key: url,
+            values: [
+                FontManager.keyName: name,
+                FontManager.keyTimestamp: "\(Date().timeIntervalSince1970)"
+            ]
+        ) {
+            saved.fulfill()
+        }
+
+        wait(for: [saved], timeout: 15)
+
+        try XCTestCase.writeFontFileToCache(named: name)
+        XCTAssertFalse(FontManager.isDownloadingFontRequired(font: FontModel(name: name, url: url)))
+    }
+
+    private func removeCachedFontFile(named name: String) {
+        guard let fileUrl = FontManager.getFileUrl(name: name) else { return }
+        try? FileManager.default.removeItem(at: fileUrl)
+    }
+
+    /// The cache metadata is written asynchronously, so conditions that depend on it are
+    /// polled rather than read once.
+    private func waitUntil(timeout: TimeInterval = 5, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        return condition()
     }
 
     // MARK: - Thread Safety Tests


### PR DESCRIPTION
Stacked on #267 — targets `fix/font-cache-recovery`, since both types this touches are introduced there and do not exist on `main`. Review/merge #267 first; this will retarget to `main` automatically.

Addresses @denis-rokt's review comment on #267 asking for actors instead of `NSLock`.

## What changed

**`FontDownloadBatch` is now an actor.** Its counter is shared across download callbacks that arrive on arbitrary threads, so it is a good fit: actor isolation lets the compiler enforce the exclusion rather than a hand-held lock. `settle()` now returns `Bool` — `true` only for the call that settles the last outstanding font — so the completion runs off the actor and cannot fire twice.

Completion is dispatched to the main queue. The download callbacks already deliver there (`RoktHTTPClient` completes on `.main`), so observers of `finishedDownloadingFonts` keep their existing thread, and the `queue.sync(flags: .barrier)` inside `getExistingFontsByPostScriptName()` stays off the cooperative thread pool.

**The recovery budget stays synchronous, with its lock encapsulated.** It is read and written from `registerFont`, which `reRegisterFonts` calls on the render path. Making it an actor forces `registerFont` to be `async`, which propagates to `reRegisterFonts` and turns the execute continuation at `RoktInternalImplementation.swift:1087` — the one that drives the cache lookup, `isExecuting`, and presentation — into a deferred hop. That is a render-path behaviour change unrelated to the bug #267 fixes, so instead the state moved into a dedicated `FontRecoveryLedger` that owns its lock. No call site handles `lock()`/`unlock()` anymore.

`@Sendable` was threaded through `downloadFonts` to keep the build warning-free; that surfaced a real data race in `test_downloadFonts_should_call_onFontDownloadComplete_only_once...`, where an unguarded `var callbackCount` was mutated from a concurrent callback. It now uses the existing thread-safe `Counter`.

## No behaviour change

No test changes were needed beyond that race fix — the batch's observable contract (fires exactly once, regardless of font order) is unchanged and still covered by the existing tests.

## Test plan

- [x] `xcodebuild build` — no new warnings
- [x] Full `Rokt_WidgetTests` suite: 660 tests, 0 failures, 2 skipped
- [x] `TestFontManager`: 35 tests, 0 failures
- [x] `trunk check` clean on all changed files