### PR TITLE
fix: font storage migration and enospace guard

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -53,7 +53,10 @@ lint:
     - shfmt@3.6.0
     - swiftformat@0.59.1
     - swiftlint@0.63.2
-    - trufflehog@3.96.0
+    # 3.96.0 Lob detector matches XCTest names of the form test_ + 35 word chars
+    # (exactly 40 chars) as verified credentials. Pin until upstream fixes that FP:
+    # https://github.com/trufflesecurity/trufflehog/issues/5184
+    - trufflehog@3.95.5
     - yamllint@1.38.0
 actions:
   enabled:

--- a/Sources/Rokt_Widget/DataAccess/FontRepository.swift
+++ b/Sources/Rokt_Widget/DataAccess/FontRepository.swift
@@ -198,26 +198,171 @@ class FontRepository {
         fontDownloadDetailFileName = fileName
     }
 
-    private static let cacheDirectory = "RoktFonts"
+    // MARK: - Font directory (Application Support)
 
-    internal static func getCacheDirectoryUrl() -> URL? {
-        guard let cachesUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+    static let fontDirectoryName = "RoktFonts"
+    private static let migrationMarkerFileName = ".rokt_font_storage_application_support"
+    private static let productionFontURLMetadataFileName = "RoktFontDownloadedUrl.json"
+    private static let productionFontDetailMetadataFileName = "RoktFontDownloadedDetail.json"
+
+    private static let migrationLock = NSLock()
+
+    /// Directory used for font binaries and metadata. Application Support is durable
+    /// (unlike Caches) while remaining outside Documents.
+    internal static func getFontDirectoryUrl(fileManager: FileManager = .default) -> URL? {
+        guard let supportUrl = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
 
         let fullPath: URL
         if #available(iOS 16.0, *) {
-            fullPath = cachesUrl.appending(component: cacheDirectory, directoryHint: .isDirectory)
+            fullPath = supportUrl.appending(component: fontDirectoryName, directoryHint: .isDirectory)
         } else {
-            fullPath = cachesUrl.appendingPathComponent(cacheDirectory, isDirectory: true)
+            fullPath = supportUrl.appendingPathComponent(fontDirectoryName, isDirectory: true)
         }
 
         return fullPath
     }
 
