### PR TITLE
fix: Pin hosted SwiftUI view to bottom of RoktEmbeddedView

### DIFF
--- a/Sources/Rokt_Widget/RoktEmbeddedView.swift
+++ b/Sources/Rokt_Widget/RoktEmbeddedView.swift
@@ -9,6 +9,7 @@ private var roktEmbeddedSwiftUIViewKey: UInt8 = 0
 private var topConstraintKey: UInt8 = 0
 private var leadingConstraintKey: UInt8 = 0
 private var trailingConstraintKey: UInt8 = 0
+private var bottomConstraintKey: UInt8 = 0
 private var heightConstraintKey: UInt8 = 0
 private var latestHeightKey: UInt8 = 0
 private var onSizeChangeKey: UInt8 = 0
@@ -34,6 +35,11 @@ extension RoktEmbeddedView {
     var trailingConstaint: NSLayoutConstraint? {
         get { objc_getAssociatedObject(self, &trailingConstraintKey) as? NSLayoutConstraint }
         set { objc_setAssociatedObject(self, &trailingConstraintKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    var bottomConstaint: NSLayoutConstraint? {
+        get { objc_getAssociatedObject(self, &bottomConstraintKey) as? NSLayoutConstraint }
+        set { objc_setAssociatedObject(self, &bottomConstraintKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
     }
 
     var heightConstaint: NSLayoutConstraint? {
@@ -66,7 +72,7 @@ extension RoktEmbeddedView {
     }
 
     private func decideTranslatesAutoresizingMask() {
-        if !self.constraints.isEmpty {
+        if !translatesAutoresizingMaskIntoConstraints || !self.constraints.isEmpty {
             self.translatesAutoresizingMaskIntoConstraints = false
         } else {
             self.translatesAutoresizingMaskIntoConstraints = true
@@ -78,6 +84,7 @@ extension RoktEmbeddedView {
         removeEmbeddedLayoutConstraint(topConstaint)
         removeEmbeddedLayoutConstraint(leadingConstaint)
         removeEmbeddedLayoutConstraint(trailingConstaint)
+        removeEmbeddedLayoutConstraint(bottomConstaint)
         removeEmbeddedLayoutConstraint(heightConstaint)
     }
 
@@ -91,12 +98,16 @@ extension RoktEmbeddedView {
         trailingConstaint = NSLayoutConstraint(item: self, attribute: .trailing,
                                                relatedBy: .equal, toItem: embeddedView,
                                                attribute: .trailing, multiplier: 1, constant: 0)
+        bottomConstaint = NSLayoutConstraint(item: self, attribute: .bottom,
+                                             relatedBy: .equal, toItem: embeddedView,
+                                             attribute: .bottom, multiplier: 1, constant: 0)
         heightConstaint = NSLayoutConstraint(item: self, attribute: .height,
                                              relatedBy: .equal, toItem: nil,
                                              attribute: .notAnAttribute, multiplier: 1, constant: 0)
         addEmbeddedLayoutConstraint(topConstaint)
         addEmbeddedLayoutConstraint(leadingConstaint)
         addEmbeddedLayoutConstraint(trailingConstaint)
+        addEmbeddedLayoutConstraint(bottomConstaint)
         addEmbeddedLayoutConstraint(heightConstaint)
     }
 
@@ -141,6 +152,7 @@ extension RoktEmbeddedView: InternalLayoutLoader {
     public func load<Content>(onSizeChanged: @escaping ((CGFloat) -> Void),
                               injectedView: @escaping () -> Content) where Content: View {
         cleanupEmbeddedView()
+        clipsToBounds = true
         self.onSizeChange = onSizeChanged
         let vc = ResizableHostingController(rootView: AnyView(injectedView()))
         if #available(iOS 16.4, *),

--- a/Tests/Rokt_WidgetTests/TestRoktEmbeddedViewLayout.swift
+++ b/Tests/Rokt_WidgetTests/TestRoktEmbeddedViewLayout.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import XCTest
+@testable import Rokt_Widget
+
+final class TestRoktEmbeddedViewLayout: XCTestCase {
+    private var window: UIWindow!
+    private var containerViewController: UIViewController!
+
+    override func setUp() {
+        super.setUp()
+        containerViewController = UIViewController()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 812))
+        window.rootViewController = containerViewController
+        window.makeKeyAndVisible()
+    }
+
+    override func tearDown() {
+        window.isHidden = true
+        window = nil
+        containerViewController = nil
+        super.tearDown()
+    }
+
+    func testLoadPinsHostedViewWithBottomConstraint() {
+        let embeddedView = makeEmbeddedViewInHierarchy(width: 320)
+
+        embeddedView.load(onSizeChanged: { _ in }, injectedView: {
+            Text("Embedded placement")
+        })
+
+        XCTAssertNotNil(embeddedView.bottomConstaint)
+        XCTAssertTrue(embeddedView.bottomConstaint?.isActive ?? false)
+        XCTAssertTrue(embeddedView.clipsToBounds)
+    }
+
+    func testUpdateEmbeddedSizeKeepsHostAndHostedBoundsEqualAfterLayout() {
+        let embeddedView = makeEmbeddedViewInHierarchy(width: 320)
+        let heightConstraint = embeddedView.heightAnchor.constraint(equalToConstant: 0)
+        heightConstraint.isActive = true
+
+        embeddedView.load(onSizeChanged: { _ in }, injectedView: {
+            Text("Embedded placement")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 40)
+        })
+
+        let expectedHeight: CGFloat = 180
+        embeddedView.updateEmbeddedSize(expectedHeight)
+        layoutEmbeddedView(embeddedView)
+
+        guard let hostedView = embeddedView.roktEmbeddedSwiftUIView else {
+            return XCTFail("Expected a hosted SwiftUI view after load")
+        }
+
+        XCTAssertEqual(embeddedView.bounds.height, expectedHeight, accuracy: 0.5)
+        XCTAssertEqual(hostedView.bounds.height, embeddedView.bounds.height, accuracy: 0.5)
+        XCTAssertEqual(hostedView.frame.height, expectedHeight, accuracy: 0.5)
+        XCTAssertEqual(heightConstraint.constant, expectedHeight, accuracy: 0.5)
+    }
+
+    func testLoadPreservesAutoLayoutWhenHostOptedInBeforeLoad() {
+        let embeddedView = RoktEmbeddedView()
+        embeddedView.translatesAutoresizingMaskIntoConstraints = false
+        pinEmbeddedViewInContainer(embeddedView, width: 280)
+
+        embeddedView.load(onSizeChanged: { _ in }, injectedView: {
+            Text("Embedded placement")
+        })
+
+        XCTAssertFalse(embeddedView.translatesAutoresizingMaskIntoConstraints)
+    }
+
+    func testReloadRemovesAndRecreatesBottomConstraint() {
+        let embeddedView = makeEmbeddedViewInHierarchy(width: 320)
+
+        embeddedView.load(onSizeChanged: { _ in }, injectedView: {
+            Text("First load")
+        })
+        let firstBottomConstraint = embeddedView.bottomConstaint
+
+        embeddedView.load(onSizeChanged: { _ in }, injectedView: {
+            Text("Second load")
+        })
+
+        XCTAssertNotNil(embeddedView.bottomConstaint)
+        XCTAssertTrue(embeddedView.bottomConstaint?.isActive ?? false)
+        XCTAssertNotEqual(ObjectIdentifier(firstBottomConstraint as AnyObject),
+                          ObjectIdentifier(embeddedView.bottomConstaint as AnyObject))
+    }
+
+    private func makeEmbeddedViewInHierarchy(width: CGFloat) -> RoktEmbeddedView {
+        let embeddedView = RoktEmbeddedView()
+        embeddedView.translatesAutoresizingMaskIntoConstraints = false
+        pinEmbeddedViewInContainer(embeddedView, width: width)
+        return embeddedView
+    }
+
+    private func pinEmbeddedViewInContainer(_ embeddedView: RoktEmbeddedView, width: CGFloat) {
+        containerViewController.view.addSubview(embeddedView)
+        NSLayoutConstraint.activate([
+            embeddedView.topAnchor.constraint(equalTo: containerViewController.view.safeAreaLayoutGuide.topAnchor),
+            embeddedView.centerXAnchor.constraint(equalTo: containerViewController.view.centerXAnchor),
+            embeddedView.widthAnchor.constraint(equalToConstant: width)
+        ])
+    }
+
+    private func layoutEmbeddedView(_ embeddedView: RoktEmbeddedView) {
+        containerViewController.view.setNeedsLayout()
+        containerViewController.view.layoutIfNeeded()
+        embeddedView.setNeedsLayout()
+        embeddedView.layoutIfNeeded()
+    }
+}


### PR DESCRIPTION
## Background

UIKit RoktEmbeddedView did not pin the bottom of the hosted SwiftUI view, unlike RoktLayoutUIView in RoktUXHelper. Hosted height could resolve from intrinsic content size and exceed the height driven by updateEmbeddedSize(_:), so content overflowed the embedded container.

## What Has Changed

- Added a bottomConstaint associated object and pinned embeddedView.bottom == self.bottom in addEmbeddedLayoutConstraints, including cleanup on reload.
- Hardened decideTranslatesAutoresizingMask() so hosts that already set translatesAutoresizingMaskIntoConstraints = false stay on Auto Layout (not only when self.constraints is non-empty).
- Set clipsToBounds = true on load as a safety net against overflow.
- Added UIKit unit tests covering the bottom pin, host/hosted bounds after updateEmbeddedSize(_:), Auto Layout preference preservation, and constraint recreation on reload.

This change aligns the UIKit embedded layout path with the UX helper constraint model. No new dependencies.

## How Has This Been Tested

- trunk check on the changed files (clean)
- xcodebuild test -scheme Rokt-Widget -only-testing:Rokt_WidgetTests/TestRoktEmbeddedViewLayout on an iPhone 16 simulator — all four tests passed

## Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
