### PR TITLE
ci: Add workflow_dispatch to the Pull Request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
       - workstation/*
+  # Manual runs against an arbitrary ref, for measuring test flakiness: dispatch the
+  # same ref repeatedly and count how many runs come back green. Note that the
+  # concurrency group below keys on `github.ref`, so dispatches of one ref supersede
+  # each other — run them one at a time.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the Pull Request workflow.

## Why

Measuring how flaky a test is needs the same ref run many times over. GitHub only exposes a `workflow_dispatch` trigger once it is present on the default branch, so this has to land on its own, ahead of the UI-test flakiness fix it is intended to verify.

## Notes

- No inputs — a manual run does exactly what a `pull_request` run does.
- The existing `concurrency` group keys on `github.ref` with `cancel-in-progress: true`, so dispatches of the same ref supersede one another. Manual runs therefore need to be fired one at a time; called out in a comment next to the trigger.
- `pr-notify` is already gated on `github.event_name == 'pull_request'`, so a manual run will not post to GChat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)