### PR TITLE
feat: Update to Session Token

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -2,13 +2,6 @@
 import Foundation
 
 internal actor TxnSessionManager {
-    private enum Keys {
-        static let tagId = "ROKT_TXN_TAG_ID"
-        static let sessionId = "ROKT_TXN_SESSION_ID"
-        static let token = "ROKT_TXN_SESSION_TOKEN"
-        static let expiresAt = "ROKT_TXN_TOKEN_EXPIRES_AT"
-    }
-
     private let clock: () -> Date
 
     // nil disables persistence (in-memory only), preserving the lightweight test setup.
@@ -75,29 +68,24 @@ internal actor TxnSessionManager {
         token = nil
         expiresAt = nil
         guard let store else { return }
-        store.removeValue(forKey: Keys.tagId)
-        store.removeValue(forKey: Keys.sessionId)
-        store.removeValue(forKey: Keys.token)
-        store.removeValue(forKey: Keys.expiresAt)
+        TxnSessionPersistence.clear(store: store)
     }
 
     private var hasExpired: Bool {
-        guard let expiresAt else { return true }
-        return clock() >= expiresAt
+        TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: clock)
     }
 
     private func restoreFromStore() {
         guard let store, let roktTagId else { return }
         // Only restore a session bound to the current tag id; otherwise start clean.
-        guard store.string(forKey: Keys.tagId) == roktTagId else {
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
             clear()
             return
         }
-        sessionId = store.string(forKey: Keys.sessionId)
-        token = store.string(forKey: Keys.token)
-        expiresAt = store.string(forKey: Keys.expiresAt)
-            .flatMap(Double.init)
-            .map { Date(timeIntervalSince1970: $0/1000) }
+        let raw = TxnSessionPersistence.readRaw(store: store)
+        sessionId = raw.sessionId
+        token = raw.token
+        expiresAt = raw.expiresAt
         // Drop a persisted-but-expired token so we never start with stale state;
         // an expired JWT is dead server-side and a fresh session is minted at init.
         if hasExpired {
@@ -107,18 +95,13 @@ internal actor TxnSessionManager {
 
     private func persist(includeSessionId: Bool) {
         guard let store, let roktTagId else { return }
-        // Always record the tag-id binding: restoreFromStore treats a missing/mismatched
-        // tag id as another account's data and clears the session, so a token persisted
-        // without it would never survive a reload.
-        store.setString(roktTagId, forKey: Keys.tagId)
-        if includeSessionId, let sessionId {
-            store.setString(sessionId, forKey: Keys.sessionId)
-        }
-        if let token {
-            store.setString(token, forKey: Keys.token)
-        }
-        if let expiresAt {
-            store.setString(String(expiresAt.timeIntervalSince1970 * 1000), forKey: Keys.expiresAt)
-        }
+        TxnSessionPersistence.persist(
+            roktTagId: roktTagId,
+            sessionId: sessionId,
+            token: token,
+            expiresAt: expiresAt,
+            includeSessionId: includeSessionId,
+            store: store
+        )
     }
 }

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
@@ -1,0 +1,104 @@
+// periphery:ignore:all
+import Foundation
+
+/// UserDefaults keys shared by ``TxnSessionManager`` and the public session handoff APIs.
+internal enum TxnSessionStoreKeys {
+    static let tagId = "ROKT_TXN_TAG_ID"
+    static let sessionId = "ROKT_TXN_SESSION_ID"
+    static let token = "ROKT_TXN_SESSION_TOKEN"
+    static let expiresAt = "ROKT_TXN_TOKEN_EXPIRES_AT"
+}
+
+/// In-memory view of a persisted txn session (id + JWT + expiry).
+internal struct TxnSessionSnapshot: Equatable {
+    let sessionId: String?
+    let token: String?
+    let expiresAt: Date?
+}
+
+/// Synchronous read/write for the txn session store so public APIs can seed state
+/// before the next offers/events call constructs a ``TxnSessionManager``.
+internal enum TxnSessionPersistence {
+    static func seed(
+        roktTagId: String,
+        sessionId: String,
+        sessionToken: TxnSessionToken,
+        store: TxnSessionStore = UserDefaultsTxnSessionStore()
+    ) {
+        store.setString(roktTagId, forKey: TxnSessionStoreKeys.tagId)
+        store.setString(sessionId, forKey: TxnSessionStoreKeys.sessionId)
+        store.setString(sessionToken.token, forKey: TxnSessionStoreKeys.token)
+        // Persist epoch ms as an integer string so public getSession round-trips without float drift.
+        store.setString(String(sessionToken.expiresAt), forKey: TxnSessionStoreKeys.expiresAt)
+    }
+
+    /// Loads a valid session for `roktTagId`. Clears the store and returns `nil` on
+    /// tag mismatch or expired token (same rules as ``TxnSessionManager`` restore).
+    static func load(
+        roktTagId: String,
+        store: TxnSessionStore = UserDefaultsTxnSessionStore(),
+        clock: () -> Date = Date.init
+    ) -> TxnSessionSnapshot? {
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+            clear(store: store)
+            return nil
+        }
+
+        let sessionId = store.string(forKey: TxnSessionStoreKeys.sessionId)
+        let token = store.string(forKey: TxnSessionStoreKeys.token)
+        let expiresAt = store.string(forKey: TxnSessionStoreKeys.expiresAt)
+            .flatMap(Double.init)
+            .map { Date(timeIntervalSince1970: $0/1000) }
+
+        if isExpired(expiresAt: expiresAt, clock: clock) {
+            clear(store: store)
+            return nil
+        }
+
+        return TxnSessionSnapshot(sessionId: sessionId, token: token, expiresAt: expiresAt)
+    }
+
+    static func clear(store: TxnSessionStore) {
+        store.removeValue(forKey: TxnSessionStoreKeys.tagId)
+        store.removeValue(forKey: TxnSessionStoreKeys.sessionId)
+        store.removeValue(forKey: TxnSessionStoreKeys.token)
+        store.removeValue(forKey: TxnSessionStoreKeys.expiresAt)
+    }
+
+    static func persist(
+        roktTagId: String,
+        sessionId: String?,
+        token: String?,
+        expiresAt: Date?,
+        includeSessionId: Bool,
+        store: TxnSessionStore
+    ) {
+        // Always record the tag-id binding: load treats a missing/mismatched
+        // tag id as another account's data and clears the session, so a token persisted
+        // without it would never survive a reload.
+        store.setString(roktTagId, forKey: TxnSessionStoreKeys.tagId)
+        if includeSessionId, let sessionId {
+            store.setString(sessionId, forKey: TxnSessionStoreKeys.sessionId)
+        }
+        if let token {
+            store.setString(token, forKey: TxnSessionStoreKeys.token)
+        }
+        if let expiresAt {
+            store.setString(String(expiresAt.timeIntervalSince1970 * 1000), forKey: TxnSessionStoreKeys.expiresAt)
+        }
+    }
+
+    static func isExpired(expiresAt: Date?, clock: () -> Date) -> Bool {
+        guard let expiresAt else { return true }
+        return clock() >= expiresAt
+    }
+
+    static func readRaw(store: TxnSessionStore) -> TxnSessionSnapshot {
+        let sessionId = store.string(forKey: TxnSessionStoreKeys.sessionId)
+        let token = store.string(forKey: TxnSessionStoreKeys.token)
+        let expiresAt = store.string(forKey: TxnSessionStoreKeys.expiresAt)
+            .flatMap(Double.init)
+            .map { Date(timeIntervalSince1970: $0/1000) }
+        return TxnSessionSnapshot(sessionId: sessionId, token: token, expiresAt: expiresAt)
+    }
+}

--- a/Sources/Rokt_Widget/Models/RoktSession.swift
+++ b/Sources/Rokt_Widget/Models/RoktSession.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A Rokt session suitable for handoff between native and non-native integrations (e.g. WebView).
+///
+/// Includes the session id plus the short-lived session token used to authorize offers and events.
+@objc public class RoktSession: NSObject {
+    /// The Rokt session identifier.
+    @objc public let sessionId: String
+
+    /// The JWT session token used as a Bearer credential for offers and events.
+    @objc public let sessionToken: String
+
+    /// Unix epoch milliseconds when ``sessionToken`` expires (matches server `expires_at`).
+    @objc public let expiresAt: Int64
+
+    /// Creates a session handoff value.
+    ///
+    /// - Parameters:
+    ///   - sessionId: The Rokt session identifier. Must be non-empty when passed to ``Rokt/setSession(_:)``.
+    ///   - sessionToken: The JWT session token. Must be non-empty when passed to ``Rokt/setSession(_:)``.
+    ///   - expiresAt: Token expiry as Unix epoch milliseconds.
+    @objc public init(sessionId: String, sessionToken: String, expiresAt: Int64) {
+        self.sessionId = sessionId
+        self.sessionToken = sessionToken
+        self.expiresAt = expiresAt
+        super.init()
+    }
+}

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -251,14 +251,36 @@ internal import RoktUXHelper
         shared.roktImplementation.purchaseFinalized(identifier: identifier, catalogItemId: catalogItemId, success: success)
     }
 
