### PR TITLE
fix: skip Dependabot-incompatible jobs on Dependabot PRs

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -94,8 +94,10 @@ jobs:
     name: Publish to Broker
     needs: [consumer-test, detect-changes]
     # Main pushes and same-repo (non-fork) PR pushes with contract changes.
+    # Skip Dependabot: its secret store has no pact-publish environment credentials.
     if: |
       needs.detect-changes.outputs.contract == 'true'
+      && github.actor != 'dependabot[bot]'
       && (
         (github.event_name == 'push' && github.ref == 'refs/heads/main')
         || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -305,7 +305,8 @@ jobs:
   pr-notify:
     if: >
       github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
     name: Notify GChat
     needs: [unit-test, ui-test, package-unit-tests, periphery-scan]
     uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@93d6833818312c13d472e69050e2f0560b31076e # main


### PR DESCRIPTION
## Background

Dependabot PRs cannot reach environment-scoped secrets (`pact-publish` broker credentials, GChat webhook). When those jobs run on Dependabot PRs they fail red and hide whether the bump is actually mergeable.

## What Has Changed

- Skip `Publish to Broker` when `github.actor` is Dependabot (`Can I Deploy` skips via `needs`)
- Skip `Notify GChat` on Dependabot PRs for the same reason
- Consumer contract tests still run; only publish/notify are skipped

## How Has This Been Tested

- `trunk check` clean on both workflow files
- Happy-path will be validated by CI on this human-authored PR
- Dependabot path needs a re-run of an existing Dependabot PR after merge

## Notes

Mirrors the same guards already landed on the Android SDK consumer workflow.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.