### PR TITLE
ci: Fix the remaining two UI test flake mechanisms

### DIFF
--- a/Example/Tests/NetworkMock/MockResponse.swift
+++ b/Example/Tests/NetworkMock/MockResponse.swift
@@ -53,9 +53,9 @@ var mockRecordingGeneration = 0
 // into the same capture-scoped arrays, so those late deliveries used to be recorded as
 // though they belonged to the following example — which is how `timingsRequests.count`
 // was observed as 2 in an example that made exactly one timings call. Checking the
-// generation inside the main-queue hop closes that window: a stale delivery lands after
-// the next example's `beforeEach` has bumped the generation, so it is discarded instead
-// of being counted.
+// generation inside the main-queue hop discards deliveries whose request *started* under an
+// earlier example. One a previous flow only *starts* later carries the current generation and
+// is indistinguishable from a real recording — hence installing the test VC per example too.
 //
 // The generation is bumped by `useNetworkedMockEnvironment`, i.e. alongside the
 // `Mocker.removeAll()` that tears the previous example's stubs down. That keeps the two

--- a/Example/Tests/QuickSpec+Extension.swift
+++ b/Example/Tests/QuickSpec+Extension.swift
@@ -14,7 +14,9 @@ import Foundation
 ///
 /// `toEventually` returns as soon as its condition holds, so a generous budget costs nothing on a
 /// healthy run. It only changes the outcome of a run that would otherwise have failed for want of a
-/// second — at the price of a genuinely broken assertion taking longer to report.
+/// second — at the price of a genuinely broken assertion taking longer to report. Examples chain two
+/// of these, so keep it under half the `ui-test` job's `-default-test-execution-time-allowance`, or a
+/// doubly-failing one is killed by the per-test timeout instead of naming the assertion.
 let kPipelineWaitTimeout: NimbleTimeInterval = .seconds(30)
 
 // MARK: Event expectations

--- a/Example/Tests/RoktExperienceCacheExecuteTests.swift
+++ b/Example/Tests/RoktExperienceCacheExecuteTests.swift
@@ -69,6 +69,40 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
         )
     }
 