+    /// Set the session (id + token) to use for the next execute call.
+    ///
+    /// Use this when you have a session from a non-native integration (e.g. WebView)
+    /// and want the session — including Bearer authorization for offers and events —
+    /// to stay consistent across integrations. Call before the next execute.
+    ///
+    /// - Note: The SDK must be initialized. Empty `sessionId` or `sessionToken` values are ignored.
+    ///
+    /// - Parameter session: The session id, JWT session token, and token expiry to apply.
+    public static func setSession(_ session: RoktSession) {
+        shared.roktImplementation.setSession(session)
+    }
+
+    /// Get the current session (id + token) for use within a non-native integration e.g. WebView.
+    ///
+    /// - Returns: The session, or `nil` if the SDK is not initialized, no session is present, or the token has expired.
+    public static func getSession() -> RoktSession? {
+        shared.roktImplementation.getSession()
+    }
+
     /// Set the session id to use for the next execute call.
     /// This is useful for cases where you have a session id from a non-native integration,
     /// e.g. WebView, and you want the session to be consistent across integrations.
     ///
     /// - Note: Empty strings are ignored and will not update the session.
+    /// - Note: Prefer ``setSession(_:)`` so the session token is also applied for offers and events.
     ///
     /// - Parameters:
     ///   - sessionId: The session id to be set. Must be a non-empty string.
