### PR TITLE
fix: multicast Rokt.globalEvents so kit and client can both subscribe

### DIFF
--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -31,7 +31,6 @@ class RoktInternalImplementation {
     private static let maxPendingApiLogs = 10
     private static let initFailedError = "INIT_FAILED"
     private static let fontFailedError = "FONT_FAILED"
-    private static let defaultRoktInitEvent = "DEFAULT_ROKT_INIT_EVENT"
     private static let trackingConsentError = "tracking consent not authorised"
     private static let cacheDurationKey = "cacheDuration"
     private static let cacheAttributesKey = "cacheAttributeKeys"
@@ -101,6 +100,11 @@ class RoktInternalImplementation {
     // store callback for partner event integration
     private var roktEvent: ((RoktEvent) -> Void)?
     private var roktEventMap: [String: ((RoktEvent) -> Void)?] = [:]
+
+    // Multicast: the mParticle kit and the host app both subscribe through Rokt.globalEvents,
+    // so a single slot let whichever registered last silently unsubscribe the other.
+    private var globalEventListeners: [(RoktEvent) -> Void] = []
+    private let globalEventListenersLock = NSLock()
 
     // debounce work item for EmbeddedSizeChanged
     private var sizeChangeWorkItem: DispatchWorkItem?
@@ -899,6 +903,25 @@ class RoktInternalImplementation {
         }
     }
 
+    private func addGlobalEventListener(_ onEvent: @escaping (RoktEvent) -> Void) {
+        globalEventListenersLock.lock()
+        defer { globalEventListenersLock.unlock() }
+        globalEventListeners.append(onEvent)
+    }
+
+    func removeAllGlobalEventListeners() {
+        globalEventListenersLock.lock()
+        defer { globalEventListenersLock.unlock() }
+        globalEventListeners.removeAll()
+    }
+
+    private func sendEventToGlobalListeners(_ roktEvent: RoktEvent) {
+        globalEventListenersLock.lock()
+        let listeners = globalEventListeners
+        globalEventListenersLock.unlock()
+        listeners.forEach { $0(roktEvent) }
+    }
+
     func initWith(
         roktTagId: String,
         mParticleKitDetails: MParticleKitDetails?
@@ -965,9 +988,7 @@ class RoktInternalImplementation {
         self.processedTimingsRequests?.setInitEndTime()
 
         RoktLogger.shared.info("Initialization complete - success: \(self.isInitialized)")
-        if let eventListener = self.roktEventMap[Self.defaultRoktInitEvent] {
-            eventListener?(RoktEvent.InitComplete(success: self.isInitialized))
-        }
+        self.sendEventToGlobalListeners(RoktEvent.InitComplete(success: self.isInitialized))
 
         // Replay any execute that arrived before init finished.
         if let page = pendingPayload {
@@ -994,9 +1015,7 @@ class RoktInternalImplementation {
         if let code = statusCode, code != 429 {
             self.sendDiagnostics(Self.initDiagnosticCode, error: error, statusCode: statusCode, response: response)
         }
-        if let eventListener = self.roktEventMap[Self.defaultRoktInitEvent] {
-            eventListener?(RoktEvent.InitComplete(success: false))
-        }
+        self.sendEventToGlobalListeners(RoktEvent.InitComplete(success: false))
     }
 
     private func defaultTxnInitService(roktTagId: String) -> TxnInitService {
@@ -1401,7 +1420,11 @@ class RoktInternalImplementation {
         onEvent: ((RoktEvent) -> Void)?
     ) {
         if isGlobal, viewName.isEmpty {
-            roktEventMap[Self.defaultRoktInitEvent] = onEvent
+            if let onEvent {
+                addGlobalEventListener(onEvent)
+            } else {
+                removeAllGlobalEventListeners()
+            }
         } else {
             roktEventMap[viewName] = onEvent
         }

--- a/Tests/Rokt_WidgetTests/TestGlobalEventsMulticast.swift
+++ b/Tests/Rokt_WidgetTests/TestGlobalEventsMulticast.swift
@@ -59,6 +59,24 @@ final class TestGlobalEventsMulticast: XCTestCase {
         XCTAssertTrue((clientEvents.first as? RoktEvent.InitComplete)?.success == true)
     }
 
+    // Subscriptions accumulate: a caller that subscribes N times is called back N times per event,
+    // where previously every subscription but the last was silently dropped.
+    func test_globalEvents_subscriptionsAccumulateSoEachOneIsCalledBack() {
+        stubInitSuccess()
+        let subscriptionCount = 3
+        var received: [RoktEvent] = []
+
+        for _ in 0..<subscriptionCount {
+            impl.mapEvents(isGlobal: true, onEvent: { received.append($0) })
+        }
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+
+        waitUntil { received.count == subscriptionCount }
+        XCTAssertEqual(received.count, subscriptionCount)
+        XCTAssertTrue(received.allSatisfy { ($0 as? RoktEvent.InitComplete)?.success == true })
+    }
+
     func test_globalEvents_bothSubscribersReceiveInitFailure() {
         stub.result = .status(400)
         var kitEvents: [RoktEvent] = []

--- a/Tests/Rokt_WidgetTests/TestGlobalEventsMulticast.swift
+++ b/Tests/Rokt_WidgetTests/TestGlobalEventsMulticast.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class TestGlobalEventsMulticast: XCTestCase {
+
+    private var impl: RoktInternalImplementation!
+    private var stub: StubGlobalEventsInitHTTPClient!
+
+    override func setUp() {
+        super.setUp()
+        impl = RoktInternalImplementation()
+        stub = StubGlobalEventsInitHTTPClient()
+        impl.makeTxnInitServiceOverride = { [stub] tagId in
+            TxnInitService(
+                environment: .Prod,
+                accountId: tagId,
+                sdkVersion: "5.3.2",
+                layoutSchemaVersion: "1.0",
+                httpClient: stub!,
+                baseBackoff: 0,
+                sleep: { _ in }
+            )
+        }
+    }
+
+    override func tearDown() {
+        impl = nil
+        stub = nil
+        super.tearDown()
+    }
+
+    private func stubInitSuccess() {
+        stub.result = .success(data: Data(
+            """
+            {
+              "session_id": "sess-1",
+              "session_token": { "token": "jwt", "expires_at": 32503680000000 },
+              "feature_flags": {},
+              "fonts": []
+            }
+            """.utf8
+        ))
+    }
+
+    func test_globalEvents_bothKitAndClientReceiveInitComplete() {
+        stubInitSuccess()
+        var kitEvents: [RoktEvent] = []
+        var clientEvents: [RoktEvent] = []
+
+        impl.mapEvents(isGlobal: true, onEvent: { kitEvents.append($0) })
+        impl.mapEvents(isGlobal: true, onEvent: { clientEvents.append($0) })
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+
+        waitUntil { !kitEvents.isEmpty && !clientEvents.isEmpty }
+        XCTAssertEqual(kitEvents.count, 1)
+        XCTAssertEqual(clientEvents.count, 1)
+        XCTAssertTrue((kitEvents.first as? RoktEvent.InitComplete)?.success == true)
+        XCTAssertTrue((clientEvents.first as? RoktEvent.InitComplete)?.success == true)
+    }
+
+    func test_globalEvents_bothSubscribersReceiveInitFailure() {
+        stub.result = .status(400)
+        var kitEvents: [RoktEvent] = []
+        var clientEvents: [RoktEvent] = []
+
+        impl.mapEvents(isGlobal: true, onEvent: { kitEvents.append($0) })
+        impl.mapEvents(isGlobal: true, onEvent: { clientEvents.append($0) })
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+
+        waitUntil { !kitEvents.isEmpty && !clientEvents.isEmpty }
+        XCTAssertTrue((kitEvents.first as? RoktEvent.InitComplete)?.success == false)
+        XCTAssertTrue((clientEvents.first as? RoktEvent.InitComplete)?.success == false)
+    }
+
+    func test_globalEvents_nilOnEventRemovesAllSubscribers() {
+        stubInitSuccess()
+        var received: [RoktEvent] = []
+
+        impl.mapEvents(isGlobal: true, onEvent: { received.append($0) })
+        impl.mapEvents(isGlobal: true, onEvent: { received.append($0) })
+        impl.mapEvents(isGlobal: true, onEvent: nil)
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+
+        waitUntil { self.impl.isInitialized }
+        XCTAssertTrue(received.isEmpty)
+    }
+
+    func test_globalEvents_perViewListenersAreUnaffected() {
+        stubInitSuccess()
+        var globalEvents: [RoktEvent] = []
+        var viewEvents: [RoktEvent] = []
+
+        impl.mapEvents(isGlobal: true, onEvent: { globalEvents.append($0) })
+        impl.mapEvents(viewName: "checkout", onEvent: { viewEvents.append($0) })
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+
+        waitUntil { !globalEvents.isEmpty }
+        XCTAssertEqual(globalEvents.count, 1)
+        XCTAssertTrue(viewEvents.isEmpty)
+    }
+}
+
+private final class StubGlobalEventsInitHTTPClient: HTTPClientAdapter {
+    enum Result {
+        case success(data: Data)
+        case status(Int)
+    }
+
+    var result: Result = .status(500)
+
+    func updateTimeout(timeout: Double) {}
+
+    @discardableResult
+    func startRequestWith(
+        urlAddress: String,
+        method: RoktHTTPMethod,
+        parameters: RoktHTTPParameters?,
+        parameterArray: RoktHTTPParameterArray?,
+        headers: RoktHTTPHeaders?,
+        onRequestStart: (() -> Void)?,
+        requestTimeout: TimeInterval?,
+        completionQueue: DispatchQueue,
+        completionHandler: ((RoktHTTPRequestResult) -> Void)?
+    ) -> URLRequest? {
+        let url = URL(string: urlAddress)!
+        let httpResult: RoktHTTPRequestResult
+        switch result {
+        case .success(let data):
+            httpResult = RoktHTTPRequestResult(
+                httpURLResponse: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil),
+                responseData: data,
+                responseError: nil,
+                jsonSerialisedResponseData: .success(NSNull())
+            )
+        case .status(let code):
+            httpResult = RoktHTTPRequestResult(
+                httpURLResponse: HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil),
+                responseData: nil,
+                responseError: nil,
+                jsonSerialisedResponseData: .success(NSNull())
+            )
+        }
+        completionQueue.async { completionHandler?(httpResult) }
+        return nil
+    }
+
+    func downloadFile(
+        source urlAddress: String,
+        destinationURL: URL,
+        options: [RoktDownloadOptions],
+        parameters: RoktHTTPParameters?,
+        headers: RoktHTTPHeaders?,
+        requestTimeout: TimeInterval?,
+        completionQueue: DispatchQueue,
+        completionHandler: ((RoktDownloadResult) -> Void)?
+    ) {}
+}

--- a/Tests/Rokt_WidgetTests/TestRokt.swift
+++ b/Tests/Rokt_WidgetTests/TestRokt.swift
@@ -13,6 +13,7 @@ class TestRokt: XCTestCase {
             UserDefaults.standard.removePersistentDomain(forName: bundleID)
             UserDefaults.standard.synchronize()
         }
+        Rokt.shared.roktImplementation.removeAllGlobalEventListeners()
     }
 
     override func tearDown() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

`Rokt.globalEvents(onEvent:)` stored its subscriber in a single dictionary slot, so the **last** caller to subscribe silently unsubscribed everyone before it:

```swift
// RoktInternalImplementation.swift (before)
if isGlobal, viewName.isEmpty {
    roktEventMap[Self.defaultRoktInitEvent] = onEvent   // overwrite, not append
}
```

There are always at least two subscribers in an mParticle integration, and they collide:

1. The **mParticle Rokt kit** subscribes during `didFinishLaunchingWithConfiguration:` and uses `InitComplete(success: true)` as the sole trigger to mark itself started ([`MPKitRokt.m:80-93`](https://github.com/mParticle/mparticle-apple-sdk/blob/main/kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m)).
2. The **host app** subscribes either directly via `Rokt.globalEvents`, or through `MParticle.rokt.globalEvents:`, which the kit forwards straight back into the same slot ([`MPKitRokt.m:555-558`](https://github.com/mParticle/mparticle-apple-sdk/blob/main/kits/rokt/rokt/Sources/mParticle-Rokt/MPKitRokt.m)).

Whichever registers second wins. The failure is severe and completely silent when the app wins:

- the kit never receives `InitComplete`, so `started` stays `NO`;
- `MPKitContainer.isActiveAndNotDisabled:` therefore excludes Rokt from `activeKitsRegistry`;
- `forwardSDKCall:` iterates an empty list, so **every `selectPlacements` call is discarded without ever invoking the caller's `onEvent`**.

The partner sees no placements *and* no events at all — not even `PlacementFailure`, because the call never reaches the Rokt SDK, which would otherwise always report one via `preExecuteFailureHandler()`. There is no log on the app side and no recovery for the rest of the process lifetime.

This was found while investigating a partner reporting missing placements with zero Rokt events of any type.

Fixes [(issue)]

## What Has Changed

Global event subscribers are now multicast instead of single-slot.

- Replaced the shared `roktEventMap[DEFAULT_ROKT_INIT_EVENT]` slot with a dedicated `globalEventListeners` array guarded by an `NSLock` — `mapEvents` is reachable from any thread while delivery happens on main.
- `mapEvents(isGlobal: true, onEvent:)` now **appends** a subscriber; passing `nil` clears all of them, preserving the previous "stop delivering" behaviour.
- Both `InitComplete` emit sites (`handleInitSuccess` / `handleInitFailure`) fan out to every subscriber.
- Removed the now-unused `defaultRoktInitEvent` sentinel key.

Per-view listeners registered through `Rokt.events(identifier:onEvent:)` are deliberately untouched — they keep today's replace-on-re-register semantics, and a test pins that.

**No public API change.** `Rokt.globalEvents(onEvent:)` and `Rokt.events(identifier:onEvent:)` keep their exact signatures and ObjC selectors; only the internal dispatch changes. Existing single-subscriber integrations behave identically.

### Behaviour change to be aware of

A caller that subscribes to `globalEvents` more than once now receives each event once **per subscription**, where previously the earlier subscription was silently dropped. `globalEvents` is documented as a process-wide subscription and the kit registers under a `dispatch_once`, so this is not expected to affect existing integrations — but it is the one observable difference and worth a reviewer's eye.

## How Has This Been Tested

New `Tests/Rokt_WidgetTests/TestGlobalEventsMulticast.swift`, driving init deterministically through the `makeTxnInitServiceOverride` seam with a stubbed HTTP client (same pattern as `TestTxnInitWiring`), against a fresh `RoktInternalImplementation` rather than the shared singleton:

- `test_globalEvents_bothKitAndClientReceiveInitComplete` — two subscribers, both receive exactly one `InitComplete(success: true)`. Fails on `main` (the first subscriber gets nothing).
- `test_globalEvents_bothSubscribersReceiveInitFailure` — same fan-out on the failure path.
- `test_globalEvents_nilOnEventRemovesAllSubscribers` — `nil` clears every subscriber.
- `test_globalEvents_perViewListenersAreUnaffected` — a per-view listener does not receive global `InitComplete`.

`TestRokt.setUp` now clears global subscribers between tests. Those two existing tests subscribe on the shared `Rokt.shared` singleton, so without a reset the multicast list would leak across tests and fulfil expectations belonging to already-finished cases.

Validation run:

- `trunk check` — clean on all changed files.
- `xcodebuild test -scheme Rokt-Widget -only-testing:Rokt_WidgetTests` — full unit suite green on iPhone 16 Pro (iOS 18.6).

Not run: `periphery scan` and `Tests/SizeReport/measure_size.sh`. The change is a few lines in one file with no new types or assets, so size impact is nil, but flagging that I skipped those two steps rather than implying they passed.

## Notes

This fixes the *collision*. It does not fix the underlying fragility that the mParticle Rokt kit only becomes active on `InitComplete(success: true)` — a failed Rokt init (network error, 429, font failure) still leaves the kit permanently inactive for the process lifetime, with the same silent-drop symptom. That is addressed separately by adding init retry, stacked on this branch.

Related follow-up worth considering, not included here: per-view listeners registered via `Rokt.events(identifier:)` have the same single-slot overwrite behaviour, scoped per `viewName`. Lower impact, but the same class of bug.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
