### PR TITLE
test: cover the init recovery guards and the performPost retry branch

### DIFF
--- a/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkingHelper.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/TestNetworkingHelper.swift
@@ -116,6 +116,53 @@ class TestNetworkingHelper: XCTestCase {
         )
     }
 
+    // performPost's happy path is covered indirectly through forwardPayment; these drive the
+    // retry branch itself, which decides whether the recursive call happens at all.
+    private func runPerformPost(statusCode: Int, onRequest: @escaping () -> Void) -> Int? {
+        let expectation = expectation(description: "performPost completes")
+        let originalClient = NetworkingHelper.shared.httpClient
+        defer {
+            NetworkingHelper.shared.httpClient = originalClient
+            Mocker.removeAll()
+        }
+
+        let url = URL(string: "https://apps.stage.rokt.com/rokt-mobile/test/perform-post")!
+        var mock = Mock(url: url, dataType: .json, statusCode: statusCode, data: [.post: Data("{}".utf8)])
+        mock.onRequest = { _, _ in onRequest() }
+        mock.register()
+        NetworkingHelper.shared.httpClient = makeMockHTTPClient()
+
+        var failureStatusCode: Int?
+        NetworkingHelper.performPost(
+            url: url.absoluteString,
+            body: [:],
+            success: { _, _, _ in XCTFail("Expected \(statusCode) to be reported as a failure") },
+            failure: { _, code, _ in
+                failureStatusCode = code
+                expectation.fulfill()
+            }
+        )
+
+        waitForExpectations(timeout: 10.0)
+        return failureStatusCode
+    }
+
+    func test_performPost_retriesRetryableStatusUntilAttemptsAreExhausted() {
+        var requestCount = 0
+        let statusCode = runPerformPost(statusCode: 500) { requestCount += 1 }
+
+        XCTAssertEqual(statusCode, 500)
+        XCTAssertEqual(requestCount, maxRetries + 1, "initial attempt plus \(maxRetries) retries")
+    }
+
+    func test_performPost_doesNotRetryNonRetryableStatus() {
+        var requestCount = 0
+        let statusCode = runPerformPost(statusCode: 400) { requestCount += 1 }
+
+        XCTAssertEqual(statusCode, 400)
+        XCTAssertEqual(requestCount, 1, "a 400 fails the same way every time")
+    }
+
     func test_common_header_defaults() throws {
         let headers = NetworkingHelper.getCommonHeaders([:])
 

--- a/Tests/Rokt_WidgetTests/TestInitRecovery.swift
+++ b/Tests/Rokt_WidgetTests/TestInitRecovery.swift
@@ -118,6 +118,48 @@ final class TestInitRecovery: XCTestCase {
         XCTAssertEqual(stub.requestCount, 6)
     }
 
+    // The guards inside the scheduled block only matter while an attempt is in flight, which the
+    // default immediate scheduler can never produce. These two hold the attempt instead of running
+    // it, change the state underneath it, and only then let it go.
+    func test_initRecovery_supersededAttemptDoesNotReinitialise() {
+        var pending: [() -> Void] = []
+        impl.initRecoveryScheduler = { _, work in pending.append(work) }
+        stub.results = [.status(429), .status(400)]
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+        settle()
+        XCTAssertEqual(stub.requestCount, 1)
+        XCTAssertEqual(pending.count, 1, "a 429 schedules a recovery")
+
+        // A fresh init supersedes the held attempt, and fails permanently so nothing new is queued.
+        impl.initWith(roktTagId: "tag-2", mParticleKitDetails: nil)
+        settle()
+        XCTAssertEqual(stub.requestCount, 2)
+        XCTAssertEqual(pending.count, 1, "a 400 must not schedule a recovery")
+
+        pending.forEach { $0() }
+        settle()
+        XCTAssertEqual(stub.requestCount, 2, "the superseded generation must not re-init")
+        XCTAssertFalse(impl.isInitialized)
+    }
+
+    func test_initRecovery_scheduledAttemptIsSkippedOnceInitHasSucceeded() {
+        var pending: [() -> Void] = []
+        impl.initRecoveryScheduler = { _, work in pending.append(work) }
+        stub.results = [.status(503)]
+
+        impl.initWith(roktTagId: "tag-1", mParticleKitDetails: nil)
+        settle()
+        XCTAssertEqual(stub.requestCount, 1)
+        XCTAssertEqual(pending.count, 1)
+
+        // Init has since succeeded by another route, so the held attempt is redundant.
+        impl.isInitialized = true
+        pending.forEach { $0() }
+        settle()
+        XCTAssertEqual(stub.requestCount, 1, "a recovery must not re-init once init has succeeded")
+    }
+
     private static func urlError(_ code: Int) -> NSError {
         NSError(domain: NSURLErrorDomain, code: code)
     }


### PR DESCRIPTION
> **Stacked on #286** (which is stacked on #285). Base is `refactor/centralize-network-retry-rules`, so the diff here is the tests alone. **No source changes** — `Tests/` only.

## Background

Reviewing the stack turned up three branches that no test could fail on. They were all reachable, all load-bearing, and all invisible to the suite:

- The `initGeneration == generation` guard inside the scheduled recovery block.
- The `!isInitialized` guard beside it.
- The retry branch in `NetworkingHelper.performPost` that decides whether the recursive call happens at all.

The two guards only matter while a recovery attempt is in flight. Every existing test set `initRecoveryScheduler` to run its work immediately, so no test ever had an attempt pending across a state change — **both guards could be deleted with the full suite still green.**

`performPost`'s happy path is covered indirectly through `forwardPayment`, but nothing ever returned a retryable status to it, so the retry branch itself was never taken.

## What Has Changed

Tests only.

**`TestInitRecovery`** — two tests that hold the scheduled attempt instead of running it, change the state underneath it, then release it:

```swift
var pending: [() -> Void] = []
impl.initRecoveryScheduler = { _, work in pending.append(work) }
```

- `supersededAttemptDoesNotReinitialise` — holds a 429's recovery, supersedes it with a fresh `initWith` that fails 400 (so `isInitialized` stays false and only the generation guard can stop it), then releases the stale closure and asserts no further request. Without the guard, a superseded recovery re-inits with the *previous* tag id.
- `scheduledAttemptIsSkippedOnceInitHasSucceeded` — holds a 503's recovery, lets init succeed, then releases. Without the guard, a redundant init request fires and every global subscriber gets a duplicate `InitComplete(true)`.

**`TestNetworkingHelper`** — the retry branch in both directions: a 500 must be attempted `maxRetries + 1` times before failing, a 400 exactly once. The shared helper restores `NetworkingHelper.shared.httpClient` and calls `Mocker.removeAll()` in `defer`.

## How Has This Been Tested

Full suite: **723 tests, 0 failures** (2 skipped), `xcodebuild test -scheme Rokt-Widget` on iPhone 17 Pro sim. `trunk check` clean.

Passing tests prove nothing by themselves, so each guard was broken and the suite re-run to confirm the right test — and only that test — fails:

| Mutation | Result |
|---|---|
| drop `self.initGeneration == generation` | `supersededAttemptDoesNotReinitialise` fails |
| drop `!self.isInitialized` | `scheduledAttemptIsSkippedOnceInitHasSucceeded` fails |
| replace the retry condition with `if false` | `performPost_retriesRetryableStatusUntilAttemptsAreExhausted` fails |

Sources were restored after each; this PR touches `Tests/` only.

## Notes

Two gaps found in the same review and deliberately left out, both pre-existing and neither caused by this stack:

- `handleFontDownloadResponse` has no end-to-end retry test, so the `timeoutOnly` policy isn't pinned on the font download path.
- No test asserts that two global subscribers both observe the full `InitComplete(false) … (true)` sequence across a recovery — the composition of #284 and #285, though each half is covered on its own.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)