+    @available(*, deprecated, message: "Use setSession(_:) to set session id and session token.")
     public static func setSessionId(sessionId: String) {
         shared.roktImplementation.setSessionId(sessionId: sessionId)
     }
@@ -266,6 +288,8 @@ internal import RoktUXHelper
     /// Get the session id to use within a non-native integration e.g. WebView
     ///
     /// - Returns: The session id or nil if no session is present.
+    /// - Note: Prefer ``getSession()`` to also read the session token.
+    @available(*, deprecated, message: "Use getSession() to read session id and session token.")
     public static func getSessionId() -> String? {
         shared.roktImplementation.getSessionId()
     }

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -282,6 +282,9 @@ internal import RoktUXHelper
     ///   - sessionId: The session id to be set. Must be a non-empty string.
     @available(*, deprecated, message: "Use setSession(_:) to set session id and session token.")
     public static func setSessionId(sessionId: String) {
+        RoktLogger.shared.warning(
+            "Rokt.setSessionId(sessionId:) is deprecated. Use setSession(_:) to set session id and session token."
+        )
         shared.roktImplementation.setSessionId(sessionId: sessionId)
     }
 
@@ -291,6 +294,9 @@ internal import RoktUXHelper
     /// - Note: Prefer ``getSession()`` to also read the session token.
     @available(*, deprecated, message: "Use getSession() to read session id and session token.")
     public static func getSessionId() -> String? {
-        shared.roktImplementation.getSessionId()
+        RoktLogger.shared.warning(
+            "Rokt.getSessionId() is deprecated. Use getSession() to read session id and session token."
+        )
+        return shared.roktImplementation.getSessionId()
     }
 }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1330,6 +1330,40 @@ class RoktInternalImplementation {
         }
     }
 
