### PR TITLE
refactor: centralize the transient transport failure allowlist

### DIFF
--- a/Sources/Rokt_Widget/Models/Payment/ForwardPaymentRetryRules.swift
+++ b/Sources/Rokt_Widget/Models/Payment/ForwardPaymentRetryRules.swift
@@ -28,18 +28,6 @@ enum ForwardPaymentRetryRules {
             if code == 408 || code == 429 { return true }
             return false
         }
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorNotConnectedToInternet,
-             NSURLErrorCannotFindHost,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
+        return NetworkRetryRules.isTransientTransportFailure(error, policy: .transientIncludingOffline)
     }
 }

--- a/Sources/Rokt_Widget/Networking/NetworkRetryRules.swift
+++ b/Sources/Rokt_Widget/Networking/NetworkRetryRules.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Shared classification of URL-layer failures that may succeed if the same request is sent again.
+///
+/// Status-code policy deliberately stays with each caller — init, offers, events, forward payment
+/// and the legacy post/download path do not agree on which HTTP codes are worth another attempt —
+/// but the transport allowlist is the same question everywhere, and the hand-maintained copies had
+/// already drifted apart on the offline case.
+enum NetworkRetryRules {
+
+    /// How much of the transient set a given caller is willing to come back for.
+    enum TransportPolicy {
+        /// Timeouts only. The legacy `performPost` / font download path, which retries in place
+        /// almost immediately and treats every other transport failure as terminal.
+        case timeoutOnly
+        /// Transient failures, but not a device with no connectivity: an in-request retry loop
+        /// should fail fast rather than spend its attempts while the radio is down.
+        case transient
+        /// Transient failures including offline, for work that is persisted or rescheduled and
+        /// comes back seconds or minutes later rather than inline.
+        case transientIncludingOffline
+    }
+
+    static func isTransientTransportFailure(_ error: Error, policy: TransportPolicy) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+
+        switch nsError.code {
+        case NSURLErrorTimedOut:
+            return true
+        case NSURLErrorNetworkConnectionLost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorCannotFindHost,
+             NSURLErrorDNSLookupFailed:
+            return policy != .timeoutOnly
+        case NSURLErrorNotConnectedToInternet:
+            return policy == .transientIncludingOffline
+        default:
+            // Cancelled requests, bad URLs and TLS/ATS rejections fail the same way every time.
+            return false
+        }
+    }
+}

