### PR TITLE
fix: use Pact branch selector in Release Draft gate

### DIFF
--- a/.github/workflows/pact-consumer.yml
+++ b/.github/workflows/pact-consumer.yml
@@ -1,13 +1,16 @@
 name: Pact Consumer
 
 # Generates the consumer pact on every PR, publishes it to the broker on
-# same-repo PR pushes and main, then runs a blocking contract check against
-# production. Release – Draft runs the same check before opening a release PR.
+# same-repo PR pushes and pushes to main/maintenance/*, then runs a blocking
+# contract check against production. Release – Draft runs the same check
+# before opening a release PR.
 
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - maintenance/*
 
 permissions:
   contents: read
@@ -98,13 +101,14 @@ jobs:
   publish:
     name: Publish to Broker
     needs: [consumer-test, detect-changes]
-    # Main pushes and same-repo (non-fork) PR pushes with contract changes.
-    # Skip Dependabot: its secret store has no pact-publish environment credentials.
+    # Push events (main/maintenance/* via on.push.branches) and same-repo
+    # (non-fork) PR pushes with contract changes. Skip Dependabot: its secret
+    # store has no pact-publish environment credentials.
     if: |
       needs.detect-changes.outputs.contract == 'true'
       && github.actor != 'dependabot[bot]'
       && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        github.event_name == 'push'
         || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,8 +23,8 @@ jobs:
   contract-verified:
     name: Contract verified vs production
     runs-on: ubuntu-latest
-    # Blocking: refuse to open a release PR unless the latest main consumer
-    # contract is verified against the provider currently in production.
+    # Blocking: refuse to open a release PR unless the latest consumer
+    # contract for this branch is verified against production.
     environment: pact-publish
     steps:
       - name: Check provider verification
@@ -32,6 +32,7 @@ jobs:
           PACT_BROKER_BASE_URL: ${{ vars.PACT_BROKER_BASE_URL }}
           PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          PACT_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           # renovate: datasource=docker depName=pactfoundation/pact-cli
@@ -43,7 +44,7 @@ jobs:
             "${PACT_CLI_IMAGE}" \
             broker can-i-deploy \
               --pacticipant rokt-sdk-ios \
-              --latest --branch main \
+              --latest --branch "${PACT_BRANCH}" \
               --to-environment production
 
   prepare-release:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -43,7 +43,7 @@ jobs:
             "${PACT_CLI_IMAGE}" \
             broker can-i-deploy \
               --pacticipant rokt-sdk-ios \
-              --latest main \
+              --latest --branch main \
               --to-environment production
 
   prepare-release:


### PR DESCRIPTION
## Background
Release – Draft fails with `No version with tag main exists` because `can-i-deploy --latest main` looks up a Pact tag, while publish only sets branch `main`.

## What Has Changed
- Switched the Release Draft contract gate to `--latest --branch main` so it matches how consumer pacts are published

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.