+    func setSession(_ session: RoktSession) {
+        guard let roktTagId,
+              !session.sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !session.sessionToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return
+        }
+
+        let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: session.expiresAt)
+        TxnSessionPersistence.seed(
+            roktTagId: roktTagId,
+            sessionId: session.sessionId,
+            sessionToken: sessionToken
+        )
+        sessionManager.updateSessionId(newSessionId: session.sessionId)
+    }
+
+    func getSession() -> RoktSession? {
+        guard let roktTagId else {
+            return nil
+        }
+        guard let snapshot = TxnSessionPersistence.load(roktTagId: roktTagId),
+              let sessionId = snapshot.sessionId,
+              !sessionId.isEmpty,
+              let token = snapshot.token,
+              !token.isEmpty,
+              let expiresAt = snapshot.expiresAt
+        else {
+            return nil
+        }
+        let expiresAtMs = Int64((expiresAt.timeIntervalSince1970 * 1000).rounded(.down))
+        return RoktSession(sessionId: sessionId, sessionToken: token, expiresAt: expiresAtMs)
+    }
+
     func setSessionId(sessionId: String) {
         guard !sessionId.isEmpty else {
             return

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1335,10 +1335,20 @@ class RoktInternalImplementation {
               !session.sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !session.sessionToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
+            RoktLogger.shared.warning(
+                "Rokt.setSession ignored: SDK must be initialized and sessionId/sessionToken must be non-empty."
+            )
             return
         }
 
         let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: session.expiresAt)
+        if TxnSessionPersistence.isExpired(expiresAt: sessionToken.expiresAtDate, clock: Date.init) {
+            RoktLogger.shared.warning(
+                "Rokt.setSession ignored: session token is expired."
+            )
+            return
+        }
+
         TxnSessionPersistence.seed(
             roktTagId: roktTagId,
             sessionId: session.sessionId,
@@ -1349,17 +1359,41 @@ class RoktInternalImplementation {
 
     func getSession() -> RoktSession? {
         guard let roktTagId else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: SDK must be initialized."
+            )
             return nil
         }
-        guard let snapshot = TxnSessionPersistence.load(roktTagId: roktTagId),
-              let sessionId = snapshot.sessionId,
+
+        let store = UserDefaultsTxnSessionStore()
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: no session is present."
+            )
+            return nil
+        }
+
+        let snapshot = TxnSessionPersistence.readRaw(store: store)
+        guard let sessionId = snapshot.sessionId,
               !sessionId.isEmpty,
               let token = snapshot.token,
               !token.isEmpty,
               let expiresAt = snapshot.expiresAt
         else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: no session is present."
+            )
             return nil
         }
+
+        if TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: Date.init) {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: session token is expired."
+            )
+            TxnSessionPersistence.clear(store: store)
+            return nil
+        }
+
         let expiresAtMs = Int64((expiresAt.timeIntervalSince1970 * 1000).rounded(.down))
         return RoktSession(sessionId: sessionId, sessionToken: token, expiresAt: expiresAtMs)
     }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -223,4 +223,62 @@ final class TestTxnSessionManager: XCTestCase {
         let sessionId = await persistent.currentSessionId
         XCTAssertNil(sessionId)
     }
