### PR TITLE
feat(diagnostics): log public API usage as INFO diagnostics

### DIFF
--- a/Sources/Rokt_Widget/Models/RoktConfig+Internal.swift
+++ b/Sources/Rokt_Widget/Models/RoktConfig+Internal.swift
@@ -4,6 +4,15 @@ internal import RoktUXHelper
 // MARK: - RoktConfig SDK Extensions
 
 extension RoktConfig {
+    var colorModeDiagnosticValue: String {
+        switch colorMode {
+        case .light: return "light"
+        case .dark: return "dark"
+        case .system: return "system"
+        @unknown default: return "unknown"
+        }
+    }
+
     @available(iOS 15, *)
     func getUXConfig() -> RoktUXConfig {
         let builder = RoktUXConfig.Builder().logLevel(RoktLogger.shared.logLevel.toUXLogLevel())

--- a/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
+++ b/Sources/Rokt_Widget/Networking/RoktAPIHelper.swift
@@ -76,6 +76,17 @@ internal class RoktAPIHelper {
         }
     }
 
+    /// Log a partner-facing public API call as an INFO diagnostic.
+    /// Fire-and-forget; `sendDiagnostics` drops it pre-init via the `roktTagId` guard.
+    /// `additionalInfo` is non-PII only (booleans/counts/enums as strings) — never attribute values,
+    /// view names, URLs, session ids, or secrets.
+    class func logApiCalled(_ code: String, _ additionalInfo: [String: String] = [:]) {
+        sendDiagnostics(message: code,
+                        callStack: "public API called",
+                        severity: .info,
+                        additionalInfo: additionalInfo)
+    }
+
     /// Initialize a purchase for Shoppable Ads.
     ///
     /// - Parameters:

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -37,6 +37,20 @@ internal import RoktUXHelper
         )
     }
 
