### PR TITLE
fix: create the real-time event store directory before writing to it

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -166,6 +166,7 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         do {
             let encoder = JSONEncoder()
             let data = try encoder.encode(value)
+            try createContainingDirectoryIfNeeded(of: url)
             // Encrypt at rest with iOS Data Protection. Use `.completeFileProtectionUntilFirstUserAuthentication`
             // (not `.completeFileProtection`): events are persisted during normal app runtime, including while
             // backgrounded and the device is locked. A stricter class would make those writes fail and drop
@@ -174,6 +175,17 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         } catch {
             RoktLogger.shared.error("Failed to save real-time events", error: error)
         }
+    }
+
+    // Every other store either writes to a directory it creates (the font directory, the
+    // experience cache) or to the root of Caches, which always exists. This one writes into the
+    // host app's Documents, and saving is best-effort, so a container without that directory -
+    // an app extension, or a host app whose "clear data" path removed it - loses every event for
+    // the rest of the process with nothing but a log line to show for it.
+    private func createContainingDirectoryIfNeeded(of url: URL) throws {
+        let directory = url.deletingLastPathComponent()
+        guard !FileManager.default.fileExists(atPath: directory.path) else { return }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 
     private func load<T: Codable>(from url: URL) -> [T] {

--- a/Tests/Rokt_WidgetTests/Extension/XCTestCase+Extension.swift
+++ b/Tests/Rokt_WidgetTests/Extension/XCTestCase+Extension.swift
@@ -17,6 +17,23 @@ extension XCTestCase {
     }
 }
 
+// MARK: - Document Directory
+
+extension XCTestCase {
+    /// Creates the document directory a test is about to read or write through.
+    ///
+    /// These tests run without a host app, so `NSHomeDirectory()` is the simulator's device data
+    /// root rather than an app container. `Documents` is created there during boot rather than at
+    /// install, so a suite that reaches it first finds no directory and every write into it fails -
+    /// including the ones `-retry-tests-on-failure` retries, since nothing creates it in between.
+    func ensureDocumentDirectoryExists() {
+        guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return
+        }
+        try? FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+    }
+}
+
 // MARK: - Memory Leak Tracking
 
 extension XCTestCase {

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/FontRepositoryTests.swift
@@ -16,6 +16,8 @@ class FontRepositoryTests: XCTestCase {
             self?.diagnosticsReceived.append(model.code)
         }
 
+        ensureDocumentDirectoryExists()
+
         FontRepositoryTests.prepareTestFiles()
 
         FontRepositoryTests.deleteAllTestFiles()

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/JSONBackingStoreTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/JSONBackingStoreTests.swift
@@ -10,6 +10,8 @@ final class JSONBackingStoreTests: XCTestCase {
 
         sut = JSONBackingStore()
 
+        ensureDocumentDirectoryExists()
+
         XCTestCase.deleteJSONFileWith(name: testFileName)
     }
 

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
@@ -92,6 +92,41 @@ class RealTimeEventStoreFileTest: XCTestCase {
         )
     }
 
+    // MARK: - Storage directory
+
+    func test_markAsTriggered_whenStorageDirectoryDoesNotExist_stillPersistsEvents() {
+        let markExpectation = expectation(description: "Events marked and processed after debounce")
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("absent-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+
+        let store = RealTimeEventStoreFile(
+            triggeredEventsFilePath: directory.appendingPathComponent("triggered_events.json"),
+            untriggeredEventsFilePath: directory.appendingPathComponent("untriggered_events.json")
+        )
+        store.addUntriggeredEvents([
+            createRoktUXRealTimeEventResponse(
+                triggerGuid: guid1,
+                triggerEvent: signalImpressionRawValue,
+                eventType: finalType1,
+                payload: payload1
+            )
+        ])
+        store.markAsTriggered([
+            createRoktEventRequest(
+                parentGuid: guid1,
+                eventType: RoktUXEventType(rawValue: signalImpressionRawValue)!
+            )
+        ])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + expectationTimeout, execute: {
+            XCTAssertEqual(store.getTriggeredEvents().count, 1)
+            markExpectation.fulfill()
+        })
+        wait(for: [markExpectation], timeout: expectationTimeout + 0.5)
+    }
+
     // MARK: - Tests for addUntriggeredEvents & markAsTriggered (indirectly testing getTriggeredEvents)
 
     func test_markAsTriggered_singleMatch_eventIsTriggered() {


### PR DESCRIPTION
## Background

`RealTimeEventStoreFile` persists triggered and untriggered real-time events into the host app's document directory, and its saves are best-effort — a failure is logged and swallowed. If that directory does not exist, every save fails, and the store silently keeps no state for the rest of the process: untriggered events never get matched to their trigger, so those events never fire, and the only trace is one log line per write.

A normal app container always has that directory, so this does not affect a typical integration. Two cases where it is genuinely absent: an app extension container, which never gets one, and a host app that clears its own documents as part of a "reset/clear data" flow.

Every other store in the SDK already handles this — the font directory is created and reused, and the experience cache writes with intermediate directories created. This one was the exception.

The same assumption made the unit tests order-dependent. The test bundle runs without a host app, so it reads and writes the simulator's device-level document directory, which is created during boot rather than at install. A suite that got there first found nothing and failed every write, including the retries `-retry-tests-on-failure` performs, because nothing creates the directory in between. That is the intermittent `FontRepositoryTests` / `JSONBackingStoreTests` failure seen on CI: 4 tests, identical on all 3 attempts, passing on an immediate rerun of the same commit.

## What Has Changed

- `RealTimeEventStoreFile` creates the containing directory if it is missing before writing. When it already exists — the normal case — nothing changes.
- `XCTestCase.ensureDocumentDirectoryExists()` added, called from `FontRepositoryTests` and `JSONBackingStoreTests` setUp, so those suites no longer depend on boot timing.

No public API change, no change to what the SDK sends or receives, and no change to where anything is stored.

## How Has This Been Tested

- New test `test_markAsTriggered_whenStorageDirectoryDoesNotExist_stillPersistsEvents` points the store at a directory that does not exist and asserts the event still round-trips. Confirmed it catches the bug: with the production change reverted it fails (`0` is not equal to `1`), and passes with it.
- Reproduced the CI flake on a freshly created simulator (device-level `Documents` confirmed absent): the same 4 failures on `main`, and 41/41 passing with this branch on an equally fresh device.
- Full suite: **711 tests, 0 failures** (2 skipped). `trunk check` clean on all 5 files.
- Podspec lint not run locally — no files added or removed, so the spec globs are unaffected; CI covers it.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)