+
+    // MARK: - TxnSessionPersistence (sync seed/load)
+
+    func test_persistence_seed_isVisibleToTxnSessionManager() async {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "seeded-sid",
+            sessionToken: token("seeded-jwt", expiresInSeconds: 1800),
+            store: store
+        )
+
+        let restored = persistentManager(tagId: "tag-1", store: store)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "seeded-sid")
+        XCTAssertEqual(header, "Bearer seeded-jwt")
+    }
+
+    func test_persistence_load_returnsSnapshot() {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "sid",
+            sessionToken: token("jwt", expiresInSeconds: 1800),
+            store: store
+        )
+
+        let snapshot = TxnSessionPersistence.load(
+            roktTagId: "tag-1",
+            store: store,
+            clock: { self.now }
+        )
+
+        XCTAssertEqual(snapshot?.sessionId, "sid")
+        XCTAssertEqual(snapshot?.token, "jwt")
+        XCTAssertNotNil(snapshot?.expiresAt)
+    }
+
+    func test_persistence_load_clearsExpiredAndReturnsNil() {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "sid",
+            sessionToken: token("jwt", expiresInSeconds: 60),
+            store: store
+        )
+        now = now.addingTimeInterval(61)
+
+        let snapshot = TxnSessionPersistence.load(
+            roktTagId: "tag-1",
+            store: store,
+            clock: { self.now }
+        )
+
+        XCTAssertNil(snapshot)
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
+    }
 }

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -263,6 +263,23 @@ class TestRokt: XCTestCase {
 
     func test_getSession_returnsNilWhenExpired() {
         let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-expired-get"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiresAt)
+        )
+        XCTAssertNotNil(roktInternalImplementation.getSession())
+
+        // Simulate elapsed time after a valid seed without sleeping.
+        let pastMs = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
+        UserDefaultsTxnSessionStore().setString(String(pastMs), forKey: TxnSessionStoreKeys.expiresAt)
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(TxnSessionPersistence.load(roktTagId: "tag-expired-get"))
+    }
+
+    func test_setSession_ignoresExpiredToken() async {
+        let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-expired"
         let expiredAt = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
 
@@ -271,15 +288,12 @@ class TestRokt: XCTestCase {
         )
 
         XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
         let restored = TxnSessionManager(roktTagId: "tag-expired")
-        // Expired seed is cleared on load; a fresh manager should see nothing.
-        let expectation = expectation(description: "load expired")
-        Task {
-            let sessionId = await restored.currentSessionId
-            XCTAssertNil(sessionId)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
     }
 
     func test_setSessionId_doesNotWriteTxnSessionToken() async {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -185,6 +185,117 @@ class TestRokt: XCTestCase {
         RoktAPIHelperSpy.reset()
     }
 
+    // MARK: - setSession Tests
+
+    func test_setSession_noopWhenNotInitialized() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        let session = RoktSession(
+            sessionId: "sid",
+            sessionToken: "jwt",
+            expiresAt: Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        )
+
+        roktInternalImplementation.setSession(session)
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_setSession_persistsForTxnSessionManagerAndMirrorsLegacySessionId() async {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-set-session"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "webview-sid", sessionToken: "webview-jwt", expiresAt: expiresAt)
+
+        roktInternalImplementation.setSession(session)
+
+        let restored = TxnSessionManager(roktTagId: "tag-set-session")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "webview-sid")
+        XCTAssertEqual(header, "Bearer webview-jwt")
+        XCTAssertEqual(
+            roktInternalImplementation.sessionManager.getCurrentSessionIdWithoutExpiring(),
+            "webview-sid"
+        )
+        XCTAssertEqual(roktInternalImplementation.getSessionId(), "webview-sid")
+    }
+
+    func test_setSession_ignoresEmptySessionId() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-empty-id"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "  ", sessionToken: "jwt", expiresAt: expiresAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_setSession_ignoresEmptySessionToken() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-empty-token"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "", expiresAt: expiresAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_getSession_roundTripsSetSession() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-round-trip"
+        let expiresAt = Int64(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "sid-1", sessionToken: "jwt-1", expiresAt: expiresAt)
+
+        roktInternalImplementation.setSession(session)
+        let loaded = roktInternalImplementation.getSession()
+
+        XCTAssertEqual(loaded?.sessionId, "sid-1")
+        XCTAssertEqual(loaded?.sessionToken, "jwt-1")
+        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+    }
+
+    func test_getSession_returnsNilWhenExpired() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-expired"
+        let expiredAt = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiredAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        let restored = TxnSessionManager(roktTagId: "tag-expired")
+        // Expired seed is cleared on load; a fresh manager should see nothing.
+        let expectation = expectation(description: "load expired")
+        Task {
+            let sessionId = await restored.currentSessionId
+            XCTAssertNil(sessionId)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_setSessionId_doesNotWriteTxnSessionToken() async {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-legacy-set"
+        roktInternalImplementation.setSessionId(sessionId: "legacy-only-sid")
+
+        let restored = TxnSessionManager(roktTagId: "tag-legacy-set")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertEqual(roktInternalImplementation.getSessionId(), "legacy-only-sid")
+        XCTAssertNil(roktInternalImplementation.getSession())
+    }
+
     // MARK: - setSessionId Tests
 
     func test_setSessionId_updatesSessionManager() {
@@ -366,30 +477,43 @@ class TestRokt: XCTestCase {
 
     // MARK: - Rokt Public API Tests
 
+    func test_Rokt_setSession_roundTrips() {
+        Rokt.shared.roktImplementation.roktTagId = "public-tag"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "public-sid", sessionToken: "public-jwt", expiresAt: expiresAt)
+
+        Rokt.setSession(session)
+        let loaded = Rokt.getSession()
+
+        XCTAssertEqual(loaded?.sessionId, "public-sid")
+        XCTAssertEqual(loaded?.sessionToken, "public-jwt")
+        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+    }
+
     func test_Rokt_setSessionId_updatesSession() {
         let expectedSessionId = "public-api-session-id"
 
-        Rokt.setSessionId(sessionId: expectedSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: expectedSessionId)
 
-        XCTAssertEqual(Rokt.getSessionId(), expectedSessionId)
+        XCTAssertEqual(Rokt.shared.roktImplementation.getSessionId(), expectedSessionId)
     }
 
     func test_Rokt_getSessionId_returnsSessionId() {
         let expectedSessionId = "get-session-test-id"
-        Rokt.setSessionId(sessionId: expectedSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: expectedSessionId)
 
-        let sessionId = Rokt.getSessionId()
+        let sessionId = Rokt.shared.roktImplementation.getSessionId()
 
         XCTAssertEqual(sessionId, expectedSessionId)
     }
 
     func test_Rokt_setSessionId_ignoresEmptyString() {
         let originalSessionId = "original-session-id"
-        Rokt.setSessionId(sessionId: originalSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: originalSessionId)
 
-        Rokt.setSessionId(sessionId: "")
+        Rokt.shared.roktImplementation.setSessionId(sessionId: "")
 
         // Empty string should be a no-op - original session should remain
-        XCTAssertEqual(Rokt.getSessionId(), originalSessionId)
+        XCTAssertEqual(Rokt.shared.roktImplementation.getSessionId(), originalSessionId)
     }
 }


### PR DESCRIPTION
## Background

Hybrid native + WebView integrations need to share more than a session id. Offers and events authorize with a short-lived session token (Bearer JWT) plus expiry, but the public setSessionId / getSessionId APIs only updated the legacy diagnostics session id and did not seed that token for the next offers/events call.

This PR adds additive APIs so partners can hand off the full session (id + token + expiry) and keep continuity across integrations. Existing session-id-only APIs stay source/binary compatible and are marked deprecated.

## What Has Changed

- Added public @objc RoktSession (sessionId, sessionToken, expiresAt in Unix epoch ms).
- Added Rokt.setSession(_:) and Rokt.getSession().
- setSession synchronously persists into the txn session store used by offers/events (so the next call can send Authorization: Bearer …), and mirrors the session id into the legacy session manager.
- getSession reads that store with the same tag-id / expiry rules; returns nil when uninitialized, missing, or expired.
- Deprecated setSessionId(sessionId:) and getSessionId() (behavior unchanged: legacy session id only).
- Extracted shared sync persist/load helpers used by TxnSessionManager and the public handoff path.
- Extended unit tests for round-trip, empty/blank no-ops, init gate, expiry clear, Bearer restore, and deprecated BC.

## How Has This Been Tested

- trunk check on changed files
- Unit tests: xcodebuild test -scheme Rokt-Widget for TestRokt and TestTxnSessionManager (all passed)
- xcodebuild build for rokt-Example
- periphery scan (no unused code)
- Tests/SizeReport/measure_size.sh

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