+    /// Logs a public mParticle API call as an INFO diagnostic. Called only by the mParticle Rokt
+    /// kit, and only when the kit is active — so nothing is logged when the kit isn't integrated.
+    ///
+    /// - Parameters:
+    ///   - code: A bounded, non-PII identifier in uppercase SNAKE_CASE (e.g. `"LOG_EVENT"`),
+    ///     wrapped for the wire as `[MP_API_<code>]`. Malformed codes are dropped. Never pass any
+    ///     argument data (event/screen names, attribute values, URLs, identities) — the code alone.
+    ///   - additionalInfo: Optional non-PII booleans/counts/enums as strings. Empty for core
+    ///     mParticle APIs (identity only).
+    public static func logMParticleApiCall(_ code: String, additionalInfo: [String: String] = [:]) {
+        guard RoktInternalImplementation.isValidMParticleApiCode(code) else { return }
+        shared.roktImplementation.logApiCallBuffered("[MP_API_\(code)]", additionalInfo)
+    }
+
     // MARK: - Rokt public functions
 
     /// Function to initialize the Rokt SDK

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -82,7 +82,7 @@ internal import RoktUXHelper
         RoktAPIHelper.logApiCalled(RoktInternalImplementation.apiSelectPlacementsCode, [
             "embedded": "\(placements != nil)",
             "hasConfig": "\(config != nil)",
-            "colorMode": RoktInternalImplementation.colorModeString(config),
+            "colorMode": config?.colorModeDiagnosticValue ?? "none",
             "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
             "hasPlacementOptions": "\(placementOptions != nil)",
             "attributeCount": "\(attributes.count)"

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -65,6 +65,14 @@ internal import RoktUXHelper
         placementOptions: RoktPlacementOptions? = nil,
         onEvent: ((RoktEvent) -> Void)? = nil
     ) {
+        RoktAPIHelper.logApiCalled(RoktInternalImplementation.apiSelectPlacementsCode, [
+            "embedded": "\(placements != nil)",
+            "hasConfig": "\(config != nil)",
+            "colorMode": RoktInternalImplementation.colorModeString(config),
+            "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
+            "hasPlacementOptions": "\(placementOptions != nil)",
+            "attributeCount": "\(attributes.count)"
+        ])
         shared.roktImplementation.execute(
             viewName: identifier,
             attributes: attributes,
@@ -129,6 +137,7 @@ internal import RoktUXHelper
     ///   - identifier: The identifier for the view / page where you're displaying the placement
     ///   - onEvent: Function to execute when some events triggered, the first item is RoktEvent
     public static func events(identifier: String, onEvent: ((RoktEvent) -> Void)?) {
+        RoktAPIHelper.logApiCalled(RoktInternalImplementation.apiEventsCode)
         shared.roktImplementation.mapEvents(viewName: identifier, onEvent: onEvent)
     }
 
@@ -138,6 +147,8 @@ internal import RoktUXHelper
     /// - Parameters:
     ///   - onEvent: Function to execute when some events triggered, the first item is RoktEvent
     public static func globalEvents(onEvent: @escaping ((RoktEvent) -> Void)) {
+        // Buffered: globalEvents is usually subscribed before init (to catch InitComplete).
+        shared.roktImplementation.logApiCallBuffered(RoktInternalImplementation.apiGlobalEventsCode)
         shared.roktImplementation.mapEvents(isGlobal: true, onEvent: onEvent)
     }
 
@@ -154,6 +165,7 @@ internal import RoktUXHelper
             RoktLogger.shared.warning("Rokt: custom base URL must use HTTPS and include a valid host - ignored.")
             return
         }
+        shared.roktImplementation.logApiCallBuffered(RoktInternalImplementation.apiSetCustomBaseURLCode)
         var components = URLComponents()
         components.scheme = "https"
         components.host = host

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -304,6 +304,17 @@ class RoktInternalImplementation {
         }
     }
 
+    /// Bounded, non-PII format guard for the mParticle public-API diagnostic codes forwarded by
+    /// the Rokt kit. Accepts uppercase SNAKE_CASE identifiers only (e.g. `LOG_EVENT`), 1...40
+    /// chars — which structurally excludes event/screen names, attribute values, URLs, and ids
+    /// from ever reaching the `code` tag. Malformed codes are dropped by the caller.
+    static func isValidMParticleApiCode(_ code: String) -> Bool {
+        guard (1...40).contains(code.count), let first = code.first, ("A"..."Z").contains(first) else {
+            return false
+        }
+        return code.allSatisfy { ("A"..."Z").contains($0) || ("0"..."9").contains($0) || $0 == "_" }
+    }
+
     /// Log a public API call, buffering it until init when the SDK isn't initialised yet. Only
     /// `setCustomBaseURL` / `setFrameworkType` need this (they run pre-init); everything else logs inline.
     func logApiCallBuffered(_ code: String, _ additionalInfo: [String: String] = [:]) {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -304,8 +304,8 @@ class RoktInternalImplementation {
         return code.allSatisfy { ("A"..."Z").contains($0) || ("0"..."9").contains($0) || $0 == "_" }
     }
 
-    /// Log a public API call, buffering it until init when the SDK isn't initialised yet. Only
-    /// `setCustomBaseURL` / `setFrameworkType` need this (they run pre-init); everything else logs inline.
+    /// Log a public API call, buffering it until init when the SDK isn't initialised yet. This supports
+    /// `globalEvents`, mParticle API forwarding, and configuration APIs that may run before init.
     func logApiCallBuffered(_ code: String, _ additionalInfo: [String: String] = [:]) {
         let shouldSend = pendingApiLogsLock.withLock {
             guard roktTagId == nil else { return true }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -11,6 +11,24 @@ class RoktInternalImplementation {
     private static let notInitializedDiagnosticCode = "[NOT_INITIALIZED]"
     private static let cacheHitDiagnosticCode = "[CACHE_HIT]"
     private static let cacheHitMessage = "Cache hit for view - %@"
+    // Public-API-usage diagnostics (INFO severity). Keep this a small, bounded set of codes.
+    static let apiInitCode = "[API_INIT]"
+    static let apiInitMParticleCode = "[API_INIT_MPARTICLE]"
+    static let apiSelectPlacementsCode = "[API_SELECT_PLACEMENTS]"
+    static let apiLayoutCode = "[API_LAYOUT]"
+    static let apiSelectShoppableAdsCode = "[API_SELECT_SHOPPABLE_ADS]"
+    static let apiPurchaseFinalizedCode = "[API_PURCHASE_FINALIZED]"
+    static let apiEventsCode = "[API_EVENTS]"
+    static let apiGlobalEventsCode = "[API_GLOBAL_EVENTS]"
+    static let apiCloseCode = "[API_CLOSE]"
+    static let apiRegisterPaymentExtensionCode = "[API_REGISTER_PAYMENT_EXTENSION]"
+    static let apiSetCustomBaseURLCode = "[API_SET_CUSTOM_BASE_URL]"
+    static let apiSetFrameworkTypeCode = "[API_SET_FRAMEWORK_TYPE]"
+    static let apiGetSessionIdCode = "[API_GET_SESSION_ID]"
+    static let apiSetSessionIdCode = "[API_SET_SESSION_ID]"
+    static let apiHandleURLCallbackCode = "[API_HANDLE_URL_CALLBACK]"
+    static let apiSetPayPalRedirectSchemeCode = "[API_SET_PAYPAL_REDIRECT_SCHEME]"
+    private static let maxPendingApiLogs = 10
     private static let initFailedError = "INIT_FAILED"
     private static let fontFailedError = "FONT_FAILED"
     private static let defaultRoktInitEvent = "DEFAULT_ROKT_INIT_EVENT"
@@ -34,6 +52,10 @@ class RoktInternalImplementation {
     var isInitialized = false
     var isInitFailedForFont = false
     private(set) var frameworkType: RoktFrameworkType = .iOS
+    // Public-API logs that arrive before init (setCustomBaseURL / setFrameworkType). Held until init
+    // sets `roktTagId`, then flushed — the diagnostics send needs the tag id for partner attribution.
+    private var pendingApiLogs: [(code: String, info: [String: String])] = []
+    private let pendingApiLogsLock = NSLock()
     var processedEvents: PlatformEventProcessor?
     var fontDiagnostics = FontDiagnosticsViewModel()
     // Feature flags
@@ -108,6 +130,7 @@ class RoktInternalImplementation {
     }
 
     func close() {
+        RoktAPIHelper.logApiCalled(Self.apiCloseCode)
         guard let window = UIApplication.shared.windows.filter({$0.isKeyWindow}).first,
               let rootViewController = window.rootViewController
         else {
@@ -129,6 +152,7 @@ class RoktInternalImplementation {
     }
 
     func purchaseFinalized(identifier: String, catalogItemId: String, success: Bool) {
+        RoktAPIHelper.logApiCalled(Self.apiPurchaseFinalizedCode, ["success": "\(success)"])
         guard let state = stateManager.find(where: \.instantPurchaseInitiated),
         let uxHelper = state.uxHelper as? RoktUX else { return }
         uxHelper.instantPurchaseFinalized(
@@ -236,6 +260,10 @@ class RoktInternalImplementation {
     ///   when ``PayPalRedirectURLSchemeValidator/shouldValidateAgainstInfoPlist`` is `true` (see that property for XCTest / sample-app **DEBUG** exceptions).
     @discardableResult
     func setBuiltInPayPalRedirectURLScheme(_ scheme: String?) -> Bool {
+        RoktAPIHelper.logApiCalled(
+            Self.apiSetPayPalRedirectSchemeCode,
+            ["hasScheme": "\(scheme?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)"]
+        )
         guard let scheme, !scheme.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             builtInPayPalRedirectURLScheme = nil
             return true
@@ -260,6 +288,43 @@ class RoktInternalImplementation {
 
     func setFrameworkType(_ frameworkType: RoktFrameworkType) {
         self.frameworkType = frameworkType
+        logApiCallBuffered(Self.apiSetFrameworkTypeCode, ["frameworkType": frameworkType.toString])
+    }
+
+    // MARK: - Public API usage diagnostics
+
+    /// Map a partner-supplied RoktConfig color mode to a bounded, non-PII string tag.
+    static func colorModeString(_ config: RoktConfig?) -> String {
+        guard let colorMode = config?.colorMode else { return "none" }
+        switch colorMode {
+        case .light: return "light"
+        case .dark: return "dark"
+        case .system: return "system"
+        @unknown default: return "unknown"
+        }
+    }
+
+    /// Log a public API call, buffering it until init when the SDK isn't initialised yet. Only
+    /// `setCustomBaseURL` / `setFrameworkType` need this (they run pre-init); everything else logs inline.
+    func logApiCallBuffered(_ code: String, _ additionalInfo: [String: String] = [:]) {
+        guard roktTagId == nil else {
+            RoktAPIHelper.logApiCalled(code, additionalInfo)
+            return
+        }
+        pendingApiLogsLock.lock()
+        defer { pendingApiLogsLock.unlock() }
+        // Bounded buffer — a wrapper spamming setFrameworkType pre-init must not grow it unbounded.
+        guard pendingApiLogs.count < Self.maxPendingApiLogs else { return }
+        pendingApiLogs.append((code, additionalInfo))
+    }
+
+    /// Flush buffered pre-init public-API logs once init has set `roktTagId`.
+    private func flushPendingApiLogs() {
+        pendingApiLogsLock.lock()
+        let logs = pendingApiLogs
+        pendingApiLogs.removeAll()
+        pendingApiLogsLock.unlock()
+        logs.forEach { RoktAPIHelper.logApiCalled($0.code, $0.info) }
     }
 
     // Shows the widget on top the visible view controller
@@ -847,6 +912,8 @@ class RoktInternalImplementation {
 
         self.roktTagId = roktTagId
         sessionManager.storedTagId = roktTagId
+        RoktAPIHelper.logApiCalled(mParticleKitDetails != nil ? Self.apiInitMParticleCode : Self.apiInitCode)
+        flushPendingApiLogs()
         isInitFailedForFont = false
         FontManager.resetFontRecoveryState()
         stateManager = StateBagManager()
@@ -1297,6 +1364,12 @@ class RoktInternalImplementation {
         placementOptions: RoktPlacementOptions? = nil,
         onRoktEvent: ((RoktEvent) -> Void)? = nil
     ) {
+        RoktAPIHelper.logApiCalled(Self.apiLayoutCode, [
+            "hasConfig": "\(config != nil)",
+            "colorMode": Self.colorModeString(config),
+            "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
+            "attributeCount": "\(attributes.count)"
+        ])
         _swiftUiExecuteLayout = layout
         execute(
             viewName: viewName,
@@ -1334,17 +1407,21 @@ class RoktInternalImplementation {
         guard !sessionId.isEmpty else {
             return
         }
+        RoktAPIHelper.logApiCalled(Self.apiSetSessionIdCode)
         sessionManager.updateSessionId(newSessionId: sessionId)
     }
 
     func getSessionId() -> String? {
-        return sessionManager.getCurrentSessionIdWithoutExpiring()
+        let sessionId = sessionManager.getCurrentSessionIdWithoutExpiring()
+        RoktAPIHelper.logApiCalled(Self.apiGetSessionIdCode, ["hasSession": "\(sessionId != nil)"])
+        return sessionId
     }
 
     // MARK: - Payment Extension
 
     /// Register a payment extension for Shoppable Ads.
     func registerPaymentExtension(_ paymentExtension: PaymentExtension, config: [String: String]) {
+        RoktAPIHelper.logApiCalled(Self.apiRegisterPaymentExtensionCode, ["hasConfig": "\(!config.isEmpty)"])
         if !paymentOrchestrator.register(paymentExtension, config: config) {
             RoktLogger.shared.error("Rokt: Failed to register payment extension: \(paymentExtension.id)")
             RoktAPIHelper.sendDiagnostics(
@@ -1358,7 +1435,9 @@ class RoktInternalImplementation {
     /// Forward a URL to registered payment extensions.
     @discardableResult
     func handleURLCallback(with url: URL) -> Bool {
-        paymentOrchestrator.handleURLCallback(with: url)
+        let handled = paymentOrchestrator.handleURLCallback(with: url)
+        RoktAPIHelper.logApiCalled(Self.apiHandleURLCallbackCode, ["handled": "\(handled)"])
+        return handled
     }
 
     // MARK: - Shoppable Ads
@@ -1373,6 +1452,12 @@ class RoktInternalImplementation {
         config: RoktConfig?,
         onRoktEvent: ((RoktEvent) -> Void)?
     ) {
+        RoktAPIHelper.logApiCalled(Self.apiSelectShoppableAdsCode, [
+            "hasConfig": "\(config != nil)",
+            "colorMode": Self.colorModeString(config),
+            "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
+            "attributeCount": "\(attributes.count)"
+        ])
         if isInitialized && !validateShoppableAdsFeatureFlag(identifier: identifier, onFailure: onRoktEvent) { return }
         guard validateShoppableAdsPaymentExtension(identifier: identifier, onFailure: onRoktEvent) else { return }
 

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -293,17 +293,6 @@ class RoktInternalImplementation {
 
     // MARK: - Public API usage diagnostics
 
-    /// Map a partner-supplied RoktConfig color mode to a bounded, non-PII string tag.
-    static func colorModeString(_ config: RoktConfig?) -> String {
-        guard let colorMode = config?.colorMode else { return "none" }
-        switch colorMode {
-        case .light: return "light"
-        case .dark: return "dark"
-        case .system: return "system"
-        @unknown default: return "unknown"
-        }
-    }
-
     /// Bounded, non-PII format guard for the mParticle public-API diagnostic codes forwarded by
     /// the Rokt kit. Accepts uppercase SNAKE_CASE identifiers only (e.g. `LOG_EVENT`), 1...40
     /// chars — which structurally excludes event/screen names, attribute values, URLs, and ids
@@ -318,24 +307,27 @@ class RoktInternalImplementation {
     /// Log a public API call, buffering it until init when the SDK isn't initialised yet. Only
     /// `setCustomBaseURL` / `setFrameworkType` need this (they run pre-init); everything else logs inline.
     func logApiCallBuffered(_ code: String, _ additionalInfo: [String: String] = [:]) {
-        guard roktTagId == nil else {
-            RoktAPIHelper.logApiCalled(code, additionalInfo)
-            return
+        let shouldSend = pendingApiLogsLock.withLock {
+            guard roktTagId == nil else { return true }
+            // Bounded buffer — a wrapper spamming setFrameworkType pre-init must not grow it unbounded.
+            guard pendingApiLogs.count < Self.maxPendingApiLogs else { return false }
+            pendingApiLogs.append((code, additionalInfo))
+            return false
         }
-        pendingApiLogsLock.lock()
-        defer { pendingApiLogsLock.unlock() }
-        // Bounded buffer — a wrapper spamming setFrameworkType pre-init must not grow it unbounded.
-        guard pendingApiLogs.count < Self.maxPendingApiLogs else { return }
-        pendingApiLogs.append((code, additionalInfo))
+        if shouldSend {
+            RoktAPIHelper.logApiCalled(code, additionalInfo)
+        }
     }
 
-    /// Flush buffered pre-init public-API logs once init has set `roktTagId`.
-    private func flushPendingApiLogs() {
-        pendingApiLogsLock.lock()
-        let logs = pendingApiLogs
-        pendingApiLogs.removeAll()
-        pendingApiLogsLock.unlock()
-        logs.forEach { RoktAPIHelper.logApiCalled($0.code, $0.info) }
+    func setRoktTagIdAndDrainPendingApiLogs(
+        _ roktTagId: String
+    ) -> [(code: String, info: [String: String])] {
+        pendingApiLogsLock.withLock {
+            self.roktTagId = roktTagId
+            let logs = pendingApiLogs
+            pendingApiLogs.removeAll()
+            return logs
+        }
     }
 
     // Shows the widget on top the visible view controller
@@ -921,10 +913,10 @@ class RoktInternalImplementation {
             NetworkingHelper.updateMParticleKitDetails(mParticleKitDetails: mParticleKitDetails)
         }
 
-        self.roktTagId = roktTagId
+        let pendingApiLogs = setRoktTagIdAndDrainPendingApiLogs(roktTagId)
         sessionManager.storedTagId = roktTagId
         RoktAPIHelper.logApiCalled(mParticleKitDetails != nil ? Self.apiInitMParticleCode : Self.apiInitCode)
-        flushPendingApiLogs()
+        pendingApiLogs.forEach { RoktAPIHelper.logApiCalled($0.code, $0.info) }
         isInitFailedForFont = false
         FontManager.resetFontRecoveryState()
         stateManager = StateBagManager()
@@ -1377,7 +1369,7 @@ class RoktInternalImplementation {
     ) {
         RoktAPIHelper.logApiCalled(Self.apiLayoutCode, [
             "hasConfig": "\(config != nil)",
-            "colorMode": Self.colorModeString(config),
+            "colorMode": config?.colorModeDiagnosticValue ?? "none",
             "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
             "attributeCount": "\(attributes.count)"
         ])
@@ -1465,7 +1457,7 @@ class RoktInternalImplementation {
     ) {
         RoktAPIHelper.logApiCalled(Self.apiSelectShoppableAdsCode, [
             "hasConfig": "\(config != nil)",
-            "colorMode": Self.colorModeString(config),
+            "colorMode": config?.colorModeDiagnosticValue ?? "none",
             "cacheEnabled": "\(config?.cacheConfig.isCacheEnabled() == true)",
             "attributeCount": "\(attributes.count)"
         ])

--- a/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
+++ b/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Mocker
 @testable import Rokt_Widget
 
 /// Verifies the public-API-usage INFO diagnostics emitted on partner API calls.
@@ -11,6 +12,7 @@ final class TestPublicApiDiagnostics: XCTestCase {
     }
 
     override func tearDown() {
+        Mocker.removeAll()
         Rokt.shared.roktImplementation.roktTagId = nil
         super.tearDown()
     }

--- a/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
+++ b/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
@@ -60,4 +60,42 @@ final class TestPublicApiDiagnostics: XCTestCase {
 
         wait(for: [exp], timeout: 0.5)
     }
+
+    func test_logMParticleApiCall_sendsPrefixedInfoDiagnosticWithNoAdditionalInfo() {
+        let exp = expectation(description: "diagnostic received")
+        var received: StubbedDiagnosticsModel?
+        stubDiagnostics(onDiagnosticsModelReceive: { received = $0; exp.fulfill() })
+
+        Rokt.logMParticleApiCall("LOG_EVENT")
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(received?.code, "[MP_API_LOG_EVENT]")
+        XCTAssertEqual(received?.severity, "INFO")
+    }
+
+    func test_logMParticleApiCall_dropsMalformedCode_doesNotSend() {
+        let exp = expectation(description: "no diagnostic for malformed code")
+        exp.isInverted = true
+        stubDiagnostics(onDiagnosticsReceive: { _ in exp.fulfill() })
+
+        // Lowercase, spaces, PII-shaped, empty, and over-length are all rejected by the guard.
+        Rokt.logMParticleApiCall("log_event")
+        Rokt.logMParticleApiCall("user email@example.com")
+        Rokt.logMParticleApiCall("")
+        Rokt.logMParticleApiCall(String(repeating: "A", count: 41))
+
+        wait(for: [exp], timeout: 0.5)
+    }
+
+    func test_isValidMParticleApiCode_boundsShapeToUppercaseSnakeCase() {
+        XCTAssertTrue(RoktInternalImplementation.isValidMParticleApiCode("LOG_EVENT"))
+        XCTAssertTrue(RoktInternalImplementation.isValidMParticleApiCode("SET_USER_ATTRIBUTE_LIST"))
+        XCTAssertTrue(RoktInternalImplementation.isValidMParticleApiCode("A"))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode("log_event"))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode("_LEADING_UNDERSCORE"))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode("HAS SPACE"))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode("user@x.com"))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode(""))
+        XCTAssertFalse(RoktInternalImplementation.isValidMParticleApiCode(String(repeating: "A", count: 41)))
+    }
 }

--- a/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
+++ b/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
@@ -17,11 +17,12 @@ final class TestPublicApiDiagnostics: XCTestCase {
         super.tearDown()
     }
 
-    func test_colorModeString_mapsEveryModeToBoundedNonPIIString() {
-        XCTAssertEqual(RoktInternalImplementation.colorModeString(nil), "none")
-        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.light).build()), "light")
-        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.dark).build()), "dark")
-        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.system).build()), "system")
+    func test_colorModeDiagnosticValue_mapsEveryModeToBoundedNonPIIString() {
+        let missingConfig: RoktConfig? = nil
+        XCTAssertEqual(missingConfig?.colorModeDiagnosticValue ?? "none", "none")
+        XCTAssertEqual(RoktConfig.Builder().colorMode(.light).build().colorModeDiagnosticValue, "light")
+        XCTAssertEqual(RoktConfig.Builder().colorMode(.dark).build().colorModeDiagnosticValue, "dark")
+        XCTAssertEqual(RoktConfig.Builder().colorMode(.system).build().colorModeDiagnosticValue, "system")
     }
 
     func test_purchaseFinalized_sendsApiPurchaseFinalizedInfoDiagnostic() {
@@ -59,6 +60,17 @@ final class TestPublicApiDiagnostics: XCTestCase {
         Rokt.shared.roktImplementation.logApiCallBuffered(RoktInternalImplementation.apiSetFrameworkTypeCode)
 
         wait(for: [exp], timeout: 0.5)
+    }
+
+    func test_bufferedApiCall_beforeInit_isDrainedOnceWhenTagIdIsSet() {
+        let implementation = RoktInternalImplementation()
+        implementation.logApiCallBuffered(RoktInternalImplementation.apiSetFrameworkTypeCode)
+
+        let logs = implementation.setRoktTagIdAndDrainPendingApiLogs("123")
+
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.code, "[API_SET_FRAMEWORK_TYPE]")
+        XCTAssertTrue(implementation.setRoktTagIdAndDrainPendingApiLogs("123").isEmpty)
     }
 
     func test_logMParticleApiCall_sendsPrefixedInfoDiagnosticWithNoAdditionalInfo() {

--- a/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
+++ b/Tests/Rokt_WidgetTests/TestPublicApiDiagnostics.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Rokt_Widget
+
+/// Verifies the public-API-usage INFO diagnostics emitted on partner API calls.
+final class TestPublicApiDiagnostics: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Satisfy the `roktTagId != nil` send guard without running a full init.
+        Rokt.shared.roktImplementation.roktTagId = "123"
+    }
+
+    override func tearDown() {
+        Rokt.shared.roktImplementation.roktTagId = nil
+        super.tearDown()
+    }
+
+    func test_colorModeString_mapsEveryModeToBoundedNonPIIString() {
+        XCTAssertEqual(RoktInternalImplementation.colorModeString(nil), "none")
+        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.light).build()), "light")
+        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.dark).build()), "dark")
+        XCTAssertEqual(RoktInternalImplementation.colorModeString(RoktConfig.Builder().colorMode(.system).build()), "system")
+    }
+
+    func test_purchaseFinalized_sendsApiPurchaseFinalizedInfoDiagnostic() {
+        let exp = expectation(description: "diagnostic received")
+        var received: StubbedDiagnosticsModel?
+        stubDiagnostics(onDiagnosticsModelReceive: { model in
+            received = model
+            exp.fulfill()
+        })
+
+        Rokt.shared.roktImplementation.purchaseFinalized(identifier: "id", catalogItemId: "cat", success: true)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(received?.code, "[API_PURCHASE_FINALIZED]")
+        XCTAssertEqual(received?.severity, "INFO")
+    }
+
+    func test_bufferedApiCall_afterInit_sendsInline() {
+        let exp = expectation(description: "diagnostic received")
+        var code: String?
+        stubDiagnostics(onDiagnosticsReceive: { code = $0; exp.fulfill() })
+
+        Rokt.shared.roktImplementation.logApiCallBuffered(RoktInternalImplementation.apiSetCustomBaseURLCode)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(code, "[API_SET_CUSTOM_BASE_URL]")
+    }
+
+    func test_bufferedApiCall_beforeInit_doesNotSend() {
+        Rokt.shared.roktImplementation.roktTagId = nil
+        let exp = expectation(description: "no diagnostic before init")
+        exp.isInverted = true
+        stubDiagnostics(onDiagnosticsReceive: { _ in exp.fulfill() })
+
+        Rokt.shared.roktImplementation.logApiCallBuffered(RoktInternalImplementation.apiSetFrameworkTypeCode)
+
+        wait(for: [exp], timeout: 0.5)
+    }
+}


### PR DESCRIPTION
## Background

We currently have no visibility into which public SDK APIs partners actually call, how often, or how they integrate (SwiftUI `RoktLayout` vs the imperative `selectPlacements`). This adds a lightweight INFO diagnostic on every partner-facing public API call so usage is observable, plus non-PII hints about the parameters passed. It reuses the existing `sendDiagnostics` pipeline — no new networking and no backend change.

Fixes N/A

## What Has Changed

- New `RoktAPIHelper.logApiCalled(_:_:)` helper that emits an INFO diagnostic with a distinct code per public API. Fire-and-forget; self-guards on `roktTagId` so it never throws into or blocks the partner call.
- Instrumented the public API surface with distinct codes: `init`, `selectPlacements`, the SwiftUI `RoktLayout`, `selectShoppableAds`, `purchaseFinalized`, `events`, `globalEvents`, `close`, `registerPaymentExtension`, `setCustomBaseURL`, `setFrameworkType`, `getSessionId`, `setSessionId`, `handleURLCallback`, and `setBuiltInPayPalRedirectURLScheme`.
- `RoktLayout` (SwiftUI) and `selectPlacements` get separate codes, so the declarative-vs-imperative integration split is visible.
- Calls that normally run before `init` (`setCustomBaseURL`, `setFrameworkType`, `globalEvents`) are buffered and flushed once `init` sets the tag id, so they still get attributed. The buffer is bounded and thread-safe.
- `additionalInformation` carries non-PII hints only (booleans/counts/enums as strings): e.g. `hasConfig`, `colorMode`, `cacheEnabled`, `embedded`, `attributeCount`, `frameworkType`, `success`. Never logged: attribute values, view names, URLs, session ids, the redirect URL, or payment-extension config/secrets.

## How Has This Been Tested

- New unit tests in `TestPublicApiDiagnostics.swift` (4 tests): a representative public call emits the expected code at INFO severity; the color-mode mapping; and the pre-init buffer routing (buffered before init, sent inline after). All pass.
- `xcodebuild test -scheme Rokt-Widget` on iOS Simulator: build succeeds, tests pass, no new warnings from these changes.

## Notes

Logging reuses the existing diagnostics endpoint and severity levels; there is no change to the request contract or any backend service.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