+    /// Moves leftover fonts/metadata from Documents (pre-5.2.6) and Caches/RoktFonts
+    /// (5.2.6+) into Application Support once per install.
+    internal static func migrateLegacyFontStorageIfNeeded(fileManager: FileManager = .default) {
+        migrationLock.lock()
+        defer { migrationLock.unlock() }
+
+        guard let destination = getFontDirectoryUrl(fileManager: fileManager) else { return }
+
+        let markerURL = destination.appendingPathComponent(migrationMarkerFileName)
+        if fileManager.fileExists(atPath: markerURL.path) {
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(
+                at: destination,
+                withIntermediateDirectories: true,
+                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+            )
+        } catch {
+            return
+        }
+
+        if let cachesRoot = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            let legacyCaches = cachesRoot.appendingPathComponent(fontDirectoryName, isDirectory: true)
+            migrateDirectoryContents(from: legacyCaches, to: destination, fileManager: fileManager)
+            removeDirectoryIfEmpty(legacyCaches, fileManager: fileManager)
+        }
+
+        if let documentsRoot = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            migrateDocumentsLegacyFonts(from: documentsRoot, to: destination, fileManager: fileManager)
+        }
+
+        try? Data().write(to: markerURL, options: .atomic)
+    }
+
+    // periphery:ignore - used by tests
+    /// Test seam to re-run migration against a clean destination marker.
+    internal static func resetMigrationMarkerForTests(fileManager: FileManager = .default) {
+        migrationLock.lock()
+        defer { migrationLock.unlock() }
+
+        guard let destination = getFontDirectoryUrl(fileManager: fileManager) else { return }
+        let markerURL = destination.appendingPathComponent(migrationMarkerFileName)
+        try? fileManager.removeItem(at: markerURL)
+    }
+
+    private static func migrateDocumentsLegacyFonts(
+        from documentsRoot: URL,
+        to destination: URL,
+        fileManager: FileManager
+    ) {
+        migrateFileIfNeeded(
+            from: documentsRoot.appendingPathComponent(productionFontURLMetadataFileName),
+            to: destination.appendingPathComponent(productionFontURLMetadataFileName),
+            fileManager: fileManager
+        )
+        migrateFileIfNeeded(
+            from: documentsRoot.appendingPathComponent(productionFontDetailMetadataFileName),
+            to: destination.appendingPathComponent(productionFontDetailMetadataFileName),
+            fileManager: fileManager
+        )
+
+        let detailURL = destination.appendingPathComponent(productionFontDetailMetadataFileName)
+        guard fileManager.fileExists(atPath: detailURL.path),
+              let data = try? Data(contentsOf: detailURL),
+              let details = try? JSONDecoder().decode(FontDetails.self, from: data)
+        else {
+            return
+        }
+
+        let fontNames = Set(details.values.compactMap { $0["name"] })
+        for fontName in fontNames {
+            let fileName = "\(fontName).ttf"
+            migrateFileIfNeeded(
+                from: documentsRoot.appendingPathComponent(fileName),
+                to: destination.appendingPathComponent(fileName),
+                fileManager: fileManager
+            )
+        }
+    }
+
+    private static func migrateDirectoryContents(
+        from source: URL,
+        to destination: URL,
+        fileManager: FileManager
+    ) {
+        guard fileManager.fileExists(atPath: source.path),
+              let items = try? fileManager.contentsOfDirectory(
+                  at: source,
+                  includingPropertiesForKeys: nil,
+                  options: [.skipsHiddenFiles]
+              )
+        else {
+            return
+        }
+
+        for item in items {
+            migrateFileIfNeeded(
+                from: item,
+                to: destination.appendingPathComponent(item.lastPathComponent),
+                fileManager: fileManager
+            )
+        }
+    }
+
+    private static func migrateFileIfNeeded(from source: URL, to destination: URL, fileManager: FileManager) {
+        guard fileManager.fileExists(atPath: source.path) else { return }
+
+        if fileManager.fileExists(atPath: destination.path) {
+            try? fileManager.removeItem(at: source)
+            return
+        }
+
+        do {
+            try fileManager.moveItem(at: source, to: destination)
+        } catch {
+            do {
+                try fileManager.copyItem(at: source, to: destination)
+                try? fileManager.removeItem(at: source)
+            } catch {
+                // Best-effort: leave the source in place if neither move nor copy succeeds.
+            }
+        }
+    }
+
+    private static func removeDirectoryIfEmpty(_ directory: URL, fileManager: FileManager) {
+        guard fileManager.fileExists(atPath: directory.path),
+              let remaining = try? fileManager.contentsOfDirectory(atPath: directory.path),
+              remaining.isEmpty
+        else {
+            return
+        }
+        try? fileManager.removeItem(at: directory)
+    }
+
     internal static func getFileUrl(name: String) -> URL? {
-        guard let cacheDirectoryUrl = getCacheDirectoryUrl() else { return nil }
-        return cacheDirectoryUrl.appendingPathComponent(name).appendingPathExtension("json")
+        guard let fontDirectoryUrl = getFontDirectoryUrl() else { return nil }
+        return fontDirectoryUrl.appendingPathComponent(name).appendingPathExtension("json")
     }
 
     internal static func isFileExist(name: String) -> Bool {

--- a/Sources/Rokt_Widget/DataAccess/FontRepository.swift
+++ b/Sources/Rokt_Widget/DataAccess/FontRepository.swift
@@ -224,26 +224,41 @@ class FontRepository {
         return fullPath
     }
 
+    /// Creates `RoktFonts` under Application Support if needed and excludes it from device/iCloud
+    /// backup. Fonts are regenerable downloads; durable local storage must not inflate backups.
+    internal static func ensureFontDirectory(fileManager: FileManager = .default) -> URL? {
+        guard let directoryURL = getFontDirectoryUrl(fileManager: fileManager) else {
+            return nil
+        }
+
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+                )
+            } catch {
+                return nil
+            }
+        }
+
+        excludeFromBackup(directoryURL)
+        return directoryURL
+    }
+
     /// Moves leftover fonts/metadata from Documents (pre-5.2.6) and Caches/RoktFonts
     /// (5.2.6+) into Application Support once per install.
     internal static func migrateLegacyFontStorageIfNeeded(fileManager: FileManager = .default) {
         migrationLock.lock()
         defer { migrationLock.unlock() }
 
-        guard let destination = getFontDirectoryUrl(fileManager: fileManager) else { return }
+        // Always ensure + exclude, including when the migration marker already exists
+        // (upgrades from builds that migrated without setting the backup flag).
+        guard let destination = ensureFontDirectory(fileManager: fileManager) else { return }
 
         let markerURL = destination.appendingPathComponent(migrationMarkerFileName)
         if fileManager.fileExists(atPath: markerURL.path) {
-            return
-        }
-
-        do {
-            try fileManager.createDirectory(
-                at: destination,
-                withIntermediateDirectories: true,
-                attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
-            )
-        } catch {
             return
         }
 
@@ -260,9 +275,15 @@ class FontRepository {
         try? Data().write(to: markerURL, options: .atomic)
     }
 
-    // periphery:ignore - used by tests
+    private static func excludeFromBackup(_ url: URL) {
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var mutableURL = url
+        try? mutableURL.setResourceValues(resourceValues)
+    }
+
     /// Test seam to re-run migration against a clean destination marker.
-    internal static func resetMigrationMarkerForTests(fileManager: FileManager = .default) {
+    internal static func resetMigrationMarkerForTests(fileManager: FileManager = .default) { // periphery:ignore - used by tests
         migrationLock.lock()
         defer { migrationLock.unlock() }
 
@@ -361,7 +382,7 @@ class FontRepository {
     }
 
     internal static func getFileUrl(name: String) -> URL? {
-        guard let fontDirectoryUrl = getFontDirectoryUrl() else { return nil }
+        guard let fontDirectoryUrl = ensureFontDirectory() else { return nil }
         return fontDirectoryUrl.appendingPathComponent(name).appendingPathExtension("json")
     }
 

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -50,7 +50,7 @@ internal class RoktNetWorkAPI {
         onDownloadComplete: @escaping () -> Void,
         retryCount: Int = 0
     ) {
-        if FontManager.shouldSkipFontDownloadDueToDiskPressure(font: font) {
+        if FontManager.isFontDownloadBlockedByDiskPressure() {
             onDownloadComplete()
             return
         }
@@ -90,11 +90,7 @@ internal class RoktNetWorkAPI {
             // Disk-full is environmental and not retriable. Trip the circuit so the rest of
             // this process stops issuing downloads that cannot succeed.
             FontManager.noteFontDiskFull()
-            FontManager.reportDiskPressureDiagnosticIfNeeded(
-                font: font,
-                detail: "No space left on device")
-            Rokt.shared.roktImplementation.isInitFailedForFont = true
-            RoktLogger.shared.verbose("\(fontErrorMessage) \(font.url), error: No space left on device")
+            reportTerminalDownloadFailure(font: font, downloadResponse: downloadResponse)
         } else if let downloadError = downloadResponse.downloadError,
                   retryCount < maxRetries,
                   NetworkingHelper.retriableResponse(
@@ -115,13 +111,7 @@ internal class RoktNetWorkAPI {
             return
         } else if downloadResponse.downloadError != nil {
             // Terminal download failure: not retriable, or the retry budget is spent.
-            // Best-effort: mark for diagnostics, don't un-initialise.
-            Rokt.shared.roktImplementation.isInitFailedForFont = true
-            let callstack = "\(fontErrorMessage) \(font.url), " +
-                "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
-
-            RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
-            RoktLogger.shared.verbose(callstack)
+            reportTerminalDownloadFailure(font: font, downloadResponse: downloadResponse)
         } else {
             // Neither an error nor a file came back, so there is nothing to register and
             // nothing to retry. Reported on its own line rather than as a download failure
@@ -135,6 +125,17 @@ internal class RoktNetWorkAPI {
         }
 
         onDownloadComplete()
+    }
+
+    /// Best-effort: mark for diagnostics, don't un-initialise. Shared by every failure that
+    /// will not be retried so the `[FONT]` rows keep one shape regardless of the cause.
+    private class func reportTerminalDownloadFailure(font: FontModel, downloadResponse: RoktDownloadResult) {
+        Rokt.shared.roktImplementation.isInitFailedForFont = true
+        let callstack = "\(fontErrorMessage) \(font.url), " +
+            "error: \(String(describing: downloadResponse.downloadError.debugDescription))"
+
+        RoktAPIHelper.sendDiagnostics(message: fontDiagnosticCode, callStack: callstack)
+        RoktLogger.shared.verbose(callstack)
     }
 
     /// Rokt diagnostics API call

--- a/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
+++ b/Sources/Rokt_Widget/Networking/RoktNetworkAPI.swift
@@ -50,6 +50,11 @@ internal class RoktNetWorkAPI {
         onDownloadComplete: @escaping () -> Void,
         retryCount: Int = 0
     ) {
+        if FontManager.shouldSkipFontDownloadDueToDiskPressure(font: font) {
+            onDownloadComplete()
+            return
+        }
+
         NetworkingHelper.shared.downloadFile(
             source: font.url,
             destinationURL: destinationURL,
@@ -80,6 +85,16 @@ internal class RoktNetWorkAPI {
                 fontLogId: fullFontLogCode3)
 
             FontManager.registerFont(font: font, fileUrl: downloadedFileLocalURL, isDownloaded: true)
+        } else if let downloadError = downloadResponse.downloadError,
+                  FontManager.isNoSpaceLeftError(downloadError) {
+            // Disk-full is environmental and not retriable. Trip the circuit so the rest of
+            // this process stops issuing downloads that cannot succeed.
+            FontManager.noteFontDiskFull()
+            FontManager.reportDiskPressureDiagnosticIfNeeded(
+                font: font,
+                detail: "No space left on device")
+            Rokt.shared.roktImplementation.isInitFailedForFont = true
+            RoktLogger.shared.verbose("\(fontErrorMessage) \(font.url), error: No space left on device")
         } else if let downloadError = downloadResponse.downloadError,
                   retryCount < maxRetries,
                   NetworkingHelper.retriableResponse(

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -849,6 +849,7 @@ class RoktInternalImplementation {
         sessionManager.storedTagId = roktTagId
         isInitFailedForFont = false
         FontManager.resetFontRecoveryState()
+        FontManager.resetDiskPressureState()
         stateManager = StateBagManager()
 
         RoktLogger.shared.debug("Starting API initialization request")

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -63,6 +63,7 @@ internal class FontManager {
 
     class func downloadFonts(_ fonts: [FontModel], _ onFontDownloadComplete: @escaping () -> Void) {
         getExistingFontsByPostScriptName()
+        FontRepository.migrateLegacyFontStorageIfNeeded()
 
         guard !fonts.isEmpty else {
             onFontDownloadComplete()
@@ -90,7 +91,7 @@ internal class FontManager {
                 continue
             }
 
-            // additional check if font can be created in local caches directory
+            // additional check if font can be created in local application support directory
             guard let fileUrl = getFileUrl(name: registeredFontName) else {
                 // Best-effort: mark for diagnostics, don't un-initialise.
                 Rokt.shared.roktImplementation.isInitFailedForFont = true
@@ -102,6 +103,11 @@ internal class FontManager {
             }
 
             if FontManager.isDownloadingFontRequired(font: font) {
+                if shouldSkipFontDownloadDueToDiskPressure(font: font) {
+                    batch.settle()
+                    continue
+                }
+
                 RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {
                     batch.settle()
                 }
@@ -268,13 +274,131 @@ internal class FontManager {
         }
     }
 
+    // MARK: - Disk pressure
+
+    /// Minimum free space required before starting a font download.
+    static var minimumFreeDiskBytesForFontDownload: Int64 = 5 * 1024 * 1024
+
+    /// Test seam. When non-nil, replaces the system free-space probe.
+    static var freeDiskBytesOverride: Int64?
+
+    private static let diskPressureLock = NSLock()
+    private static var diskFullCircuitOpen = false
+    private static var hasReportedDiskPressure = false
+
+    static func isFontDownloadBlockedByDiskPressure() -> Bool {
+        diskPressureLock.lock()
+        defer { diskPressureLock.unlock() }
+        return diskFullCircuitOpen
+    }
+
+    @discardableResult
+    static func noteFontDiskFull() -> Bool {
+        diskPressureLock.lock()
+        let alreadyOpen = diskFullCircuitOpen
+        diskFullCircuitOpen = true
+        diskPressureLock.unlock()
+        return !alreadyOpen
+    }
+
+    static func resetDiskPressureState() {
+        diskPressureLock.lock()
+        diskFullCircuitOpen = false
+        hasReportedDiskPressure = false
+        diskPressureLock.unlock()
+        freeDiskBytesOverride = nil
+        minimumFreeDiskBytesForFontDownload = 5 * 1024 * 1024
+    }
+
+    static func hasSufficientDiskSpaceForFontDownload() -> Bool {
+        if let override = freeDiskBytesOverride {
+            return override >= minimumFreeDiskBytesForFontDownload
+        }
+
+        guard let directoryURL = FontRepository.getFontDirectoryUrl() else {
+            return true
+        }
+
+        let probeURL = FileManager.default.fileExists(atPath: directoryURL.path)
+            ? directoryURL
+            : directoryURL.deletingLastPathComponent()
+
+        guard let values = try? probeURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+              let capacity = values.volumeAvailableCapacityForImportantUsage
+        else {
+            return true
+        }
+
+        return capacity >= minimumFreeDiskBytesForFontDownload
+    }
+
+    static func isNoSpaceLeftError(_ error: Error) -> Bool {
+        if let downloadError = error as? RoktHTTPClient.RoktDownloadError {
+            switch downloadError {
+            case .downloadFailed(let inner):
+                return isNoSpaceLeftError(inner)
+            case .downloadLocationError(let locationError):
+                if case .targetDirectoryInvalid(let inner) = locationError {
+                    return isNoSpaceLeftError(inner)
+                }
+                return false
+            }
+        }
+
+        var current: NSError? = error as NSError
+        while let err = current {
+            if err.domain == NSPOSIXErrorDomain && err.code == Int(ENOSPC) {
+                return true
+            }
+            if err.domain == NSCocoaErrorDomain && err.code == NSFileWriteOutOfSpaceError {
+                return true
+            }
+            current = err.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return false
+    }
+
+    static func shouldSkipFontDownloadDueToDiskPressure(font: FontModel) -> Bool {
+        if isFontDownloadBlockedByDiskPressure() {
+            return true
+        }
+
+        guard hasSufficientDiskSpaceForFontDownload() else {
+            noteFontDiskFull()
+            reportDiskPressureDiagnosticIfNeeded(
+                font: font,
+                detail: "insufficient free disk space before download"
+            )
+            return true
+        }
+
+        return false
+    }
+
+    static func reportDiskPressureDiagnosticIfNeeded(font: FontModel, detail: String) {
+        diskPressureLock.lock()
+        let shouldReport = !hasReportedDiskPressure
+        if shouldReport {
+            hasReportedDiskPressure = true
+        }
+        diskPressureLock.unlock()
+
+        guard shouldReport else { return }
+
+        RoktAPIHelper.sendDiagnostics(
+            message: fontDiagnosticCode,
+            callStack: "font: \(font.url), error: \(detail)",
+            severity: .info
+        )
+    }
+
     // MARK: - Cache recovery
 
-    /// Fonts live in `Library/Caches`, which the OS may purge at any time, and a purge
-    /// can leave a partially written file behind. Because `isDownloadingFontRequired`
-    /// treats any present file as usable, an unreadable one would otherwise be re-read
-    /// and re-rejected on every render, pinning the layout to the fallback font for the
-    /// life of the install. Dropping the cache entry lets the next pass re-fetch it.
+    /// Font files can still be incomplete after a failed write. Because
+    /// `isDownloadingFontRequired` treats any present file as usable, an unreadable
+    /// one would otherwise be re-read and re-rejected on every render, pinning the
+    /// layout to the fallback font for the life of the install. Dropping the cache
+    /// entry lets the next pass re-fetch it.
     ///
     /// Attempts are capped per font per process so a permanently bad asset cannot loop,
     /// and the re-fetch is always asynchronous so it never delays a render.
@@ -314,6 +438,7 @@ internal class FontManager {
         invalidateCachedFont(font)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + fontRecoveryBackoff) {
+            guard !shouldSkipFontDownloadDueToDiskPressure(font: font) else { return }
             guard let fileUrl = getFileUrl(name: font.postScriptName ?? font.name) else { return }
             RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {}
         }
@@ -338,7 +463,7 @@ internal class FontManager {
     }
 
     #if DEBUG
-    /// `FileManager` always reports a caches directory on a real device, so the
+    /// `FileManager` always reports an application-support directory on a real device, so the
     /// unresolvable-path branch can only be exercised through this seam. Compiled out of
     /// release builds so it never ships.
     internal static var fileUrlResolverOverride: ((String) -> URL?)?
@@ -351,13 +476,16 @@ internal class FontManager {
         }
         #endif
 
-        guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
+        guard let fontDirectoryUrl = FontRepository.getFontDirectoryUrl() else {
             // Log FFL009
-            sendFullFontLogs("File Manager failed to read caches directory in user home", fontLogId: fullFontLogCode9)
+            sendFullFontLogs(
+                "File Manager failed to read application support directory in user home",
+                fontLogId: fullFontLogCode9
+            )
             return nil
         }
 
-        let fullPath = cacheDirectoryUrl.appendingPathComponent("\(name)\(fontExtension)")
+        let fullPath = fontDirectoryUrl.appendingPathComponent("\(name)\(fontExtension)")
         // Log FFL008
         sendFullFontLogs("Full file path URL: \(fullPath)", fontLogId: fullFontLogCode8)
         return fullPath

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -476,7 +476,7 @@ internal class FontManager {
         }
         #endif
 
-        guard let fontDirectoryUrl = FontRepository.getFontDirectoryUrl() else {
+        guard let fontDirectoryUrl = FontRepository.ensureFontDirectory() else {
             // Log FFL009
             sendFullFontLogs(
                 "File Manager failed to read application support directory in user home",

--- a/Sources/Rokt_Widget/Util/FontManager.swift
+++ b/Sources/Rokt_Widget/Util/FontManager.swift
@@ -103,7 +103,7 @@ internal class FontManager {
             }
 
             if FontManager.isDownloadingFontRequired(font: font) {
-                if shouldSkipFontDownloadDueToDiskPressure(font: font) {
+                if isFontDownloadBlockedByDiskPressure() {
                     batch.settle()
                     continue
                 }
@@ -276,15 +276,8 @@ internal class FontManager {
 
     // MARK: - Disk pressure
 
-    /// Minimum free space required before starting a font download.
-    static var minimumFreeDiskBytesForFontDownload: Int64 = 5 * 1024 * 1024
-
-    /// Test seam. When non-nil, replaces the system free-space probe.
-    static var freeDiskBytesOverride: Int64?
-
     private static let diskPressureLock = NSLock()
     private static var diskFullCircuitOpen = false
-    private static var hasReportedDiskPressure = false
 
     static func isFontDownloadBlockedByDiskPressure() -> Bool {
         diskPressureLock.lock()
@@ -304,32 +297,7 @@ internal class FontManager {
     static func resetDiskPressureState() {
         diskPressureLock.lock()
         diskFullCircuitOpen = false
-        hasReportedDiskPressure = false
         diskPressureLock.unlock()
-        freeDiskBytesOverride = nil
-        minimumFreeDiskBytesForFontDownload = 5 * 1024 * 1024
-    }
-
-    static func hasSufficientDiskSpaceForFontDownload() -> Bool {
-        if let override = freeDiskBytesOverride {
-            return override >= minimumFreeDiskBytesForFontDownload
-        }
-
-        guard let directoryURL = FontRepository.getFontDirectoryUrl() else {
-            return true
-        }
-
-        let probeURL = FileManager.default.fileExists(atPath: directoryURL.path)
-            ? directoryURL
-            : directoryURL.deletingLastPathComponent()
-
-        guard let values = try? probeURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
-              let capacity = values.volumeAvailableCapacityForImportantUsage
-        else {
-            return true
-        }
-
-        return capacity >= minimumFreeDiskBytesForFontDownload
     }
 
     static func isNoSpaceLeftError(_ error: Error) -> Bool {
@@ -356,40 +324,6 @@ internal class FontManager {
             current = err.userInfo[NSUnderlyingErrorKey] as? NSError
         }
         return false
-    }
-
-    static func shouldSkipFontDownloadDueToDiskPressure(font: FontModel) -> Bool {
-        if isFontDownloadBlockedByDiskPressure() {
-            return true
-        }
-
-        guard hasSufficientDiskSpaceForFontDownload() else {
-            noteFontDiskFull()
-            reportDiskPressureDiagnosticIfNeeded(
-                font: font,
-                detail: "insufficient free disk space before download"
-            )
-            return true
-        }
-
-        return false
-    }
-
-    static func reportDiskPressureDiagnosticIfNeeded(font: FontModel, detail: String) {
-        diskPressureLock.lock()
-        let shouldReport = !hasReportedDiskPressure
-        if shouldReport {
-            hasReportedDiskPressure = true
-        }
-        diskPressureLock.unlock()
-
-        guard shouldReport else { return }
-
-        RoktAPIHelper.sendDiagnostics(
-            message: fontDiagnosticCode,
-            callStack: "font: \(font.url), error: \(detail)",
-            severity: .info
-        )
     }
 
     // MARK: - Cache recovery
@@ -438,7 +372,7 @@ internal class FontManager {
         invalidateCachedFont(font)
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + fontRecoveryBackoff) {
-            guard !shouldSkipFontDownloadDueToDiskPressure(font: font) else { return }
+            guard !isFontDownloadBlockedByDiskPressure() else { return }
             guard let fileUrl = getFileUrl(name: font.postScriptName ?? font.name) else { return }
             RoktNetWorkAPI.downloadFont(font: font, destinationURL: fileUrl) {}
         }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -326,21 +326,112 @@ class FontRepositoryTests: XCTestCase {
         XCTAssertEqual(result, .success)
     }
 
-    // MARK: - Cache directory paths
+    // MARK: - Font directory paths
 
-    func test_getCacheDirectoryUrl_returnsRoktFontsSubdirectoryUnderCaches() throws {
-        let cacheDirectoryUrl = try XCTUnwrap(FontRepository.getCacheDirectoryUrl())
+    func test_getFontDirectoryUrl_returnsRoktFontsSubdirectoryUnderApplicationSupport() throws {
+        let fontDirectoryUrl = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
 
-        XCTAssertTrue(cacheDirectoryUrl.path.contains("Caches"))
-        XCTAssertTrue(cacheDirectoryUrl.path.hasSuffix("RoktFonts"))
+        XCTAssertTrue(fontDirectoryUrl.path.contains("Application Support"))
+        XCTAssertTrue(fontDirectoryUrl.path.hasSuffix("RoktFonts"))
     }
 
-    func test_getFileUrl_returnsJsonFileUnderCacheDirectory() throws {
+    func test_getFileUrl_returnsJsonFileUnderFontDirectory() throws {
         let fileUrl = try XCTUnwrap(FontRepository.getFileUrl(name: "custom-cache-file"))
 
         XCTAssertEqual(fileUrl.pathExtension, "json")
         XCTAssertTrue(fileUrl.path.contains("RoktFonts"))
         XCTAssertEqual(fileUrl.deletingPathExtension().lastPathComponent, "custom-cache-file")
+    }
+
+    func test_migrateLegacyFontStorage_movesCachesFontsIntoApplicationSupport() throws {
+        let fileManager = FileManager.default
+        let destination = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        FontRepository.resetMigrationMarkerForTests()
+        try? fileManager.removeItem(at: destination)
+
+        let cachesRoot = try XCTUnwrap(fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first)
+        let legacyCaches = cachesRoot.appendingPathComponent(FontRepository.fontDirectoryName, isDirectory: true)
+        try fileManager.createDirectory(at: legacyCaches, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? fileManager.removeItem(at: legacyCaches)
+            FontRepository.resetMigrationMarkerForTests()
+        }
+
+        let legacyFont = legacyCaches.appendingPathComponent("MigratedFont.ttf")
+        let legacyDetail = legacyCaches.appendingPathComponent("RoktFontDownloadedDetail.json")
+        try Data([0x01, 0x02]).write(to: legacyFont)
+        let details: [String: [String: String]] = [
+            "https://font.test/migrated.ttf": [
+                "name": "MigratedFont",
+                "timestamp": "1"
+            ]
+        ]
+        try JSONEncoder().encode(details).write(to: legacyDetail)
+
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+
+        XCTAssertTrue(fileManager.fileExists(
+            atPath: destination.appendingPathComponent("MigratedFont.ttf").path
+        ))
+        XCTAssertTrue(fileManager.fileExists(
+            atPath: destination.appendingPathComponent("RoktFontDownloadedDetail.json").path
+        ))
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyFont.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyCaches.path))
+    }
+
+    func test_migrateLegacyFontStorage_movesDocumentsFontsReferencedByMetadata() throws {
+        let fileManager = FileManager.default
+        let destination = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        FontRepository.resetMigrationMarkerForTests()
+        try? fileManager.removeItem(at: destination)
+
+        let documentsRoot = try XCTUnwrap(fileManager.urls(for: .documentDirectory, in: .userDomainMask).first)
+        let detailURL = documentsRoot.appendingPathComponent("RoktFontDownloadedDetail.json")
+        let urlListURL = documentsRoot.appendingPathComponent("RoktFontDownloadedUrl.json")
+        let fontURL = documentsRoot.appendingPathComponent("DocsFont.ttf")
+        let unrelatedTTF = documentsRoot.appendingPathComponent("Unrelated.ttf")
+
+        let details: [String: [String: String]] = [
+            "https://font.test/docs.ttf": [
+                "name": "DocsFont",
+                "timestamp": "1"
+            ]
+        ]
+        try JSONEncoder().encode(details).write(to: detailURL)
+        try JSONEncoder().encode(["https://font.test/docs.ttf"]).write(to: urlListURL)
+        try Data([0x0A]).write(to: fontURL)
+        try Data([0x0B]).write(to: unrelatedTTF)
+
+        addTeardownBlock {
+            try? fileManager.removeItem(at: detailURL)
+            try? fileManager.removeItem(at: urlListURL)
+            try? fileManager.removeItem(at: fontURL)
+            try? fileManager.removeItem(at: unrelatedTTF)
+            FontRepository.resetMigrationMarkerForTests()
+        }
+
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+
+        XCTAssertTrue(fileManager.fileExists(
+            atPath: destination.appendingPathComponent("DocsFont.ttf").path
+        ))
+        XCTAssertTrue(fileManager.fileExists(
+            atPath: destination.appendingPathComponent("RoktFontDownloadedDetail.json").path
+        ))
+        XCTAssertFalse(fileManager.fileExists(atPath: fontURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: unrelatedTTF.path),
+                      "unrelated Documents fonts must not be moved")
+    }
+
+    func test_migrateLegacyFontStorage_isIdempotent() throws {
+        FontRepository.resetMigrationMarkerForTests()
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+
+        let destination = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        let marker = destination.appendingPathComponent(".rokt_font_storage_application_support")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path))
     }
 
     func test_isFileExist_returnsTrueAfterSuccessfulSave() {
@@ -538,8 +629,8 @@ extension XCTestCase {
     private static let fontDownloadDetailFileName = "test_RoktFontDownloadedDetail"
 
     static func prepareTestFiles() {
-        FontRepository.setFontDownloadURLFileName(FontRepositoryTests.fontDownloadURLFileName)
-        FontRepository.setFontDownloadDetailFileName(FontRepositoryTests.fontDownloadDetailFileName)
+        FontRepository.setFontDownloadURLFileName(fontDownloadURLFileName)
+        FontRepository.setFontDownloadDetailFileName(fontDownloadDetailFileName)
     }
 
     static func deleteAllTestFiles() {
@@ -556,12 +647,12 @@ extension XCTestCase {
     }
 
     static func fileURLFor(fileName: String) -> URL? {
-        guard let cacheDirectoryUrl = FontRepository.getCacheDirectoryUrl() else {
-            XCTFail("caches url does not exist")
+        guard let fontDirectoryUrl = FontRepository.getFontDirectoryUrl() else {
+            XCTFail("application support font directory url does not exist")
             return nil
         }
 
-        return cacheDirectoryUrl.appendingPathComponent(fileName).appendingPathExtension("json")
+        return fontDirectoryUrl.appendingPathComponent(fileName).appendingPathExtension("json")
     }
 
     static func deleteJSONFileWith(name: String) {

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -335,6 +335,29 @@ class FontRepositoryTests: XCTestCase {
         XCTAssertTrue(fontDirectoryUrl.path.hasSuffix("RoktFonts"))
     }
 
+    func test_ensureFontDirectory_createsDirectoryAndExcludesFromBackup() throws {
+        let fileManager = FileManager.default
+        let destination = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        try? fileManager.removeItem(at: destination)
+
+        let ensured = try XCTUnwrap(FontRepository.ensureFontDirectory())
+        XCTAssertEqual(ensured.path, destination.path)
+        XCTAssertTrue(fileManager.fileExists(atPath: destination.path))
+
+        let values = try destination.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        XCTAssertEqual(values.isExcludedFromBackup, true)
+    }
+
+    func test_migrateLegacyFontStorage_excludesDestinationFromBackupEvenWhenAlreadyMigrated() throws {
+        let destination = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        FontRepository.resetMigrationMarkerForTests()
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+        FontRepository.migrateLegacyFontStorageIfNeeded()
+
+        let values = try destination.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        XCTAssertEqual(values.isExcludedFromBackup, true)
+    }
+
     func test_getFileUrl_returnsJsonFileUnderFontDirectory() throws {
         let fileUrl = try XCTUnwrap(FontRepository.getFileUrl(name: "custom-cache-file"))
 

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -36,6 +36,12 @@ private final class Traces {
         defer { lock.unlock() }
         return values.contains(where: predicate)
     }
+
+    func count(where predicate: (String) -> Bool) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.filter(predicate).count
+    }
 }
 
 class TestFontManager: XCTestCase {
@@ -70,6 +76,7 @@ class TestFontManager: XCTestCase {
             featureFlags: [:]
         )
         FontManager.resetFontRecoveryState()
+        FontManager.resetDiskPressureState()
         FontManager.maxFontRecoveryAttempts = 2
         FontManager.fontRecoveryBackoff = .seconds(1)
         FontManager.fileUrlResolverOverride = nil
@@ -124,12 +131,86 @@ class TestFontManager: XCTestCase {
     }
 
     func test_getFileURL_returnsMappedURL() throws {
-        let cacheDirectoryUrl = try XCTUnwrap(FontRepository.getCacheDirectoryUrl())
-        let expectedURL = cacheDirectoryUrl.appendingPathComponent("test.ttf")
+        let fontDirectoryUrl = try XCTUnwrap(FontRepository.getFontDirectoryUrl())
+        let expectedURL = fontDirectoryUrl.appendingPathComponent("test.ttf")
 
         let url = try XCTUnwrap(FontManager.getFileUrl(name: "test"))
 
         XCTAssertEqual(url, expectedURL)
+    }
+
+    func test_downloadFonts_whenFreeSpaceIsLow_skipsDownloadAndSettles() {
+        FontManager.freeDiskBytesOverride = 0
+        FontManager.minimumFreeDiskBytesForFontDownload = 1_000_000
+
+        let requestCount = Counter()
+        let settled = expectation(description: "batch settled without download")
+        let fontURL = "https://font.test/low-space.ttf"
+        stubFontFileUrl(fontURL) {
+            requestCount.increment()
+        }
+
+        FontManager.downloadFonts([
+            FontModel(name: "low-space-font", url: fontURL)
+        ]) {
+            settled.fulfill()
+        }
+
+        wait(for: [settled], timeout: 15)
+        XCTAssertEqual(requestCount.value, 0)
+        XCTAssertTrue(FontManager.isFontDownloadBlockedByDiskPressure())
+    }
+
+    func test_handleFontDownloadResponse_withENOSPC_tripsCircuitAndReportsOnce() throws {
+        let traces = captureDiagnosticStackTraces()
+        let enospc = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
+        let downloadError = RoktHTTPClient.RoktDownloadError.downloadFailed(error: enospc)
+
+        let firstSettled = expectation(description: "first enospc settled")
+        RoktNetWorkAPI.handleFontDownloadResponse(
+            font: FontModel(name: "enospc-font-1", url: "https://font.test/enospc-1.ttf"),
+            destinationURL: try XCTUnwrap(FontManager.getFileUrl(name: "enospc-font-1")),
+            downloadResponse: RoktDownloadResult(
+                httpURLResponse: nil,
+                downloadedFileLocalURL: nil,
+                downloadError: downloadError
+            ),
+            onDownloadComplete: { firstSettled.fulfill() }
+        )
+        wait(for: [firstSettled], timeout: 15)
+
+        let secondSettled = expectation(description: "second enospc settled")
+        RoktNetWorkAPI.handleFontDownloadResponse(
+            font: FontModel(name: "enospc-font-2", url: "https://font.test/enospc-2.ttf"),
+            destinationURL: try XCTUnwrap(FontManager.getFileUrl(name: "enospc-font-2")),
+            downloadResponse: RoktDownloadResult(
+                httpURLResponse: nil,
+                downloadedFileLocalURL: nil,
+                downloadError: downloadError
+            ),
+            onDownloadComplete: { secondSettled.fulfill() }
+        )
+        wait(for: [secondSettled], timeout: 15)
+
+        XCTAssertTrue(FontManager.isFontDownloadBlockedByDiskPressure())
+        XCTAssertTrue(waitUntil {
+            traces.count { $0.contains("No space left on device") } == 1
+        }, "disk-full should be reported once per process")
+
+        let requestCount = Counter()
+        let skipped = expectation(description: "download skipped after circuit open")
+        let blockedURL = "https://font.test/enospc-3.ttf"
+        stubFontFileUrl(blockedURL) {
+            requestCount.increment()
+        }
+        RoktNetWorkAPI.downloadFont(
+            font: FontModel(name: "enospc-font-3", url: blockedURL),
+            destinationURL: try XCTUnwrap(FontManager.getFileUrl(name: "enospc-font-3"))
+        ) {
+            skipped.fulfill()
+        }
+        wait(for: [skipped], timeout: 15)
+        XCTAssertEqual(requestCount.value, 0, "circuit breaker must stop further downloads")
     }
 
     func test_isSystemFont_forSystemFont_returnsTrue() {

--- a/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Util/TestFontManager.swift
@@ -139,29 +139,7 @@ class TestFontManager: XCTestCase {
         XCTAssertEqual(url, expectedURL)
     }
 
-    func test_downloadFonts_whenFreeSpaceIsLow_skipsDownloadAndSettles() {
-        FontManager.freeDiskBytesOverride = 0
-        FontManager.minimumFreeDiskBytesForFontDownload = 1_000_000
-
-        let requestCount = Counter()
-        let settled = expectation(description: "batch settled without download")
-        let fontURL = "https://font.test/low-space.ttf"
-        stubFontFileUrl(fontURL) {
-            requestCount.increment()
-        }
-
-        FontManager.downloadFonts([
-            FontModel(name: "low-space-font", url: fontURL)
-        ]) {
-            settled.fulfill()
-        }
-
-        wait(for: [settled], timeout: 15)
-        XCTAssertEqual(requestCount.value, 0)
-        XCTAssertTrue(FontManager.isFontDownloadBlockedByDiskPressure())
-    }
-
-    func test_handleFontDownloadResponse_withENOSPC_tripsCircuitAndReportsOnce() throws {
+    func test_handleFontDownloadResponse_withENOSPC_tripsCircuitAndReportsEveryFailure() throws {
         let traces = captureDiagnosticStackTraces()
         let enospc = NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC))
         let downloadError = RoktHTTPClient.RoktDownloadError.downloadFailed(error: enospc)
@@ -194,8 +172,8 @@ class TestFontManager: XCTestCase {
 
         XCTAssertTrue(FontManager.isFontDownloadBlockedByDiskPressure())
         XCTAssertTrue(waitUntil {
-            traces.count { $0.contains("No space left on device") } == 1
-        }, "disk-full should be reported once per process")
+            traces.count { $0.contains("Error downloading font") } == 2
+        }, "a disk-full failure should keep the existing download-failure diagnostic shape")
 
         let requestCount = Counter()
         let skipped = expectation(description: "download skipped after circuit open")


### PR DESCRIPTION
## Background

In 5.2.6, font files and metadata were moved from Documents to Library/Caches/RoktFonts. That path is purgeable and had no migration from the previous location, so upgraded installs treated fonts as cache misses and re-downloaded them. On devices with little free space those downloads fail with NSPOSIXErrorDomain code 28 (“No space left on device”), which produced a large increase in [FONT] diagnostics.

This change keeps fonts durable, migrates leftovers from older locations, excludes regenerable font storage from device/iCloud backup, and stops issuing further font downloads in a process after an out-of-space failure — while keeping the existing [FONT] download-failure diagnostic shape.

## What Has Changed

- Store font binaries and metadata under Application Support/RoktFonts instead of Caches
- One-time migration of leftover fonts/metadata from Documents (pre-5.2.6) and Caches/RoktFonts (5.2.6+)
- Create Application Support/RoktFonts with data protection and mark it excluded from backup (isExcludedFromBackup = true), including for installs that already completed migration
- Route font binary and metadata paths through ensureFontDirectory() so any write path applies creation + backup exclusion
- Trip a process-level circuit breaker on ENOSPC / out-of-space errors so further font downloads are blocked until the next init
- Keep the existing terminal [FONT] download-failure diagnostic shape for disk-full failures (no separate once-per-process INFO diagnostic)
- Unit coverage for migration, backup exclusion, and the ENOSPC circuit breaker

## How Has This Been Tested

**FontRepositoryTests**
- test_getFontDirectoryUrl_returnsRoktFontsSubdirectoryUnderApplicationSupport — font storage resolves under Application Support/RoktFonts
- test_ensureFontDirectory_createsDirectoryAndExcludesFromBackup — creates RoktFonts and sets isExcludedFromBackup
- test_migrateLegacyFontStorage_excludesDestinationFromBackupEvenWhenAlreadyMigrated — re-running migration after the marker still applies backup exclusion
- test_getFileUrl_returnsJsonFileUnderFontDirectory — metadata JSON paths are under the new font directory
- test_migrateLegacyFontStorage_movesCachesFontsIntoApplicationSupport — Caches/RoktFonts leftovers (fonts + metadata) move into Application Support and the legacy directory is removed
- test_migrateLegacyFontStorage_movesDocumentsFontsReferencedByMetadata — Documents metadata and referenced .ttf files migrate; unrelated Documents .ttf files are left alone
- test_migrateLegacyFontStorage_isIdempotent — migration writes a marker and does not re-run

**TestFontManager**
- test_getFileURL_returnsMappedURL — font binary URLs point at Application Support/RoktFonts
- test_handleFontDownloadResponse_withENOSPC_tripsCircuitAndReportsEveryFailure — ENOSPC trips the circuit, emits the standard Error downloading font diagnostic for each observed failure, and blocks subsequent downloadFont calls
- Existing FontManager / FontRepository coverage (download completion, cache recovery, save/load/remove) was re-run as part of the full suite.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