+    /// Waits for an `onPluginViewStateChange` update to reach the plugin view state cache file.
+    ///
+    /// The SDK writes it as an async barrier while the next execute reads synchronously, so waiting a
+    /// fixed interval instead lets a loaded machine read first — and a read that already returned
+    /// stale data is a hard failure, not something a wider budget can rescue.
+    ///
+    /// Reads unmapped rather than via `getCachedPluginViewStateFileData`, which uses `.mappedIfSafe`:
+    /// polling a mapped file while the writer replaces it faults the test host, whereas an unmapped
+    /// half-written read just fails to decode and is retried.
+    func waitForCachedPluginViewState(_ expected: RoktPluginViewState,
+                                      cacheProperties: LayoutPageCacheProperties?,
+                                      file: StaticString = #filePath,
+                                      line: UInt = #line) {
+        guard let cacheProperties else {
+            return XCTFail("cacheProperties should not be nil", file: file, line: line)
+        }
+
+        let fileName = ExperienceCacheUtils.getPluginViewStateFileName(
+            pluginId: expected.pluginId,
+            viewName: cacheProperties.viewName,
+            attributes: cacheProperties.experienceCacheAttributes
+        )
+        guard let fileUrl = ExperienceCacheManager.getFileUrl(name: fileName) else {
+            return XCTFail("plugin view state cache file url should not be nil", file: file, line: line)
+        }
+
+        // Not `kPipelineWaitTimeout`: this awaits one local file write, not a whole pipeline.
+        expect(file: "\(file)", line: line) { () -> RoktPluginViewState? in
+            guard let data = try? Data(contentsOf: fileUrl, options: []) else { return nil }
+            return ExperienceCacheUtils.getValidPluginViewState(pluginId: expected.pluginId, data: data)
+        }
+        .toEventually(equal(expected), timeout: .seconds(10), description: "cached plugin view state")
+    }
+
     override func spec() {
         describe("Rokt modal controller") {
 
@@ -364,11 +398,11 @@ class RoktExperienceCacheExecuteTests: QuickSpec {
                     mockImplementation.executingLayoutPage?.cacheProperties?.onPluginViewStateChange?(pluginViewStateUpdates)
 
                     // Wait for the async barrier write triggered by onPluginViewStateChange to
-                    // complete before the second execute reads from disk. Without this, the
-                    // ConcurrentQueueFileStorageDecorator.write barrier may not have flushed yet
-                    // when getCachedPluginViewStateFileData does its synchronous Data(contentsOf:) read.
-                    let expWrite = self.expectation(description: "Await plugin view state write")
-                    _ = XCTWaiter.wait(for: [expWrite], timeout: 2)
+                    // reach disk before the second execute reads it back.
+                    self.waitForCachedPluginViewState(
+                        pluginViewStateUpdates,
+                        cacheProperties: mockImplementation.executingLayoutPage?.cacheProperties
+                    )
 
                     // Second execute with same config
                     self.executeRokt(config: config)

--- a/Example/Tests/ValidLayoutBottomSheetTests.swift
+++ b/Example/Tests/ValidLayoutBottomSheetTests.swift
@@ -84,8 +84,8 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
                     timingsRequests = []
                     partnerEvents = []
                     testVC = TestViewController()
-
-                    testVC.installInTestWindow()
+                    // Installed per example, not here: installing drives a placement, and
+                    // one started here outlived the examples that never waited for it.
                 }
 
                 afterEach {
@@ -122,6 +122,8 @@ final class ValidLayoutBottomSheetTests: QuickSpec {
                 }
 
                 it("layouts loaded successfully with events") {
+                    testVC.installInTestWindow()
+
                     expect(UIApplication.topViewController()).toEventually(
                         beAnInstanceOf(RoktUXSwiftUIViewController.self),
                         timeout: .seconds(19)

--- a/Example/Tests/ValidLayoutEmbedded.swift
+++ b/Example/Tests/ValidLayoutEmbedded.swift
@@ -105,8 +105,8 @@ final class ValidLayoutEmbedded: QuickSpec {
                     partnerEventsInfo = [:]
                     testVC = TestViewController()
                     testVC.pageInitAttr = invalidPageInitDateEpoch
-
-                    testVC.installInTestWindow()
+                    // Installed per example, not here: installing drives a placement, and
+                    // one started here outlived the examples that never waited for it.
                 }
 
                 afterEach {
@@ -144,6 +144,8 @@ final class ValidLayoutEmbedded: QuickSpec {
                 }
 
                 it("layouts loaded successfully with events") {
+                    testVC.installInTestWindow()
+
                     expect(testVC.embeddedLocation1?.roktEmbeddedSwiftUIView?.isHidden).toEventually(
                         beFalse(),
                         timeout: .seconds(9)
@@ -194,6 +196,8 @@ final class ValidLayoutEmbedded: QuickSpec {
                 }
 
                 it("layouts loaded successfully with timings contains invalid pageInit") {
+                    testVC.installInTestWindow()
+
                     expect(testVC.embeddedLocation1?.roktEmbeddedSwiftUIView?.isHidden).toEventually(
                         beFalse(),
                         timeout: .seconds(9)
@@ -282,8 +286,8 @@ final class ValidLayoutEmbedded: QuickSpec {
                     events = []
                     errors = []
                     testVC = TestViewController()
-
-                    testVC.installInTestWindow()
+                    // Installed per example, not here: installing drives a placement, and
+                    // one started here outlived the examples that never waited for it.
                 }
 
                 afterEach {
@@ -309,6 +313,8 @@ final class ValidLayoutEmbedded: QuickSpec {
                 }
 
                 it("layouts loaded successfully with events") {
+                    testVC.installInTestWindow()
+
                     expect(testVC.embeddedLocation4?.roktEmbeddedSwiftUIView?.isHidden).toEventually(
                         beFalse(),
                         timeout: .seconds(9)

--- a/Example/Tests/ValidLayoutGroupedTests.swift
+++ b/Example/Tests/ValidLayoutGroupedTests.swift
@@ -46,8 +46,8 @@ final class ValidLayoutGroupedTests: QuickSpec {
                     events = []
                     errors = []
                     testVC = TestViewController()
-
-                    testVC.installInTestWindow()
+                    // Installed per example, not here: installing drives a placement, and
+                    // one started here outlived the examples that never waited for it.
                 }
 
                 afterEach {
@@ -73,6 +73,8 @@ final class ValidLayoutGroupedTests: QuickSpec {
                 }
 
                 it("layouts loaded successfully with events") {
+                    testVC.installInTestWindow()
+
                     expect(UIApplication.topViewController()).toEventually(
                         beAnInstanceOf(RoktUXSwiftUIViewController.self),
                         timeout: .seconds(19)

--- a/Example/Tests/ValidLayoutOverlayTests.swift
+++ b/Example/Tests/ValidLayoutOverlayTests.swift
@@ -104,8 +104,8 @@ final class ValidLayoutOverlayTests: QuickSpec {
                     partnerEventsInfo = [:]
                     testVC = TestViewController()
                     testVC.pageInitAttr = timingsDateEpoch
-
-                    testVC.installInTestWindow()
+                    // Installed per example, not here: installing drives a placement, and
+                    // one started here outlived the examples that never waited for it.
                 }
 
                 afterEach {
@@ -142,6 +142,8 @@ final class ValidLayoutOverlayTests: QuickSpec {
                 }
 
                 it("layouts loaded successfully with events") {
+                    testVC.installInTestWindow()
+
                     expect(UIApplication.topViewController()).toEventually(beAnInstanceOf(RoktUXSwiftUIViewController.self),
                                                                            timeout: .seconds(19))
                     // check callbacks
@@ -185,6 +187,8 @@ final class ValidLayoutOverlayTests: QuickSpec {
                 }
 
                 it("layouts loaded successfully with timings contains pageInit") {
+                    testVC.installInTestWindow()
+
                     expect(UIApplication.topViewController()).toEventually(beAnInstanceOf(RoktUXSwiftUIViewController.self),
                                                                            timeout: .seconds(19))
 
@@ -234,6 +238,8 @@ final class ValidLayoutOverlayTests: QuickSpec {
                 // user dismisses Safari, otherwise closing the placement would tear down the Safari
                 // controller it presents and dismiss it immediately.
                 it("internal link defers completion until Safari is dismissed") {
+                    testVC.installInTestWindow()
+
                     expect(UIApplication.topViewController())
                         .toEventually(beAnInstanceOf(RoktUXSwiftUIViewController.self), timeout: .seconds(19))
                     guard let overlay = UIApplication.topViewController() else {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Follow-up to #290. That PR fixed the first of **three** distinct mechanisms behind the flaky
`UI Tests` job and listed the rest as known limitations. This PR closes the remaining two.

Of the job's red runs over the measured period, only 13 were real test-assertion failures — the
rest were simulator-unavailable infra, compile errors on WIP branches, and dependency fetches.
Those 13 split three ways:

| # | Mechanism | Share of the 13 | Status |
|---|-----------|-----------------|--------|
| 1 | Per-assertion `toEventually` budgets, so the first assertion absorbed the whole pipeline's latency | 9 | Fixed in #290 |
| 2 | A placement started in a shared `beforeEach` outliving the example that started it | 2 | **Fixed here** |
| 3 | A fixed 2s sleep standing in for an async cache write | 1–2 | **Fixed here** |

This PR is purely additive on top of #290 — nothing from it is reverted, and
`kPipelineWaitTimeout` keeps its 30s value at all 23 sites.

### Mechanism 2 — placements outliving their example

The four `ValidLayout*` specs called `testVC.installInTestWindow()` from a `beforeEach` shared
by every example in the context. Installing the view controller drives a *complete* placement:
init → offers → render → events → timings.

Two of the examples in those contexts don't assert on a placement, so nothing ever waited for
that flow. It was therefore still in flight when the next example's `beforeEach` reset the
capture arrays and armed its stubs — and the in-flight flow's timings POST landed in the *next*
example's arrays. That is how `expect(timingsRequests.count).to(equal(1))` was observed as `2`
in an example that makes exactly one timings call.

#290's recording-generation guard doesn't cover this. It discards a delivery whose request
*started* under an earlier example, but a request that a previous flow only *starts* after the
next example armed its stubs resolves against the new mock and carries the current generation —
indistinguishable from a legitimate recording. The only reliable fix is to stop the overlap
existing: each example that exercises a placement now installs the view controller itself.

### Mechanism 3 — a fixed sleep in place of a write barrier

`RoktExperienceCacheExecuteTests / uses cached plugin view states` drives an
`onPluginViewStateChange` update, waited a fixed 2s, then ran a second execute that reads the
plugin view state back from disk. The SDK performs that write as an async barrier on its own
queue while the read is synchronous, so on a loaded machine the read wins and sees stale state.

This is the one mechanism a wait budget cannot cover. `kPipelineWaitTimeout` buys patience, but
**a read that has already returned the wrong value is a hard failure, not a slow success** — it
cannot be rescued by waiting longer. The 2s was also pure latency on every healthy run.

Replaced with a poll on the cache file itself, so the test proceeds the moment the write is
visible and no sooner. No SDK change was needed: `ExperienceCacheManager.getFileUrl(name:)` and
`ExperienceCacheUtils.getPluginViewStateFileName` are both `internal`, so the test derives the
cache path itself through `@testable import`.

One trap worth recording for anyone touching this: do **not** poll
`ExperienceCacheManager.getCachedPluginViewStateFileData` to do it. That reads via
`Data(contentsOf:options: .mappedIfSafe)`, and polling a memory-mapped file while the writer
replaces it invalidates the mapped pages and takes the test host down with it ("Early unexpected
exit … Lost connection to testmanagerd"). The helper reads with mapping explicitly disabled,
where a half-written file simply fails to decode and the poll tries again.

## What Has Changed

**Test-only. No library sources are touched and there is no change in SDK behaviour.**

1. **`ValidLayout{BottomSheet,Embedded,Grouped,Overlay}Tests`** — `installInTestWindow()` moves
   out of the shared `beforeEach` into each of the 8 examples that actually exercise a placement.
   Mechanism 2.
2. **`RoktExperienceCacheExecuteTests`** — the fixed 2s `XCTWaiter` wait becomes
   `waitForCachedPluginViewState(_:cacheProperties:)`, which polls the plugin view state cache
   file (unmapped read, decode-or-retry) until it reflects the update. Mechanism 3.
3. **`MockResponse.swift`** — corrects the `recordingForCurrentGeneration` comment. As merged it
   claims the generation check "closes that window"; it closes part of it, and the comment now
   says which part and what closes the rest.
4. **`QuickSpec+Extension.swift`** — documents a ceiling on `kPipelineWaitTimeout`. The value is
   unchanged; see the note below for why the ceiling is worth writing down.

### One thing to be aware of about `kPipelineWaitTimeout`

Every example in `RoktExperienceCacheExecuteTests` chains **exactly two** `toEventually` waits,
and the `ui-test` job runs with `-default-test-execution-time-allowance 60`. At 30s per wait
that is exactly the allowance, so an example that fails *both* waits is killed by the per-test
timeout and reports as a truncated run rather than naming the assertion that failed.

That is a diagnostic cost on already-failing runs only — it is not a flake risk, and it does not
affect passing runs at all, since `toEventually` returns as soon as its condition holds. The
value is therefore left at 30s and the constraint documented instead. Dropping it to
`.seconds(20)` is a one-word change if we'd rather have the headroom.

Also worth noting for reviewers: that spec has no `toNever`/`toAlways`, so no assertion there
depends on a wait actually elapsing. Wide budgets are semantically free.

Deliberately unchanged:

- The `UI Tests` job still has no `-retry-tests-on-failure`. The comment explaining why is still
  correct, and fixing mechanisms 1–3 reduces the need for it.
- `APIErrorTests` and `InvalidWidgetTests` still install from a `beforeEach`. Each of those
  contexts has a single example, so there is no following example for a late flow to contaminate.

## How Has This Been Tested

- **Full local suite: `Executed 40 tests, with 0 failures`, `** TEST SUCCEEDED **`.**
- **`RoktExperienceCacheExecuteTests` soaked repeatedly** — 12 tests per run, 0 failures, no host
  crashes. This spec is where an earlier attempt at mechanism 3 brought the test host down, so it
  was soaked specifically rather than run once.
- `uses cached plugin view states` went from 19.1s to 17.0s, i.e. the poll returns essentially
  immediately and the removed 2s was pure waiting. That also confirms the helper derives the same
  cache key the SDK writes under — a mismatched key would have timed out rather than sped up.
- `trunk check` clean on all changed files.

Note on what a green CI run does and does not prove here: at the ~12% per-attempt baseline these
mechanisms produced, a single green `UI Tests` job is weak evidence. The argument for this PR is
structural — after it, no example can inherit another's in-flight placement, and no assertion
depends on a write having completed within a guessed interval. Worth classifying any subsequent
red rather than re-running it blind: an infra red is not a regression of this work.

## Notes

`it("1. layout is configured")` waits 9 seconds and then asserts that `Rokt.shared` is a `Rokt`,
which is always true. It appears in five contexts, ~47s of job time. Before this PR it at least
had the side effect of driving the shared `beforeEach`'s placement; now it does nothing at all.
Deleting it changes test intent, so it's left for a separate decision rather than folded in here.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
