### PR TITLE
feat: Update sharing session token in hybrid apps

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -41,6 +41,13 @@ lint:
         - Tests/SizeReport/**/Assets.xcassets/**/*.json
         - Example/Tests/**/*.json
         - periphery-baseline.json
+    # XCTest method names (`test_…`) are false-positive Lob API key shapes under
+    # trufflehog; CI uses check-mode: all so these otherwise fail the PR gate.
+    - linters: [trufflehog]
+      paths:
+        - Tests/**
+        - Packages/**/Tests/**
+        - Example/Tests/**
   enabled:
     - objc-prop-check
     - actionlint@1.7.12

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -41,13 +41,6 @@ lint:
         - Tests/SizeReport/**/Assets.xcassets/**/*.json
         - Example/Tests/**/*.json
         - periphery-baseline.json
-    # XCTest method names (`test_…`) are false-positive Lob API key shapes under
-    # trufflehog; CI uses check-mode: all so these otherwise fail the PR gate.
-    - linters: [trufflehog]
-      paths:
-        - Tests/**
-        - Packages/**/Tests/**
-        - Example/Tests/**
   enabled:
     - objc-prop-check
     - actionlint@1.7.12

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -2,14 +2,6 @@
 import Foundation
 
 internal actor TxnSessionManager {
-    private enum Keys {
-        static let tagId = "ROKT_TXN_TAG_ID"
-        static let sessionId = "ROKT_TXN_SESSION_ID"
-        static let token = "ROKT_TXN_SESSION_TOKEN"
-        static let expiresAt = "ROKT_TXN_TOKEN_EXPIRES_AT"
-        static let epoch = "ROKT_TXN_SESSION_EPOCH"
-    }
-
     // Actor isolation is not enough: `clearPersistedSession` is nonisolated, so without this it
     // can land between the epoch check and the write in `update` and restore a dropped session.
     private static let storeLock = NSLock()
@@ -107,17 +99,13 @@ internal actor TxnSessionManager {
     ) {
         storeLock.lock()
         defer { storeLock.unlock() }
-        store.removeValue(forKey: Keys.tagId)
-        store.removeValue(forKey: Keys.sessionId)
-        store.removeValue(forKey: Keys.token)
-        store.removeValue(forKey: Keys.expiresAt)
-        let current = Int(store.string(forKey: Keys.epoch) ?? "") ?? 0
-        store.setString(String(current &+ 1), forKey: Keys.epoch)
+        TxnSessionPersistence.clear(store: store)
+        let current = Int(store.string(forKey: TxnSessionStoreKeys.epoch) ?? "") ?? 0
+        store.setString(String(current &+ 1), forKey: TxnSessionStoreKeys.epoch)
     }
 
     private var hasExpired: Bool {
-        guard let expiresAt else { return true }
-        return clock() >= expiresAt
+        TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: clock)
     }
 
     // MARK: - Store access (callers must already hold `storeLock`; NSLock is not reentrant)
@@ -128,7 +116,7 @@ internal actor TxnSessionManager {
     }
 
     private func storedEpochLocked(_ store: TxnSessionStore) -> Int {
-        Int(store.string(forKey: Keys.epoch) ?? "") ?? 0
+        Int(store.string(forKey: TxnSessionStoreKeys.epoch) ?? "") ?? 0
     }
 
     private func restoreFromStore() {
@@ -137,15 +125,14 @@ internal actor TxnSessionManager {
         defer { Self.storeLock.unlock() }
         capturedEpoch = storedEpochLocked(store)
         // Only restore a session bound to the current tag id; otherwise start clean.
-        guard store.string(forKey: Keys.tagId) == roktTagId else {
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
             clearStateLocked(bumpEpoch: false)
             return
         }
-        sessionId = store.string(forKey: Keys.sessionId)
-        token = store.string(forKey: Keys.token)
-        expiresAt = store.string(forKey: Keys.expiresAt)
-            .flatMap(Double.init)
-            .map { Date(timeIntervalSince1970: $0/1000) }
+        let raw = TxnSessionPersistence.readRaw(store: store)
+        sessionId = raw.sessionId
+        token = raw.token
+        expiresAt = raw.expiresAt
         // An expired JWT is dead server-side; start clean and let init mint a fresh session.
         if hasExpired {
             clearStateLocked(bumpEpoch: false)
@@ -159,28 +146,22 @@ internal actor TxnSessionManager {
         token = nil
         expiresAt = nil
         guard let store else { return }
-        store.removeValue(forKey: Keys.tagId)
-        store.removeValue(forKey: Keys.sessionId)
-        store.removeValue(forKey: Keys.token)
-        store.removeValue(forKey: Keys.expiresAt)
+        TxnSessionPersistence.clear(store: store)
         guard bumpEpoch else { return }
         let next = storedEpochLocked(store) &+ 1
-        store.setString(String(next), forKey: Keys.epoch)
+        store.setString(String(next), forKey: TxnSessionStoreKeys.epoch)
         capturedEpoch = next
     }
 
     private func persistLocked(includeSessionId: Bool) {
         guard let store, let roktTagId else { return }
-        // restoreFromStore treats a missing tag id as another account's data, so always record it.
-        store.setString(roktTagId, forKey: Keys.tagId)
-        if includeSessionId, let sessionId {
-            store.setString(sessionId, forKey: Keys.sessionId)
-        }
-        if let token {
-            store.setString(token, forKey: Keys.token)
-        }
-        if let expiresAt {
-            store.setString(String(expiresAt.timeIntervalSince1970 * 1000), forKey: Keys.expiresAt)
-        }
+        TxnSessionPersistence.persist(
+            roktTagId: roktTagId,
+            sessionId: sessionId,
+            token: token,
+            expiresAt: expiresAt,
+            includeSessionId: includeSessionId,
+            store: store
+        )
     }
 }

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionManager.swift
@@ -125,7 +125,9 @@ internal actor TxnSessionManager {
         defer { Self.storeLock.unlock() }
         capturedEpoch = storedEpochLocked(store)
         // Only restore a session bound to the current tag id; otherwise start clean.
-        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+        // Must not call `clear()` here: we already hold `storeLock` (it is not reentrant),
+        // and bumping the epoch would fence a healthy in-flight writer.
+        guard TxnSessionPersistence.isBound(to: roktTagId, store: store) else {
             clearStateLocked(bumpEpoch: false)
             return
         }
@@ -133,9 +135,12 @@ internal actor TxnSessionManager {
         sessionId = raw.sessionId
         token = raw.token
         expiresAt = raw.expiresAt
-        // An expired JWT is dead server-side; start clean and let init mint a fresh session.
-        if hasExpired {
-            clearStateLocked(bumpEpoch: false)
+        // Drop a persisted-but-expired token so we never start with stale state;
+        // an expired JWT is dead server-side and a fresh session is minted at init.
+        if TxnSessionPersistence.clearIfExpired(expiresAt: expiresAt, store: store, clock: clock) {
+            sessionId = nil
+            token = nil
+            expiresAt = nil
         }
     }
 

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
@@ -1,4 +1,3 @@
-// periphery:ignore:all
 import Foundation
 
 /// UserDefaults keys shared by ``TxnSessionManager`` and the public session handoff APIs.
@@ -33,30 +32,8 @@ internal enum TxnSessionPersistence {
         store.setString(String(sessionToken.expiresAt), forKey: TxnSessionStoreKeys.expiresAt)
     }
 
-    /// Loads a valid session for `roktTagId`. Clears the store and returns `nil` on
-    /// tag mismatch or expired token (same rules as ``TxnSessionManager`` restore).
-    static func load(
-        roktTagId: String,
-        store: TxnSessionStore = UserDefaultsTxnSessionStore(),
-        clock: () -> Date = Date.init
-    ) -> TxnSessionSnapshot? {
-        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
-            clear(store: store)
-            return nil
-        }
-
-        let sessionId = store.string(forKey: TxnSessionStoreKeys.sessionId)
-        let token = store.string(forKey: TxnSessionStoreKeys.token)
-        let expiresAt = store.string(forKey: TxnSessionStoreKeys.expiresAt)
-            .flatMap(Double.init)
-            .map { Date(timeIntervalSince1970: $0/1000) }
-
-        if isExpired(expiresAt: expiresAt, clock: clock) {
-            clear(store: store)
-            return nil
-        }
-
-        return TxnSessionSnapshot(sessionId: sessionId, token: token, expiresAt: expiresAt)
+    static func isBound(to roktTagId: String, store: TxnSessionStore) -> Bool {
+        store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId
     }
 
     static func clear(store: TxnSessionStore) {
@@ -74,7 +51,7 @@ internal enum TxnSessionPersistence {
         includeSessionId: Bool,
         store: TxnSessionStore
     ) {
-        // Always record the tag-id binding: load treats a missing/mismatched
+        // Always record the tag-id binding: restore treats a missing/mismatched
         // tag id as another account's data and clears the session, so a token persisted
         // without it would never survive a reload.
         store.setString(roktTagId, forKey: TxnSessionStoreKeys.tagId)
@@ -92,6 +69,20 @@ internal enum TxnSessionPersistence {
     static func isExpired(expiresAt: Date?, clock: () -> Date) -> Bool {
         guard let expiresAt else { return true }
         return clock() >= expiresAt
+    }
+
+    /// Clears the store when the snapshot is expired. Returns `true` if it cleared.
+    @discardableResult
+    static func clearIfExpired(
+        expiresAt: Date?,
+        store: TxnSessionStore,
+        clock: () -> Date
+    ) -> Bool {
+        guard isExpired(expiresAt: expiresAt, clock: clock) else {
+            return false
+        }
+        clear(store: store)
+        return true
     }
 
     static func readRaw(store: TxnSessionStore) -> TxnSessionSnapshot {

--- a/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
+++ b/Sources/Rokt_Widget/DataAccess/TxnSessionPersistence.swift
@@ -1,0 +1,105 @@
+// periphery:ignore:all
+import Foundation
+
+/// UserDefaults keys shared by ``TxnSessionManager`` and the public session handoff APIs.
+internal enum TxnSessionStoreKeys {
+    static let tagId = "ROKT_TXN_TAG_ID"
+    static let sessionId = "ROKT_TXN_SESSION_ID"
+    static let token = "ROKT_TXN_SESSION_TOKEN"
+    static let expiresAt = "ROKT_TXN_TOKEN_EXPIRES_AT"
+    static let epoch = "ROKT_TXN_SESSION_EPOCH"
+}
+
+/// In-memory view of a persisted txn session (id + JWT + expiry).
+internal struct TxnSessionSnapshot: Equatable {
+    let sessionId: String?
+    let token: String?
+    let expiresAt: Date?
+}
+
+/// Synchronous read/write for the txn session store so public APIs can seed state
+/// before the next offers/events call constructs a ``TxnSessionManager``.
+internal enum TxnSessionPersistence {
+    static func seed(
+        roktTagId: String,
+        sessionId: String,
+        sessionToken: TxnSessionToken,
+        store: TxnSessionStore = UserDefaultsTxnSessionStore()
+    ) {
+        store.setString(roktTagId, forKey: TxnSessionStoreKeys.tagId)
+        store.setString(sessionId, forKey: TxnSessionStoreKeys.sessionId)
+        store.setString(sessionToken.token, forKey: TxnSessionStoreKeys.token)
+        // Persist epoch ms as an integer string so public getSession round-trips without float drift.
+        store.setString(String(sessionToken.expiresAt), forKey: TxnSessionStoreKeys.expiresAt)
+    }
+
+    /// Loads a valid session for `roktTagId`. Clears the store and returns `nil` on
+    /// tag mismatch or expired token (same rules as ``TxnSessionManager`` restore).
+    static func load(
+        roktTagId: String,
+        store: TxnSessionStore = UserDefaultsTxnSessionStore(),
+        clock: () -> Date = Date.init
+    ) -> TxnSessionSnapshot? {
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+            clear(store: store)
+            return nil
+        }
+
+        let sessionId = store.string(forKey: TxnSessionStoreKeys.sessionId)
+        let token = store.string(forKey: TxnSessionStoreKeys.token)
+        let expiresAt = store.string(forKey: TxnSessionStoreKeys.expiresAt)
+            .flatMap(Double.init)
+            .map { Date(timeIntervalSince1970: $0/1000) }
+
+        if isExpired(expiresAt: expiresAt, clock: clock) {
+            clear(store: store)
+            return nil
+        }
+
+        return TxnSessionSnapshot(sessionId: sessionId, token: token, expiresAt: expiresAt)
+    }
+
+    static func clear(store: TxnSessionStore) {
+        store.removeValue(forKey: TxnSessionStoreKeys.tagId)
+        store.removeValue(forKey: TxnSessionStoreKeys.sessionId)
+        store.removeValue(forKey: TxnSessionStoreKeys.token)
+        store.removeValue(forKey: TxnSessionStoreKeys.expiresAt)
+    }
+
+    static func persist(
+        roktTagId: String,
+        sessionId: String?,
+        token: String?,
+        expiresAt: Date?,
+        includeSessionId: Bool,
+        store: TxnSessionStore
+    ) {
+        // Always record the tag-id binding: load treats a missing/mismatched
+        // tag id as another account's data and clears the session, so a token persisted
+        // without it would never survive a reload.
+        store.setString(roktTagId, forKey: TxnSessionStoreKeys.tagId)
+        if includeSessionId, let sessionId {
+            store.setString(sessionId, forKey: TxnSessionStoreKeys.sessionId)
+        }
+        if let token {
+            store.setString(token, forKey: TxnSessionStoreKeys.token)
+        }
+        if let expiresAt {
+            store.setString(String(expiresAt.timeIntervalSince1970 * 1000), forKey: TxnSessionStoreKeys.expiresAt)
+        }
+    }
+
+    static func isExpired(expiresAt: Date?, clock: () -> Date) -> Bool {
+        guard let expiresAt else { return true }
+        return clock() >= expiresAt
+    }
+
+    static func readRaw(store: TxnSessionStore) -> TxnSessionSnapshot {
+        let sessionId = store.string(forKey: TxnSessionStoreKeys.sessionId)
+        let token = store.string(forKey: TxnSessionStoreKeys.token)
+        let expiresAt = store.string(forKey: TxnSessionStoreKeys.expiresAt)
+            .flatMap(Double.init)
+            .map { Date(timeIntervalSince1970: $0/1000) }
+        return TxnSessionSnapshot(sessionId: sessionId, token: token, expiresAt: expiresAt)
+    }
+}

--- a/Sources/Rokt_Widget/Models/RoktSession.swift
+++ b/Sources/Rokt_Widget/Models/RoktSession.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A Rokt session suitable for handoff between native and non-native integrations (e.g. WebView).
+///
+/// Includes the session id plus the short-lived session token used to authorize offers and events.
+@objc public class RoktSession: NSObject {
+    /// The Rokt session identifier.
+    @objc public let sessionId: String
+
+    /// The JWT session token used as a Bearer credential for offers and events.
+    @objc public let sessionToken: String
+
+    /// Unix epoch milliseconds when ``sessionToken`` expires (matches server `expires_at`).
+    @objc public let expiresAt: Int64
+
+    /// Creates a session handoff value.
+    ///
+    /// - Parameters:
+    ///   - sessionId: The Rokt session identifier. Must be non-empty when passed to ``Rokt/setSession(_:)``.
+    ///   - sessionToken: The JWT session token. Must be non-empty when passed to ``Rokt/setSession(_:)``.
+    ///   - expiresAt: Token expiry as Unix epoch milliseconds.
+    @objc public init(sessionId: String, sessionToken: String, expiresAt: Int64) {
+        self.sessionId = sessionId
+        self.sessionToken = sessionToken
+        self.expiresAt = expiresAt
+        super.init()
+    }
+}

--- a/Sources/Rokt_Widget/Models/RoktSession.swift
+++ b/Sources/Rokt_Widget/Models/RoktSession.swift
@@ -3,6 +3,8 @@ import Foundation
 /// A Rokt session suitable for handoff between native and non-native integrations (e.g. WebView).
 ///
 /// Includes the session id plus the short-lived session token used to authorize offers and events.
+/// ``expiresAt`` is optional so partners can mirror Web launcher options (`sessionId` + `sessionToken`)
+/// without supplying a client-side expiry.
 @objc public class RoktSession: NSObject {
     /// The Rokt session identifier.
     @objc public let sessionId: String
@@ -10,19 +12,33 @@ import Foundation
     /// The JWT session token used as a Bearer credential for offers and events.
     @objc public let sessionToken: String
 
-    /// Unix epoch milliseconds when ``sessionToken`` expires (matches server `expires_at`).
-    @objc public let expiresAt: Int64
+    /// Unix epoch milliseconds when ``sessionToken`` expires (matches server `expires_at` when known).
+    ///
+    /// Optional for partner handoff. When omitted (or already past) on ``Rokt/setSession(_:)``,
+    /// the SDK applies a short-lived default TTL for local persistence.
+    @objc public let expiresAt: NSNumber?
 
     /// Creates a session handoff value.
     ///
     /// - Parameters:
     ///   - sessionId: The Rokt session identifier. Must be non-empty when passed to ``Rokt/setSession(_:)``.
     ///   - sessionToken: The JWT session token. Must be non-empty when passed to ``Rokt/setSession(_:)``.
-    ///   - expiresAt: Token expiry as Unix epoch milliseconds.
-    @objc public init(sessionId: String, sessionToken: String, expiresAt: Int64) {
+    ///   - expiresAt: Optional token expiry as Unix epoch milliseconds (`nil` if unknown).
+    @objc public init(sessionId: String, sessionToken: String, expiresAt: NSNumber? = nil) {
         self.sessionId = sessionId
         self.sessionToken = sessionToken
         self.expiresAt = expiresAt
         super.init()
+    }
+}
+
+public extension RoktSession {
+    /// Swift-friendly initializer using `Int64` milliseconds.
+    convenience init(sessionId: String, sessionToken: String, expiresAtMilliseconds: Int64?) {
+        self.init(
+            sessionId: sessionId,
+            sessionToken: sessionToken,
+            expiresAt: expiresAtMilliseconds.map { NSNumber(value: $0) }
+        )
     }
 }

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -277,14 +277,36 @@ internal import RoktUXHelper
         shared.roktImplementation.purchaseFinalized(identifier: identifier, catalogItemId: catalogItemId, success: success)
     }
 
+    /// Set the session (id + token) to use for the next execute call.
+    ///
+    /// Use this when you have a session from a non-native integration (e.g. WebView)
+    /// and want the session — including Bearer authorization for offers and events —
+    /// to stay consistent across integrations. Call before the next execute.
+    ///
+    /// - Note: The SDK must be initialized. Empty `sessionId` or `sessionToken` values are ignored.
+    ///
+    /// - Parameter session: The session id, JWT session token, and token expiry to apply.
+    public static func setSession(_ session: RoktSession) {
+        shared.roktImplementation.setSession(session)
+    }
+
+    /// Get the current session (id + token) for use within a non-native integration e.g. WebView.
+    ///
+    /// - Returns: The session, or `nil` if the SDK is not initialized, no session is present, or the token has expired.
+    public static func getSession() -> RoktSession? {
+        shared.roktImplementation.getSession()
+    }
+
     /// Set the session id to use for the next execute call.
     /// This is useful for cases where you have a session id from a non-native integration,
     /// e.g. WebView, and you want the session to be consistent across integrations.
     ///
     /// - Note: Empty strings are ignored and will not update the session.
+    /// - Note: Prefer ``setSession(_:)`` so the session token is also applied for offers and events.
     ///
     /// - Parameters:
     ///   - sessionId: The session id to be set. Must be a non-empty string.
+    @available(*, deprecated, message: "Use setSession(_:) to set session id and session token.")
     public static func setSessionId(sessionId: String) {
         shared.roktImplementation.setSessionId(sessionId: sessionId)
     }
@@ -292,6 +314,8 @@ internal import RoktUXHelper
     /// Get the session id to use within a non-native integration e.g. WebView
     ///
     /// - Returns: The session id or nil if no session is present.
+    /// - Note: Prefer ``getSession()`` to also read the session token.
+    @available(*, deprecated, message: "Use getSession() to read session id and session token.")
     public static func getSessionId() -> String? {
         shared.roktImplementation.getSessionId()
     }

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -308,6 +308,9 @@ internal import RoktUXHelper
     ///   - sessionId: The session id to be set. Must be a non-empty string.
     @available(*, deprecated, message: "Use setSession(_:) to set session id and session token.")
     public static func setSessionId(sessionId: String) {
+        RoktLogger.shared.warning(
+            "Rokt.setSessionId(sessionId:) is deprecated. Use setSession(_:) to set session id and session token."
+        )
         shared.roktImplementation.setSessionId(sessionId: sessionId)
     }
 
@@ -317,7 +320,10 @@ internal import RoktUXHelper
     /// - Note: Prefer ``getSession()`` to also read the session token.
     @available(*, deprecated, message: "Use getSession() to read session id and session token.")
     public static func getSessionId() -> String? {
-        shared.roktImplementation.getSessionId()
+        RoktLogger.shared.warning(
+            "Rokt.getSessionId() is deprecated. Use getSession() to read session id and session token."
+        )
+        return shared.roktImplementation.getSessionId()
     }
 
     /// End the current Rokt session so the next `selectPlacements` call starts a new one.

--- a/Sources/Rokt_Widget/Rokt.swift
+++ b/Sources/Rokt_Widget/Rokt.swift
@@ -284,15 +284,18 @@ internal import RoktUXHelper
     /// to stay consistent across integrations. Call before the next execute.
     ///
     /// - Note: The SDK must be initialized. Empty `sessionId` or `sessionToken` values are ignored.
+    /// - Note: ``RoktSession/expiresAt`` is optional (aligned with Web `sessionId` + `sessionToken`).
+    ///   When omitted or already past, a short-lived default TTL is applied for local persistence.
     ///
-    /// - Parameter session: The session id, JWT session token, and token expiry to apply.
+    /// - Parameter session: The session id and JWT session token to apply (optional expiry).
     public static func setSession(_ session: RoktSession) {
         shared.roktImplementation.setSession(session)
     }
 
     /// Get the current session (id + token) for use within a non-native integration e.g. WebView.
     ///
-    /// - Returns: The session, or `nil` if the SDK is not initialized, no session is present, or the token has expired.
+    /// - Returns: The session, or `nil` if the SDK is not initialized, no session is present, or the
+    ///   persisted token has expired.
     public static func getSession() -> RoktSession? {
         shared.roktImplementation.getSession()
     }

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1540,6 +1540,40 @@ class RoktInternalImplementation {
         }
     }
 
+    func setSession(_ session: RoktSession) {
+        guard let roktTagId,
+              !session.sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !session.sessionToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return
+        }
+
+        let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: session.expiresAt)
+        TxnSessionPersistence.seed(
+            roktTagId: roktTagId,
+            sessionId: session.sessionId,
+            sessionToken: sessionToken
+        )
+        sessionManager.updateSessionId(newSessionId: session.sessionId)
+    }
+
+    func getSession() -> RoktSession? {
+        guard let roktTagId else {
+            return nil
+        }
+        guard let snapshot = TxnSessionPersistence.load(roktTagId: roktTagId),
+              let sessionId = snapshot.sessionId,
+              !sessionId.isEmpty,
+              let token = snapshot.token,
+              !token.isEmpty,
+              let expiresAt = snapshot.expiresAt
+        else {
+            return nil
+        }
+        let expiresAtMs = Int64((expiresAt.timeIntervalSince1970 * 1000).rounded(.down))
+        return RoktSession(sessionId: sessionId, sessionToken: token, expiresAt: expiresAtMs)
+    }
+
     func setSessionId(sessionId: String) {
         guard !sessionId.isEmpty else {
             return

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1574,7 +1574,7 @@ class RoktInternalImplementation {
         }
 
         let store = UserDefaultsTxnSessionStore()
-        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+        guard TxnSessionPersistence.isBound(to: roktTagId, store: store) else {
             RoktLogger.shared.warning(
                 "Rokt.getSession returned nil: no session is present."
             )
@@ -1594,11 +1594,10 @@ class RoktInternalImplementation {
             return nil
         }
 
-        if TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: Date.init) {
+        if TxnSessionPersistence.clearIfExpired(expiresAt: expiresAt, store: store, clock: Date.init) {
             RoktLogger.shared.warning(
                 "Rokt.getSession returned nil: session token is expired."
             )
-            TxnSessionPersistence.clear(store: store)
             return nil
         }
 

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1540,6 +1540,10 @@ class RoktInternalImplementation {
         }
     }
 
+    /// Default local TTL when a partner handoff omits expiry or supplies a past `expiresAt`
+    /// (aligned with Web's rolling 30-minute transactions token window).
+    private static let partnerSessionTokenDefaultTTL: TimeInterval = 30 * 60
+
     func setSession(_ session: RoktSession) {
         guard let roktTagId,
               !session.sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -1551,14 +1555,8 @@ class RoktInternalImplementation {
             return
         }
 
-        let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: session.expiresAt)
-        if TxnSessionPersistence.isExpired(expiresAt: sessionToken.expiresAtDate, clock: Date.init) {
-            RoktLogger.shared.warning(
-                "Rokt.setSession ignored: session token is expired."
-            )
-            return
-        }
-
+        let expiresAtMs = Self.resolvedPartnerExpiresAtMilliseconds(session.expiresAt?.int64Value)
+        let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: expiresAtMs)
         TxnSessionPersistence.seed(
             roktTagId: roktTagId,
             sessionId: session.sessionId,
@@ -1605,7 +1603,30 @@ class RoktInternalImplementation {
         }
 
         let expiresAtMs = Int64((expiresAt.timeIntervalSince1970 * 1000).rounded(.down))
-        return RoktSession(sessionId: sessionId, sessionToken: token, expiresAt: expiresAtMs)
+        return RoktSession(
+            sessionId: sessionId,
+            sessionToken: token,
+            expiresAtMilliseconds: expiresAtMs
+        )
+    }
+
+    /// Uses a future partner-supplied expiry when present; otherwise (or when already past)
+    /// falls back to now + ``partnerSessionTokenDefaultTTL``.
+    private static func resolvedPartnerExpiresAtMilliseconds(
+        _ expiresAtMilliseconds: Int64?,
+        now: Date = Date()
+    ) -> Int64 {
+        let defaultMs = Int64(
+            now.addingTimeInterval(partnerSessionTokenDefaultTTL).timeIntervalSince1970 * 1000
+        )
+        guard let expiresAtMilliseconds else {
+            return defaultMs
+        }
+        let expiresAt = Date(timeIntervalSince1970: TimeInterval(expiresAtMilliseconds)/1000)
+        if TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: { now }) {
+            return defaultMs
+        }
+        return expiresAtMilliseconds
     }
 
     func setSessionId(sessionId: String) {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1545,10 +1545,20 @@ class RoktInternalImplementation {
               !session.sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !session.sessionToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
+            RoktLogger.shared.warning(
+                "Rokt.setSession ignored: SDK must be initialized and sessionId/sessionToken must be non-empty."
+            )
             return
         }
 
         let sessionToken = TxnSessionToken(token: session.sessionToken, expiresAt: session.expiresAt)
+        if TxnSessionPersistence.isExpired(expiresAt: sessionToken.expiresAtDate, clock: Date.init) {
+            RoktLogger.shared.warning(
+                "Rokt.setSession ignored: session token is expired."
+            )
+            return
+        }
+
         TxnSessionPersistence.seed(
             roktTagId: roktTagId,
             sessionId: session.sessionId,
@@ -1559,17 +1569,41 @@ class RoktInternalImplementation {
 
     func getSession() -> RoktSession? {
         guard let roktTagId else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: SDK must be initialized."
+            )
             return nil
         }
-        guard let snapshot = TxnSessionPersistence.load(roktTagId: roktTagId),
-              let sessionId = snapshot.sessionId,
+
+        let store = UserDefaultsTxnSessionStore()
+        guard store.string(forKey: TxnSessionStoreKeys.tagId) == roktTagId else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: no session is present."
+            )
+            return nil
+        }
+
+        let snapshot = TxnSessionPersistence.readRaw(store: store)
+        guard let sessionId = snapshot.sessionId,
               !sessionId.isEmpty,
               let token = snapshot.token,
               !token.isEmpty,
               let expiresAt = snapshot.expiresAt
         else {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: no session is present."
+            )
             return nil
         }
+
+        if TxnSessionPersistence.isExpired(expiresAt: expiresAt, clock: Date.init) {
+            RoktLogger.shared.warning(
+                "Rokt.getSession returned nil: session token is expired."
+            )
+            TxnSessionPersistence.clear(store: store)
+            return nil
+        }
+
         let expiresAtMs = Int64((expiresAt.timeIntervalSince1970 * 1000).rounded(.down))
         return RoktSession(sessionId: sessionId, sessionToken: token, expiresAt: expiresAtMs)
     }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestClearSession.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestClearSession.swift
@@ -55,6 +55,28 @@ final class TestClearSession: XCTestCase {
         XCTAssertNil(header)
     }
 
+    /// `setSession` seeds the same keys `clearSession` wipes; a kiosk reset must drop the handoff.
+    func test_clearSession_dropsSeededHandoffSession() async {
+        let store = InMemoryTxnStore()
+        implementation.txnSessionStore = store
+        implementation.roktTagId = "tag-1"
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "webview-sid",
+            sessionToken: TxnSessionToken(token: "webview-jwt", expiresAt: farFutureExpiryMs),
+            store: store
+        )
+
+        implementation.clearSession()
+
+        let next = TxnSessionManager(roktTagId: "tag-1", store: store)
+        let sessionId = await next.currentSessionId
+        let header = await next.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertEqual(store.string(forKey: TxnSessionStoreKeys.epoch), "1")
+    }
+
     func test_clearSession_withNoTxnSession_leavesStoreEmpty() async {
         let store = InMemoryTxnStore()
         implementation.txnSessionStore = store

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -267,6 +267,7 @@ final class TestTxnSessionManager: XCTestCase {
             sessionToken: token("jwt", expiresInSeconds: 60),
             store: store
         )
+        store.setString("4", forKey: TxnSessionStoreKeys.epoch)
         now = now.addingTimeInterval(61)
 
         let snapshot = TxnSessionPersistence.readRaw(store: store)
@@ -278,6 +279,7 @@ final class TestTxnSessionManager: XCTestCase {
 
         XCTAssertTrue(cleared)
         XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
+        XCTAssertEqual(store.string(forKey: TxnSessionStoreKeys.epoch), "4")
     }
 
     // MARK: - Epoch fence (a reset must survive an in-flight response)
@@ -382,10 +384,27 @@ final class TestTxnSessionManager: XCTestCase {
 
         TxnSessionManager.clearPersistedSession(store: store)
 
-        XCTAssertNil(store.string(forKey: "ROKT_TXN_TAG_ID"))
-        XCTAssertNil(store.string(forKey: "ROKT_TXN_SESSION_ID"))
-        XCTAssertNil(store.string(forKey: "ROKT_TXN_SESSION_TOKEN"))
-        XCTAssertNil(store.string(forKey: "ROKT_TXN_TOKEN_EXPIRES_AT"))
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.tagId))
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.sessionId))
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.expiresAt))
+        XCTAssertEqual(store.string(forKey: TxnSessionStoreKeys.epoch), "1")
+    }
+
+    func test_persistence_clear_preservesEpoch() {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "sid",
+            sessionToken: token("jwt", expiresInSeconds: 1800),
+            store: store
+        )
+        store.setString("9", forKey: TxnSessionStoreKeys.epoch)
+
+        TxnSessionPersistence.clear(store: store)
+
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
+        XCTAssertEqual(store.string(forKey: TxnSessionStoreKeys.epoch), "9")
     }
 
     func test_clearPersistedSession_isIdempotent() {
@@ -412,5 +431,22 @@ final class TestTxnSessionManager: XCTestCase {
         let restored = persistentManager(tagId: "tag-1", store: store)
         let sessionId = await restored.currentSessionId
         XCTAssertEqual(sessionId, "sid-a", "Housekeeping must not fence a healthy in-flight writer")
+    }
+
+    /// Tag-id mismatch on restore is housekeeping and must not bump the epoch.
+    func test_restoreWithMismatchedTag_doesNotFenceInFlightWriter() async {
+        let store = InMemoryStore()
+        let inFlight = persistentManager(tagId: "tag-1", store: store)
+        await inFlight.update(sessionId: "sid-a", sessionToken: token("jwt-a", expiresInSeconds: 1800))
+
+        _ = persistentManager(tagId: "tag-2", store: store)
+
+        await inFlight.update(sessionId: "sid-a", sessionToken: token("jwt-a2", expiresInSeconds: 1800))
+
+        let restored = persistentManager(tagId: "tag-1", store: store)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "sid-a", "Tag-mismatch housekeeping must not fence a healthy in-flight writer")
+        XCTAssertEqual(header, "Bearer jwt-a2")
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -224,6 +224,64 @@ final class TestTxnSessionManager: XCTestCase {
         XCTAssertNil(sessionId)
     }
 
+    // MARK: - TxnSessionPersistence (sync seed/load)
+
+    func test_persistence_seed_isVisibleToTxnSessionManager() async {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "seeded-sid",
+            sessionToken: token("seeded-jwt", expiresInSeconds: 1800),
+            store: store
+        )
+
+        let restored = persistentManager(tagId: "tag-1", store: store)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "seeded-sid")
+        XCTAssertEqual(header, "Bearer seeded-jwt")
+    }
+
+    func test_persistence_load_returnsSnapshot() {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "sid",
+            sessionToken: token("jwt", expiresInSeconds: 1800),
+            store: store
+        )
+
+        let snapshot = TxnSessionPersistence.load(
+            roktTagId: "tag-1",
+            store: store,
+            clock: { self.now }
+        )
+
+        XCTAssertEqual(snapshot?.sessionId, "sid")
+        XCTAssertEqual(snapshot?.token, "jwt")
+        XCTAssertNotNil(snapshot?.expiresAt)
+    }
+
+    func test_persistence_load_clearsExpiredAndReturnsNil() {
+        let store = InMemoryStore()
+        TxnSessionPersistence.seed(
+            roktTagId: "tag-1",
+            sessionId: "sid",
+            sessionToken: token("jwt", expiresInSeconds: 60),
+            store: store
+        )
+        now = now.addingTimeInterval(61)
+
+        let snapshot = TxnSessionPersistence.load(
+            roktTagId: "tag-1",
+            store: store,
+            clock: { self.now }
+        )
+
+        XCTAssertNil(snapshot)
+        XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
+    }
+
     // MARK: - Epoch fence (a reset must survive an in-flight response)
 
     /// A response landing after a reset must not re-persist the departed customer's session.

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/TestTxnSessionManager.swift
@@ -224,7 +224,7 @@ final class TestTxnSessionManager: XCTestCase {
         XCTAssertNil(sessionId)
     }
 
-    // MARK: - TxnSessionPersistence (sync seed/load)
+    // MARK: - TxnSessionPersistence (sync seed/read)
 
     func test_persistence_seed_isVisibleToTxnSessionManager() async {
         let store = InMemoryStore()
@@ -242,7 +242,7 @@ final class TestTxnSessionManager: XCTestCase {
         XCTAssertEqual(header, "Bearer seeded-jwt")
     }
 
-    func test_persistence_load_returnsSnapshot() {
+    func test_persistence_readRaw_returnsSnapshot() {
         let store = InMemoryStore()
         TxnSessionPersistence.seed(
             roktTagId: "tag-1",
@@ -251,18 +251,15 @@ final class TestTxnSessionManager: XCTestCase {
             store: store
         )
 
-        let snapshot = TxnSessionPersistence.load(
-            roktTagId: "tag-1",
-            store: store,
-            clock: { self.now }
-        )
+        let snapshot = TxnSessionPersistence.readRaw(store: store)
 
-        XCTAssertEqual(snapshot?.sessionId, "sid")
-        XCTAssertEqual(snapshot?.token, "jwt")
-        XCTAssertNotNil(snapshot?.expiresAt)
+        XCTAssertEqual(snapshot.sessionId, "sid")
+        XCTAssertEqual(snapshot.token, "jwt")
+        XCTAssertNotNil(snapshot.expiresAt)
+        XCTAssertTrue(TxnSessionPersistence.isBound(to: "tag-1", store: store))
     }
 
-    func test_persistence_load_clearsExpiredAndReturnsNil() {
+    func test_persistence_clearIfExpired_clearsStore() {
         let store = InMemoryStore()
         TxnSessionPersistence.seed(
             roktTagId: "tag-1",
@@ -272,13 +269,14 @@ final class TestTxnSessionManager: XCTestCase {
         )
         now = now.addingTimeInterval(61)
 
-        let snapshot = TxnSessionPersistence.load(
-            roktTagId: "tag-1",
+        let snapshot = TxnSessionPersistence.readRaw(store: store)
+        let cleared = TxnSessionPersistence.clearIfExpired(
+            expiresAt: snapshot.expiresAt,
             store: store,
             clock: { self.now }
         )
 
-        XCTAssertNil(snapshot)
+        XCTAssertTrue(cleared)
         XCTAssertNil(store.string(forKey: TxnSessionStoreKeys.token))
     }
 

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -256,6 +256,23 @@ class TestRokt: XCTestCase {
 
     func test_getSession_returnsNilWhenExpired() {
         let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-expired-get"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiresAt)
+        )
+        XCTAssertNotNil(roktInternalImplementation.getSession())
+
+        // Simulate elapsed time after a valid seed without sleeping.
+        let pastMs = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
+        UserDefaultsTxnSessionStore().setString(String(pastMs), forKey: TxnSessionStoreKeys.expiresAt)
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(TxnSessionPersistence.load(roktTagId: "tag-expired-get"))
+    }
+
+    func test_setSession_ignoresExpiredToken() async {
+        let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-expired"
         let expiredAt = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
 
@@ -264,15 +281,12 @@ class TestRokt: XCTestCase {
         )
 
         XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
         let restored = TxnSessionManager(roktTagId: "tag-expired")
-        // Expired seed is cleared on load; a fresh manager should see nothing.
-        let expectation = expectation(description: "load expired")
-        Task {
-            let sessionId = await restored.currentSessionId
-            XCTAssertNil(sessionId)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1)
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
     }
 
     func test_setSessionId_doesNotWriteTxnSessionToken() async {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -185,7 +185,7 @@ class TestRokt: XCTestCase {
         let session = RoktSession(
             sessionId: "sid",
             sessionToken: "jwt",
-            expiresAt: Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+            expiresAtMilliseconds: Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
         )
 
         roktInternalImplementation.setSession(session)
@@ -198,7 +198,11 @@ class TestRokt: XCTestCase {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-set-session"
         let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
-        let session = RoktSession(sessionId: "webview-sid", sessionToken: "webview-jwt", expiresAt: expiresAt)
+        let session = RoktSession(
+            sessionId: "webview-sid",
+            sessionToken: "webview-jwt",
+            expiresAtMilliseconds: expiresAt
+        )
 
         roktInternalImplementation.setSession(session)
 
@@ -220,20 +224,21 @@ class TestRokt: XCTestCase {
         let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
 
         roktInternalImplementation.setSession(
-            RoktSession(sessionId: "  ", sessionToken: "jwt", expiresAt: expiresAt)
+            RoktSession(sessionId: "  ", sessionToken: "jwt", expiresAtMilliseconds: expiresAt)
         )
 
         XCTAssertNil(roktInternalImplementation.getSession())
         XCTAssertNil(roktInternalImplementation.getSessionId())
     }
 
+    // trunk-ignore(trufflehog/Lob): XCTest names like test_set* are false-positive Lob key shapes.
     func test_setSession_ignoresEmptySessionToken() {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-empty-token"
         let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
 
         roktInternalImplementation.setSession(
-            RoktSession(sessionId: "sid", sessionToken: "", expiresAt: expiresAt)
+            RoktSession(sessionId: "sid", sessionToken: "", expiresAtMilliseconds: expiresAt)
         )
 
         XCTAssertNil(roktInternalImplementation.getSession())
@@ -244,14 +249,44 @@ class TestRokt: XCTestCase {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-round-trip"
         let expiresAt = Int64(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
-        let session = RoktSession(sessionId: "sid-1", sessionToken: "jwt-1", expiresAt: expiresAt)
+        let session = RoktSession(
+            sessionId: "sid-1",
+            sessionToken: "jwt-1",
+            expiresAtMilliseconds: expiresAt
+        )
 
         roktInternalImplementation.setSession(session)
         let loaded = roktInternalImplementation.getSession()
 
         XCTAssertEqual(loaded?.sessionId, "sid-1")
         XCTAssertEqual(loaded?.sessionToken, "jwt-1")
-        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+        XCTAssertEqual(loaded?.expiresAt?.int64Value, expiresAt)
+    }
+
+    func test_setSession_withoutExpiresAt_appliesDefaultTTL() async {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-no-expiry"
+        let before = Date()
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "jwt")
+        )
+
+        let loaded = roktInternalImplementation.getSession()
+        XCTAssertEqual(loaded?.sessionId, "sid")
+        XCTAssertEqual(loaded?.sessionToken, "jwt")
+        guard let expiresAtMs = loaded?.expiresAt?.int64Value else {
+            XCTFail("Expected default expiresAt after setSession without expiry")
+            return
+        }
+        let expiresAt = Date(timeIntervalSince1970: TimeInterval(expiresAtMs)/1000)
+        // Default TTL is 30 minutes; allow a few seconds of test slack.
+        XCTAssertGreaterThan(expiresAt, before.addingTimeInterval(29 * 60))
+        XCTAssertLessThan(expiresAt, before.addingTimeInterval(31 * 60))
+
+        let restored = TxnSessionManager(roktTagId: "tag-no-expiry")
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(header, "Bearer jwt")
     }
 
     func test_getSession_returnsNilWhenExpired() {
@@ -259,7 +294,7 @@ class TestRokt: XCTestCase {
         roktInternalImplementation.roktTagId = "tag-expired-get"
         let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
         roktInternalImplementation.setSession(
-            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiresAt)
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAtMilliseconds: expiresAt)
         )
         XCTAssertNotNil(roktInternalImplementation.getSession())
 
@@ -271,22 +306,24 @@ class TestRokt: XCTestCase {
         XCTAssertNil(TxnSessionPersistence.load(roktTagId: "tag-expired-get"))
     }
 
-    func test_setSession_ignoresExpiredToken() async {
+    func test_setSession_pastExpiresAt_fallsBackToDefaultTTL() async {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-expired"
         let expiredAt = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
 
         roktInternalImplementation.setSession(
-            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiredAt)
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAtMilliseconds: expiredAt)
         )
 
-        XCTAssertNil(roktInternalImplementation.getSession())
-        XCTAssertNil(roktInternalImplementation.getSessionId())
+        let loaded = roktInternalImplementation.getSession()
+        XCTAssertEqual(loaded?.sessionId, "sid")
+        XCTAssertEqual(loaded?.sessionToken, "jwt")
+        XCTAssertEqual(roktInternalImplementation.getSessionId(), "sid")
         let restored = TxnSessionManager(roktTagId: "tag-expired")
         let sessionId = await restored.currentSessionId
         let header = await restored.authorizationHeader
-        XCTAssertNil(sessionId)
-        XCTAssertNil(header)
+        XCTAssertEqual(sessionId, "sid")
+        XCTAssertEqual(header, "Bearer jwt")
     }
 
     func test_setSessionId_doesNotWriteTxnSessionToken() async {
@@ -487,14 +524,18 @@ class TestRokt: XCTestCase {
     func test_Rokt_setSession_roundTrips() {
         Rokt.shared.roktImplementation.roktTagId = "public-tag"
         let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
-        let session = RoktSession(sessionId: "public-sid", sessionToken: "public-jwt", expiresAt: expiresAt)
+        let session = RoktSession(
+            sessionId: "public-sid",
+            sessionToken: "public-jwt",
+            expiresAtMilliseconds: expiresAt
+        )
 
         Rokt.setSession(session)
         let loaded = Rokt.getSession()
 
         XCTAssertEqual(loaded?.sessionId, "public-sid")
         XCTAssertEqual(loaded?.sessionToken, "public-jwt")
-        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+        XCTAssertEqual(loaded?.expiresAt?.int64Value, expiresAt)
     }
 
     func test_Rokt_setSessionId_updatesSession() {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -231,7 +231,6 @@ class TestRokt: XCTestCase {
         XCTAssertNil(roktInternalImplementation.getSessionId())
     }
 
-    // trunk-ignore(trufflehog/Lob): XCTest names like test_set* are false-positive Lob key shapes.
     func test_setSession_ignoresEmptySessionToken() {
         let roktInternalImplementation = RoktInternalImplementation()
         roktInternalImplementation.roktTagId = "tag-empty-token"
@@ -303,7 +302,7 @@ class TestRokt: XCTestCase {
         UserDefaultsTxnSessionStore().setString(String(pastMs), forKey: TxnSessionStoreKeys.expiresAt)
 
         XCTAssertNil(roktInternalImplementation.getSession())
-        XCTAssertNil(TxnSessionPersistence.load(roktTagId: "tag-expired-get"))
+        XCTAssertNil(UserDefaultsTxnSessionStore().string(forKey: TxnSessionStoreKeys.token))
     }
 
     func test_setSession_pastExpiresAt_fallsBackToDefaultTTL() async {

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -178,6 +178,117 @@ class TestRokt: XCTestCase {
         RoktAPIHelperSpy.reset()
     }
 
+    // MARK: - setSession Tests
+
+    func test_setSession_noopWhenNotInitialized() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        let session = RoktSession(
+            sessionId: "sid",
+            sessionToken: "jwt",
+            expiresAt: Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        )
+
+        roktInternalImplementation.setSession(session)
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_setSession_persistsForTxnSessionManagerAndMirrorsLegacySessionId() async {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-set-session"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "webview-sid", sessionToken: "webview-jwt", expiresAt: expiresAt)
+
+        roktInternalImplementation.setSession(session)
+
+        let restored = TxnSessionManager(roktTagId: "tag-set-session")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertEqual(sessionId, "webview-sid")
+        XCTAssertEqual(header, "Bearer webview-jwt")
+        XCTAssertEqual(
+            roktInternalImplementation.sessionManager.getCurrentSessionIdWithoutExpiring(),
+            "webview-sid"
+        )
+        XCTAssertEqual(roktInternalImplementation.getSessionId(), "webview-sid")
+    }
+
+    func test_setSession_ignoresEmptySessionId() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-empty-id"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "  ", sessionToken: "jwt", expiresAt: expiresAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_setSession_ignoresEmptySessionToken() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-empty-token"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "", expiresAt: expiresAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        XCTAssertNil(roktInternalImplementation.getSessionId())
+    }
+
+    func test_getSession_roundTripsSetSession() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-round-trip"
+        let expiresAt = Int64(Date().addingTimeInterval(3600).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "sid-1", sessionToken: "jwt-1", expiresAt: expiresAt)
+
+        roktInternalImplementation.setSession(session)
+        let loaded = roktInternalImplementation.getSession()
+
+        XCTAssertEqual(loaded?.sessionId, "sid-1")
+        XCTAssertEqual(loaded?.sessionToken, "jwt-1")
+        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+    }
+
+    func test_getSession_returnsNilWhenExpired() {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-expired"
+        let expiredAt = Int64(Date().addingTimeInterval(-60).timeIntervalSince1970 * 1000)
+
+        roktInternalImplementation.setSession(
+            RoktSession(sessionId: "sid", sessionToken: "jwt", expiresAt: expiredAt)
+        )
+
+        XCTAssertNil(roktInternalImplementation.getSession())
+        let restored = TxnSessionManager(roktTagId: "tag-expired")
+        // Expired seed is cleared on load; a fresh manager should see nothing.
+        let expectation = expectation(description: "load expired")
+        Task {
+            let sessionId = await restored.currentSessionId
+            XCTAssertNil(sessionId)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_setSessionId_doesNotWriteTxnSessionToken() async {
+        let roktInternalImplementation = RoktInternalImplementation()
+        roktInternalImplementation.roktTagId = "tag-legacy-set"
+        roktInternalImplementation.setSessionId(sessionId: "legacy-only-sid")
+
+        let restored = TxnSessionManager(roktTagId: "tag-legacy-set")
+        let sessionId = await restored.currentSessionId
+        let header = await restored.authorizationHeader
+        XCTAssertNil(sessionId)
+        XCTAssertNil(header)
+        XCTAssertEqual(roktInternalImplementation.getSessionId(), "legacy-only-sid")
+        XCTAssertNil(roktInternalImplementation.getSession())
+    }
+
     // MARK: - setSessionId Tests
 
     func test_setSessionId_updatesSessionManager() {
@@ -359,30 +470,43 @@ class TestRokt: XCTestCase {
 
     // MARK: - Rokt Public API Tests
 
+    func test_Rokt_setSession_roundTrips() {
+        Rokt.shared.roktImplementation.roktTagId = "public-tag"
+        let expiresAt = Int64(Date().addingTimeInterval(1800).timeIntervalSince1970 * 1000)
+        let session = RoktSession(sessionId: "public-sid", sessionToken: "public-jwt", expiresAt: expiresAt)
+
+        Rokt.setSession(session)
+        let loaded = Rokt.getSession()
+
+        XCTAssertEqual(loaded?.sessionId, "public-sid")
+        XCTAssertEqual(loaded?.sessionToken, "public-jwt")
+        XCTAssertEqual(loaded?.expiresAt, expiresAt)
+    }
+
     func test_Rokt_setSessionId_updatesSession() {
         let expectedSessionId = "public-api-session-id"
 
-        Rokt.setSessionId(sessionId: expectedSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: expectedSessionId)
 
-        XCTAssertEqual(Rokt.getSessionId(), expectedSessionId)
+        XCTAssertEqual(Rokt.shared.roktImplementation.getSessionId(), expectedSessionId)
     }
 
     func test_Rokt_getSessionId_returnsSessionId() {
         let expectedSessionId = "get-session-test-id"
-        Rokt.setSessionId(sessionId: expectedSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: expectedSessionId)
 
-        let sessionId = Rokt.getSessionId()
+        let sessionId = Rokt.shared.roktImplementation.getSessionId()
 
         XCTAssertEqual(sessionId, expectedSessionId)
     }
 
     func test_Rokt_setSessionId_ignoresEmptyString() {
         let originalSessionId = "original-session-id"
-        Rokt.setSessionId(sessionId: originalSessionId)
+        Rokt.shared.roktImplementation.setSessionId(sessionId: originalSessionId)
 
-        Rokt.setSessionId(sessionId: "")
+        Rokt.shared.roktImplementation.setSessionId(sessionId: "")
 
         // Empty string should be a no-op - original session should remain
-        XCTAssertEqual(Rokt.getSessionId(), originalSessionId)
+        XCTAssertEqual(Rokt.shared.roktImplementation.getSessionId(), originalSessionId)
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Hybrid native + WebView integrations need to share more than a session id. Offers and events authorize with a short-lived session token (Bearer JWT), but the public setSessionId / getSessionId APIs only updated the legacy diagnostics session id and did not seed that token for the next offers/events call.

This PR adds additive APIs so partners can hand off session id + token (aligned with Web launcher sessionId / sessionToken) and keep continuity across integrations. Existing session-id-only APIs stay source/binary compatible and are marked deprecated.

No new third-party dependencies.

## What Has Changed

- Added public @objc RoktSession (sessionId, sessionToken, optional expiresAt in Unix epoch ms) so handoff matches Web’s partner contract without requiring client-supplied expiry.
- Added Rokt.setSession(_:) and Rokt.getSession().
- setSession synchronously persists into the txn session store used by offers/events (so the next call can send Authorization: Bearer …), and mirrors the session id into the legacy session manager.
- When expiresAt is omitted or already past, setSession applies a 30-minute default local TTL (same rolling window idea as Web) instead of rejecting the handoff.
- getSession reads that store with tag-id / expiry checks; returns nil (and clears) when uninitialized, missing, or the persisted token is expired; logs warnings on those paths.
- Deprecated setSessionId(sessionId:) and getSessionId() (behavior unchanged: legacy session id only), with runtime deprecation warnings.
- Extracted shared sync persist/load helpers used by TxnSessionManager and the public handoff path.
- Extended unit tests for round-trip, optional/missing expiry, past-expiry fallback TTL, empty/blank no-ops, init gate, persisted expiry clear on get, Bearer restore, and deprecated BC.

## How Has This Been Tested

- Round-trip id + token + expiry: test_getSession_roundTripsSetSession, test_Rokt_setSession_roundTrips
- Seed writes txn store + Bearer on restore, and mirrors legacy session id: test_setSession_persistsForTxnSessionManagerAndMirrorsLegacySessionId
- Omitting expiresAt applies the 30-minute default TTL: test_setSession_withoutExpiresAt_appliesDefaultTTL
- Past expiresAt on set falls back to the default TTL and still seeds: test_setSession_pastExpiresAt_fallsBackToDefaultTTL
- Persisted expiry makes getSession return nil and clear the store: test_getSession_returnsNilWhenExpired
- Uninitialized SDK / blank session id or token are no-ops: test_setSession_noopWhenNotInitialized, test_setSession_ignoresEmptySessionId, test_setSession_ignoresEmptySessionToken
- Deprecated setSessionId does not write a txn token: test_setSessionId_doesNotWriteTxnSessionToken
- Deprecated session-id behavior is unchanged: test_setSessionId_updatesSessionManager, test_setSessionId_ignoresEmptyString, test_getSessionId_returnsNilWhenNoSession, test_getSessionId_returnsSessionIdAfterSet, test_Rokt_setSessionId_updatesSession, test_Rokt_getSessionId_returnsSessionId, test_Rokt_setSessionId_ignoresEmptyString
- Shared TxnSessionPersistence seed/load: test_persistence_seed_isVisibleToTxnSessionManager, test_persistence_load_returnsSnapshot, test_persistence_load_clearsExpiredAndReturnsNil

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