--- a/Sources/Rokt_Widget/Networking/NetworkingHelper.swift
+++ b/Sources/Rokt_Widget/Networking/NetworkingHelper.swift
@@ -43,7 +43,6 @@ class NetworkingHelper {
     class func performPost(url: String,
                            body: [String: Any]?,
                            headers: [String: String]? = nil,
-                           extraErrorCheck: Bool = false,
                            onRequestStart: (() -> Void)? = nil,
                            success: ((NSDictionary, Data?, ResponseHeaders?) -> Void)? = nil,
                            failure: ((Error, Int?, String) -> Void)? = nil,
@@ -60,15 +59,10 @@ class NetworkingHelper {
             completionHandler: { requestResult in
                 processHTTPRequestResult(httpResult: requestResult,
                                          success: success) { error, errorCode, errorReponse in
-                    if retriableResponse(
-                        error: error,
-                        code: errorCode,
-                        extraErrorCheck: extraErrorCheck
-                    ) && retryCount < maxRetries {
+                    if retriableResponse(error: error, code: errorCode) && retryCount < maxRetries {
                         performPost(url: url,
                                     body: body,
                                     headers: headers,
-                                    extraErrorCheck: extraErrorCheck,
                                     onRequestStart: onRequestStart,
                                     success: success,
                                     failure: failure,
@@ -81,25 +75,12 @@ class NetworkingHelper {
         )
     }
 
-    class internal func retriableResponse(error: Error, code: Int?, extraErrorCheck: Bool = false) -> Bool {
-        if error._code == NSURLErrorTimedOut {
-            return true
-        }
-
-        if isRetryableStatusCode(code) {
-            return true
-        }
-
-        if extraErrorCheck && (error._code == NSURLErrorNetworkConnectionLost ||
-                                error._code == NSURLErrorCannotFindHost ||
-                                error._code == NSURLErrorCannotConnectToHost ||
-                                error._code == NSURLErrorNotConnectedToInternet ||
-                                error._code == NSURLErrorDNSLookupFailed ||
-                                error._code == NSURLErrorResourceUnavailable) {
-            return true
-        }
-
-        return false
+    // This path retries in place almost immediately, so it comes back for a timeout only.
+    // Widening it to the rest of the transient set is a `.transient` policy away, but that
+    // is a behaviour change for font downloads and should be decided on its own.
+    class internal func retriableResponse(error: Error, code: Int?) -> Bool {
+        NetworkRetryRules.isTransientTransportFailure(error, policy: .timeoutOnly)
+            || isRetryableStatusCode(code)
     }
 
     class func isRetryableStatusCode(_ code: Int?) -> Bool {

--- a/Sources/Rokt_Widget/Networking/OffersService.swift
+++ b/Sources/Rokt_Widget/Networking/OffersService.swift
@@ -244,18 +244,7 @@ internal struct OffersService {
 
     // Transient transport failures only; a hard-offline device fails fast.
     private func isRetryable(error: Error) -> Bool {
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorCannotFindHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
+        NetworkRetryRules.isTransientTransportFailure(error, policy: .transient)
     }
 
     // Exponential backoff with jitter to avoid hammering a struggling gateway.

--- a/Sources/Rokt_Widget/Networking/TxnEventService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnEventService.swift
@@ -153,22 +153,10 @@ internal struct TxnEventService {
         return seconds
     }
 
-    // Transient transport failures worth retrying, including a device that is offline
-    // (matches ForwardPaymentRetryRules and the web/Android recoverable-transport set).
+    // Transient transport failures worth retrying, including a device that is offline:
+    // batches are persisted and replayed, so an offline send is worth coming back for.
     private func isRetryable(error: Error) -> Bool {
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorNotConnectedToInternet,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorCannotFindHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
+        NetworkRetryRules.isTransientTransportFailure(error, policy: .transientIncludingOffline)
     }
 
     // Exponential backoff with jitter to avoid hammering a struggling gateway.

--- a/Sources/Rokt_Widget/Networking/TxnInitService.swift
+++ b/Sources/Rokt_Widget/Networking/TxnInitService.swift
@@ -102,18 +102,7 @@ internal struct TxnInitService {
 
     // Transient transport failures only; a hard-offline device fails fast.
     private func isRetryable(error: Error) -> Bool {
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorCannotFindHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
+        NetworkRetryRules.isTransientTransportFailure(error, policy: .transient)
     }
 
     // Exponential backoff with jitter to avoid hammering a struggling gateway.

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -1054,25 +1054,13 @@ class RoktInternalImplementation {
 
     // A wrong tag id or a rejected request will fail the same way every time, so only
     // rate limiting, server faults and transient transport failures are worth coming back for.
-    // The URL error allowlist matches TxnEventService / ForwardPaymentRetryRules: a cancelled
-    // request, a bad URL or a TLS/ATS rejection is permanent and must not be retried.
+    // Recovery is scheduled seconds later rather than sent inline, so an offline device is
+    // worth retrying here even though the in-request loops fail fast on it.
     private static func isRecoverable(error: Error, statusCode: Int?) -> Bool {
         if let statusCode {
             return statusCode == rateLimitedStatusCode || (500..<600).contains(statusCode)
         }
-        let nsError = error as NSError
-        guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorNotConnectedToInternet,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorCannotFindHost,
-             NSURLErrorDNSLookupFailed:
-            return true
-        default:
-            return false
-        }
+        return NetworkRetryRules.isTransientTransportFailure(error, policy: .transientIncludingOffline)
     }
 
     private func defaultTxnInitService(roktTagId: String) -> TxnInitService {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkRetryRules.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkRetryRules.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Rokt_Widget
+
+final class TestNetworkRetryRules: XCTestCase {
+
+    private func urlError(_ code: Int) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code)
+    }
+
+    private static let transientCodes = [
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorCannotFindHost,
+        NSURLErrorDNSLookupFailed
+    ]
+
+    func test_timeout_retryableUnderEveryPolicy() {
+        let timeout = urlError(NSURLErrorTimedOut)
+        XCTAssertTrue(NetworkRetryRules.isTransientTransportFailure(timeout, policy: .timeoutOnly))
+        XCTAssertTrue(NetworkRetryRules.isTransientTransportFailure(timeout, policy: .transient))
+        XCTAssertTrue(NetworkRetryRules.isTransientTransportFailure(timeout, policy: .transientIncludingOffline))
+    }
+
+    func test_transientCodes_excludedByTimeoutOnlyPolicy() {
+        for code in Self.transientCodes {
+            XCTAssertFalse(
+                NetworkRetryRules.isTransientTransportFailure(urlError(code), policy: .timeoutOnly),
+                "expected \(code) to be terminal for the legacy path"
+            )
+            XCTAssertTrue(
+                NetworkRetryRules.isTransientTransportFailure(urlError(code), policy: .transient),
+                "expected \(code) to be retryable"
+            )
+            XCTAssertTrue(
+                NetworkRetryRules.isTransientTransportFailure(urlError(code), policy: .transientIncludingOffline),
+                "expected \(code) to be retryable"
+            )
+        }
+    }
+
+    func test_notConnectedToInternet_onlyRetryableWhenRescheduled() {
+        let offline = urlError(NSURLErrorNotConnectedToInternet)
+        XCTAssertFalse(NetworkRetryRules.isTransientTransportFailure(offline, policy: .timeoutOnly))
+        XCTAssertFalse(NetworkRetryRules.isTransientTransportFailure(offline, policy: .transient))
+        XCTAssertTrue(NetworkRetryRules.isTransientTransportFailure(offline, policy: .transientIncludingOffline))
+    }
+
+    func test_permanentURLErrors_notRetryable() {
+        let permanent = [
+            NSURLErrorCancelled,
+            NSURLErrorBadURL,
+            NSURLErrorUnsupportedURL,
+            NSURLErrorUserAuthenticationRequired,
+            NSURLErrorSecureConnectionFailed,
+            NSURLErrorServerCertificateUntrusted,
+            NSURLErrorAppTransportSecurityRequiresSecureConnection
+        ]
+        for code in permanent {
+            XCTAssertFalse(
+                NetworkRetryRules.isTransientTransportFailure(urlError(code), policy: .transientIncludingOffline),
+                "expected \(code) to be permanent"
+            )
+        }
+    }
+
+    func test_otherErrorDomains_notRetryable() {
+        // A matching numeric code in another domain means something else entirely.
+        let impostor = NSError(domain: NSCocoaErrorDomain, code: NSURLErrorTimedOut)
+        XCTAssertFalse(NetworkRetryRules.isTransientTransportFailure(impostor, policy: .transientIncludingOffline))
+        XCTAssertFalse(
+            NetworkRetryRules.isTransientTransportFailure(
+                TxnInitService.TxnInitError.missingResponseData,
+                policy: .transientIncludingOffline
+            )
+        )
+    }
+}

--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkingHelper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkingHelper.swift
@@ -69,6 +69,53 @@ class TestNetworkingHelper: XCTestCase {
         XCTAssertFalse(NetworkingHelper.isRetryableStatusCode(999)) // Unhandled code
     }
 
+    // The legacy post/download path retries in place almost immediately, so it comes back for a
+    // timeout and the retryable status codes only. Everything below pins that policy.
+    private func urlError(_ code: Int) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code)
+    }
+
+    func test_retriableResponse_timeoutAndRetryableStatusCodes() {
+        XCTAssertTrue(NetworkingHelper.retriableResponse(error: urlError(NSURLErrorTimedOut), code: nil))
+        XCTAssertTrue(NetworkingHelper.retriableResponse(error: urlError(NSURLErrorCancelled), code: 500))
+        XCTAssertTrue(NetworkingHelper.retriableResponse(error: urlError(NSURLErrorCancelled), code: 502))
+        XCTAssertTrue(NetworkingHelper.retriableResponse(error: urlError(NSURLErrorCancelled), code: 503))
+    }
+
+    func test_retriableResponse_gatewayTimeoutIsNotRetried() {
+        // 504 is retryable for init/offers/events but has never been part of this path's set.
+        XCTAssertFalse(NetworkingHelper.retriableResponse(error: urlError(NSURLErrorCancelled), code: 504))
+    }
+
+    func test_retriableResponse_otherTransportFailuresAreTerminal() {
+        let terminal = [
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorCannotFindHost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorResourceUnavailable,
+            NSURLErrorCancelled,
+            NSURLErrorBadURL
+        ]
+        for code in terminal {
+            XCTAssertFalse(
+                NetworkingHelper.retriableResponse(error: urlError(code), code: 400),
+                "expected \(code) to be terminal on the legacy path"
+            )
+        }
+    }
+
+    func test_retriableResponse_ignoresMatchingCodesFromOtherDomains() {
+        // -1001 only means "timed out" inside NSURLErrorDomain; elsewhere it means something else.
+        let impostor = NSError(domain: NSCocoaErrorDomain, code: NSURLErrorTimedOut)
+        XCTAssertFalse(NetworkingHelper.retriableResponse(error: impostor, code: nil))
+        XCTAssertTrue(
+            NetworkingHelper.retriableResponse(error: impostor, code: 500),
+            "a retryable status code still stands on its own"
+        )
+    }
+
     func test_common_header_defaults() throws {
         let headers = NetworkingHelper.getCommonHeaders([:])
 


### PR DESCRIPTION
> **Stacked on #285.** The base of this PR is `fix/rokt-init-retry`, so the diff shown here is only the refactor. Merge #285 first; this PR's base will then retarget to `main` automatically.

## Background

Reviewing #285 turned up that the `NSURLError` allowlist deciding "is this transport failure worth retrying" had been copy-pasted six times: `TxnInitService`, `OffersService`, `TxnEventService`, `ForwardPaymentRetryRules`, the new init recovery path, and the legacy `NetworkingHelper.retriableResponse`.

The copies had already drifted. `NSURLErrorNotConnectedToInternet` was in some and not others — half deliberately (an in-request retry loop shouldn't spend its attempts while the radio is down) and half by accident. Nothing in the code distinguished the two, so the next person to touch any copy had no way to tell which it was.

## What Has Changed

- New `NetworkRetryRules.isTransientTransportFailure(_:policy:)`, the single place that classifies a URL-layer failure.
- The offline difference becomes an explicit policy instead of a difference between copies:
  - `timeoutOnly` — the legacy post/download path, which retries in place almost immediately
  - `transient` — the in-request loops in `TxnInitService` / `OffersService`, which fail fast while offline
  - `transientIncludingOffline` — persisted event batches, forward payment, and scheduled init recovery, which come back later and so are worth retrying offline
- All six call sites delegate. Each collapses from a 14-line switch to one line, keeping its local comment explaining *why* it picked that policy.
- **Status-code policy deliberately stays with each caller.** They genuinely disagree — `[500, 502, 503]` vs `[500, 502, 503, 504]` vs 5xx plus 408 and 429 — and unifying them would be a behaviour change smuggled into a refactor.

Two deliberate changes on the legacy path, called out because they are not pure moves:

- **`extraErrorCheck` is deleted.** No caller ever passed `true`, so its six-code branch was unreachable. `NSURLErrorResourceUnavailable` appeared only there, and is dropped rather than migrated — folding it into the live transient set would silently start retrying it at five call sites to honour a branch that never executed.
- **`retriableResponse` now requires `NSURLErrorDomain`** before matching a code, where it previously compared `error._code` from any domain. The errors reaching it are URLSession failures and JSON serialisation failures (positive Cocoa codes), so nothing realistic flips, but it is a behaviour change rather than a move.

## How Has This Been Tested

Full suite: **714 tests, 0 failures** (2 skipped), `xcodebuild test -scheme Rokt-Widget` on iPhone 17 Pro sim. `trunk check` clean.

The refactor is load-bearing on tests that already existed — every call site had one pinning its offline behaviour, and all pass unchanged:

| Call site | Policy | Pre-existing test |
|---|---|---|
| `TxnInitService` | `transient` | `TestTxnInitService` — offline fails fast |
| `OffersService` | `transient` | `TestOffersService` — timeout retries |
| `TxnEventService` | `transientIncludingOffline` | `TestTxnEventService` — offline retries |
| `ForwardPaymentRetryRules` | `transientIncludingOffline` | `TestForwardPaymentRetryRules` |
| init recovery | `transientIncludingOffline` | `TestInitRecovery` |
| `NetworkingHelper` | `timeoutOnly` | none — this was the gap |

New tests:

- `TestNetworkRetryRules` (5) — every policy against the transient set, the offline case, the permanent URL errors (cancelled, bad URL, TLS/ATS, untrusted cert), and foreign error domains.
- `TestNetworkingHelper` (4) — the first direct tests for `retriableResponse`, which had none. Pins the timeout-only policy, 504 staying outside this path's status set, the dropped codes as deliberately terminal, and a `-1001` from another domain no longer counting while a retryable status code still stands on its own.

## Notes

The payoff beyond tidiness: "should font downloads retry DNS failures?" is now a one-word diff (`.timeoutOnly` → `.transient`) with a test to change alongside it, rather than flipping a dead boolean nobody understood. I left it as `timeoutOnly` — widening it touches the font download path and deserves its own change.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)