### PR TITLE
feat: append sessionId to every RoktLogger line

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/SessionManager.swift
+++ b/Sources/Rokt_Widget/DataAccess/SessionManager.swift
@@ -45,10 +45,12 @@ class SessionManager {
 
         clearSession(reason: .sessionIdUpdated)
         userDefaults.set(newSessionId, forKey: userDefaultsKeySessionId)
+        RoktLogger.shared.sessionId = newSessionId
         RoktLogger.shared.info("Session updated. sessionId=\(newSessionId)")
     }
 
     private func clearSession(reason: SessionInvalidationReason) {
+        RoktLogger.shared.sessionId = nil
         RoktLogger.shared.info("Clearing session. reason=\(reason.rawValue)")
         userDefaults.removeObject(forKey: userDefaultsKeySessionId)
         managedSessions.forEach { $0.sessionInvalidated() }

--- a/Sources/Rokt_Widget/Logging/RoktLogger.swift
+++ b/Sources/Rokt_Widget/Logging/RoktLogger.swift
@@ -26,6 +26,7 @@ final class RoktLogger: @unchecked Sendable {
 
     private let lock = NSLock()
     private var _logLevel: RoktLogLevel = .none
+    private var _sessionId: String?
 
     /// The current log level. Messages below this level will not be logged.
     /// Default is `.none` (no logging).
@@ -35,6 +36,13 @@ final class RoktLogger: @unchecked Sendable {
     var logLevel: RoktLogLevel {
         get { lock.withLock { _logLevel } }
         set { lock.withLock { _logLevel = newValue } }
+    }
+
+    /// Session identifier from the current experience, when known.
+    /// When set, appended to every log line as `| sessionId=<id>` for easier support triage.
+    var sessionId: String? {
+        get { lock.withLock { _sessionId } }
+        set { lock.withLock { _sessionId = newValue } }
     }
 
     /// Logs a verbose message for detailed diagnostic information.
@@ -132,10 +140,12 @@ final class RoktLogger: @unchecked Sendable {
         function: String,
         line: Int
     ) {
-        guard level >= logLevel, logLevel != .none else { return }
+        let (currentLevel, currentSessionId) = lock.withLock { (_logLevel, _sessionId) }
+        guard level >= currentLevel, currentLevel != .none else { return }
         let prefix = "[Rokt/\(level.label)]"
         let fname = (file as NSString).lastPathComponent
         let errorSuffix = error.map { " | Error: \($0.localizedDescription)" } ?? ""
-        print("\(prefix) [\(fname) \(function):\(line)] \(message)\(errorSuffix)")
+        let sessionSuffix = currentSessionId.map { " | sessionId=\($0)" } ?? ""
+        print("\(prefix) [\(fname) \(function):\(line)] \(message)\(errorSuffix)\(sessionSuffix)")
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/SessionManagerTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/SessionManagerTest.swift
@@ -23,6 +23,7 @@ class SessionManagerTests: XCTestCase {
             managedSessions: [mockManagedSession],
             userDefaults: userDefaults
         )
+        RoktLogger.shared.sessionId = nil
     }
 
     override func tearDown() {
@@ -30,6 +31,7 @@ class SessionManagerTests: XCTestCase {
         userDefaults = nil
         mockManagedSession = nil
         sessionManager = nil
+        RoktLogger.shared.sessionId = nil
         super.tearDown()
     }
 
@@ -127,5 +129,30 @@ class SessionManagerTests: XCTestCase {
 
         XCTAssertEqual(userDefaults.string(forKey: "rokt.sessionId"), existingSessionId)
         XCTAssertEqual(mockManagedSession.sessionInvalidatedCallCount, 1)
+    }
+
+    func testUpdateSessionIdPropagatesIdToLogger() {
+        sessionManager.updateSessionId(newSessionId: "newSessionXYZ")
+
+        XCTAssertEqual(RoktLogger.shared.sessionId, "newSessionXYZ")
+    }
+
+    func testUpdateSessionIdNilClearsIdOnLogger() {
+        sessionManager.updateSessionId(newSessionId: "newSessionXYZ")
+        XCTAssertEqual(RoktLogger.shared.sessionId, "newSessionXYZ")
+
+        sessionManager.updateSessionId(newSessionId: nil)
+
+        XCTAssertNil(RoktLogger.shared.sessionId)
+    }
+
+    func testStoredTagIdChangeClearsIdOnLogger() {
+        sessionManager.storedTagId = "tag-a"
+        sessionManager.updateSessionId(newSessionId: "newSessionXYZ")
+        XCTAssertEqual(RoktLogger.shared.sessionId, "newSessionXYZ")
+
+        sessionManager.storedTagId = "tag-b"
+
+        XCTAssertNil(RoktLogger.shared.sessionId)
     }
 }

--- a/Tests/Rokt_WidgetTests/Shared/Logging/TestRoktLogger.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Logging/TestRoktLogger.swift
@@ -6,10 +6,12 @@ final class TestRoktLogger: XCTestCase {
     override func setUp() {
         super.setUp()
         RoktLogger.shared.logLevel = .none
+        RoktLogger.shared.sessionId = nil
     }
 
     override func tearDown() {
         RoktLogger.shared.logLevel = .none
+        RoktLogger.shared.sessionId = nil
         super.tearDown()
     }
 
@@ -20,6 +22,36 @@ final class TestRoktLogger: XCTestCase {
 
         // Assert
         XCTAssertEqual(logger.logLevel, .none)
+    }
+
+    func test_sessionId_canBeSetAndCleared() {
+        let logger = RoktLogger()
+        XCTAssertNil(logger.sessionId)
+
+        logger.sessionId = "session-abc"
+        XCTAssertEqual(logger.sessionId, "session-abc")
+
+        logger.sessionId = nil
+        XCTAssertNil(logger.sessionId)
+    }
+
+    func test_logMethods_doNotCrashWithSessionId() {
+        let logger = RoktLogger.shared
+        logger.logLevel = .verbose
+        logger.sessionId = "session-for-log"
+
+        logger.verbose("verbose test message")
+        logger.debug("debug test message")
+        logger.info("info test message")
+        logger.warning("warning test message")
+        logger.error("error test message")
+
+        let testError = NSError(domain: "test", code: 1, userInfo: nil)
+        logger.verbose("verbose with error", error: testError)
+        logger.debug("debug with error", error: testError)
+        logger.info("info with error", error: testError)
+        logger.warning("warning with error", error: testError)
+        logger.error("error with error", error: testError)
     }
 
     func test_logLevel_canBeSet() {


### PR DESCRIPTION
Wire SessionManager to set/clear RoktLogger.sessionId so console logs include | sessionId= once known for support triage.

<!-- markdownlint-disable MD041 -->

## Background

Console logs from the iOS SDK did not include the session ID, so partners debugging placements had no easy way to correlate local logs with support. This change mirrors the UX Helper logger behavior: once a session ID is known, append it to every console log line.

## What Has Changed

- RoktLogger now holds an optional thread-safe sessionId and appends | sessionId=<id> to every log line when set.
- SessionManager sets RoktLogger.shared.sessionId on session update and clears it on session invalidation (including tag-id changes).
- Unit tests cover logger session ID set/clear, logging with a session ID present, and SessionManager → logger wiring.

## How Has This Been Tested

- TestRoktLogger.test_sessionId_canBeSetAndCleared — verifies RoktLogger.sessionId can be assigned and cleared
- TestRoktLogger.test_logMethods_doNotCrashWithSessionId — exercises all log levels (with and without an Error) while sessionId is set, confirming lines append | sessionId=… without crashing
- SessionManagerTests.testUpdateSessionIdPropagatesIdToLogger — updateSessionId writes the new ID onto RoktLogger.shared.sessionId
- SessionManagerTests.testUpdateSessionIdNilClearsIdOnLogger — updating the session to nil clears the logger session ID
- SessionManagerTests.testStoredTagIdChangeClearsIdOnLogger — changing the stored tag ID invalidates the session and clears the logger session ID
- Existing SessionManagerTests / TestRoktLogger / TestRoktLogLevel suites still pass (28 tests total via the Rokt-Widget SPM scheme)
- trunk check on the changed files; rokt-Example build succeeded; periphery scan reported no new unused-code findings from this change

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.
