### PR TITLE
fix: keep persisted real-time events out of the host app's documents

### DIFF
--- a/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
+++ b/Sources/Rokt_Widget/DataAccess/RealtimeEventStore.swift
@@ -52,25 +52,64 @@ class RealTimeEventStoreFile: RealTimeEventStore {
     private let debounceInterval: TimeInterval = 0.5
     private let eventProcessingQueue = DispatchQueue(label: "com.rokt.RealTimeEventManager.eventProcessingQueue")
 
+    static let storageDirectoryName = "RoktRealTimeEvents"
+    static let triggeredEventsFileName = "triggered_events.json"
+    static let untriggeredEventsFileName = "untriggered_events.json"
+
     // File paths are injectable so tests can isolate each case to its own temporary files.
-    // Production uses the document-directory defaults.
+    // Production uses the storage-directory defaults.
     init(
-        triggeredEventsFilePath: URL? = RealTimeEventStoreFile.defaultFileURL(named: "triggered_events.json"),
-        untriggeredEventsFilePath: URL? = RealTimeEventStoreFile.defaultFileURL(named: "untriggered_events.json")
+        triggeredEventsFilePath: URL? = RealTimeEventStoreFile
+            .defaultFileURL(named: RealTimeEventStoreFile.triggeredEventsFileName),
+        untriggeredEventsFilePath: URL? = RealTimeEventStoreFile
+            .defaultFileURL(named: RealTimeEventStoreFile.untriggeredEventsFileName)
     ) {
         self.triggeredEventsFilePath = triggeredEventsFilePath
         self.untriggeredEventsFilePath = untriggeredEventsFilePath
     }
 
     private static func defaultFileURL(named name: String) -> URL? {
-        guard let directory = FileManager
-            .default
-            .urls(for: .documentDirectory, in: .userDomainMask)
-            .first else {
-            RoktLogger.shared.error("Document directory unavailable - RealTimeEventStore will not persist events")
+        guard let directory = ensureStorageDirectory() else {
+            RoktLogger.shared.error("Storage directory unavailable - RealTimeEventStore will not persist events")
             return nil
         }
+
         return directory.appendingPathComponent(name)
+    }
+
+    /// Directory holding the persisted events. Application Support is durable (unlike Caches, which
+    /// the system can purge) while staying out of the host app's documents, where these files were
+    /// part of the user's backup and visible to them in apps that enable file sharing. This matches
+    /// where the font cache lives.
+    static func storageDirectoryUrl(fileManager: FileManager = .default) -> URL? {
+        guard let supportUrl = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return supportUrl.appendingPathComponent(storageDirectoryName, isDirectory: true)
+    }
+
+    static func ensureStorageDirectory(fileManager: FileManager = .default) -> URL? {
+        guard let directoryURL = storageDirectoryUrl(fileManager: fileManager) else { return nil }
+
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+                )
+            } catch {
+                return nil
+            }
+        }
+
+        // Persisted events are regenerable from the next placement; they must not inflate backups.
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var mutableURL = directoryURL
+        try? mutableURL.setResourceValues(resourceValues)
+
+        return directoryURL
     }
 
     func addUntriggeredEvents(_ events: [UntriggeredRealTimeEvent]) {
@@ -177,11 +216,9 @@ class RealTimeEventStoreFile: RealTimeEventStore {
         }
     }
 
-    // Every other store either writes to a directory it creates (the font directory, the
-    // experience cache) or to the root of Caches, which always exists. This one writes into the
-    // host app's Documents, and saving is best-effort, so a container without that directory -
-    // an app extension, or a host app whose "clear data" path removed it - loses every event for
-    // the rest of the process with nothing but a log line to show for it.
+    // The storage directory is created up front, but saving is best-effort: were the directory to
+    // go missing afterwards - removed by the host app, or never there for an injected path - every
+    // save would fail for the rest of the process with nothing but a log line to show for it.
     private func createContainingDirectoryIfNeeded(of url: URL) throws {
         let directory = url.deletingLastPathComponent()
         guard !FileManager.default.fileExists(atPath: directory.path) else { return }

--- a/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
+++ b/Tests/Rokt_WidgetTests/Shared/DataAccess/RealTimeEventStoreFileTest.swift
@@ -92,6 +92,36 @@ class RealTimeEventStoreFileTest: XCTestCase {
         )
     }
 
+    // MARK: - Storage location
+
+    func test_storageDirectory_isUnderApplicationSupportAndExcludedFromBackup() throws {
+        let directory = try XCTUnwrap(RealTimeEventStoreFile.ensureStorageDirectory())
+
+        XCTAssertEqual(directory.lastPathComponent, RealTimeEventStoreFile.storageDirectoryName)
+        XCTAssertTrue(directory.deletingLastPathComponent().path.hasSuffix("Application Support"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        let values = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        XCTAssertEqual(values.isExcludedFromBackup, true)
+    }
+
+    func test_defaultStorage_persistsEventsUnderTheStorageDirectory() throws {
+        let untriggeredFile = try XCTUnwrap(RealTimeEventStoreFile.ensureStorageDirectory())
+            .appendingPathComponent(RealTimeEventStoreFile.untriggeredEventsFileName)
+        addTeardownBlock { try? FileManager.default.removeItem(at: untriggeredFile) }
+        try? FileManager.default.removeItem(at: untriggeredFile)
+
+        RealTimeEventStoreFile().addUntriggeredEvents([
+            createRoktUXRealTimeEventResponse(
+                triggerGuid: guid1,
+                triggerEvent: signalImpressionRawValue,
+                eventType: finalType1,
+                payload: payload1
+            )
+        ])
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: untriggeredFile.path))
+    }
+
     // MARK: - Storage directory
 
     func test_markAsTriggered_whenStorageDirectoryDoesNotExist_stillPersistsEvents() {


### PR DESCRIPTION
> Stacked on #291 — base is `fix/ensure-event-store-directory`. Retarget to `main` once that merges.

## Background

`triggered_events.json` and `untriggered_events.json` were the last SDK files written into the host app's document directory. Two consequences for an integrating app:

- That directory is part of the user's device backup, so SDK bookkeeping was travelling in every backup of the app.
- In an app that enables file sharing, its contents are listed in the Files app and can be deleted by the user, so these two files appeared among the user's own documents.

The rest of the SDK already avoids this: transient replay data sits in caches, and the font cache moved to Application Support to stay out of documents and out of backups. This store was the exception.

## What Has Changed

- Persisted real-time events now live in a dedicated directory under Application Support, created with the same data protection class as before and excluded from backup.
- Application Support rather than Caches: an untriggered event waits for a user action that may not arrive for some time, and the system can purge Caches. This matches the reasoning already applied to the font directory.

No public API change, and no change to what the SDK sends or receives.

On upgrade the store starts empty — real-time events captured by an earlier version and still awaiting a trigger are not carried over, so a small number of pending events can be missed once, and the two files an earlier version wrote stay in the host app's document directory until the app clears them.

## How Has This Been Tested

- New tests cover the storage directory (under Application Support, created, excluded from backup) and the default path resolution — a store constructed with default paths writes its events under that directory.
- Full suite: **713 tests, 0 failures** (2 skipped). `trunk check` clean.
- Periphery scan not run locally (~4 min); every new symbol is referenced from production code, and CI covers it.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)