### PR TITLE
fix: synchronise access to the shared HTTP client session

### DIFF
--- a/Sources/Rokt_Widget/Networking/HTTPClient/RoktHTTPClient.swift
+++ b/Sources/Rokt_Widget/Networking/HTTPClient/RoktHTTPClient.swift
@@ -69,6 +69,8 @@ internal final class RoktHTTPClient: HTTPClientAdapter {
     private let emptyDataStatusCodes: Set<Int> = [204, 205]
 
     private(set) var session: URLSession = .shared
+    // Serialises `session`, which `updateTimeout` reassigns on the request hot path.
+    private let sessionLock = NSLock()
     private(set) var downloadSession: URLSession = .shared
     private(set) var encoders: [RoktHTTPParameterEncoder] = []
 
@@ -117,12 +119,23 @@ internal final class RoktHTTPClient: HTTPClientAdapter {
     ///
     /// - Parameter timeout: seconds.
     func updateTimeout(timeout: Double) {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+
         let currentConfiguration = session.configuration
 
         currentConfiguration.timeoutIntervalForRequest = timeout
         currentConfiguration.timeoutIntervalForResource = timeout
 
         self.session = URLSession(configuration: currentConfiguration)
+    }
+
+    // Runs `body` under the lock; callers create and resume the task inside, binding it
+    // to a live session rather than a reference used after a concurrent swap.
+    private func withSession<T>(_ body: (URLSession) -> T) -> T {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+        return body(session)
     }
 
     @discardableResult
@@ -158,26 +171,26 @@ internal final class RoktHTTPClient: HTTPClientAdapter {
         }
 
         onRequestStart?()
-        let task = session.dataTask(with: request) { [weak self] (data, response, error) in
-            guard let self else { return }
+        withSession { session in
+            session.dataTask(with: request) { [weak self] (data, response, error) in
+                guard let self else { return }
 
-            let anyJSONSerialisationResult = self.serializeAsJSON(
-                data: data,
-                response: response,
-                error: error
-            )
+                let anyJSONSerialisationResult = self.serializeAsJSON(
+                    data: data,
+                    response: response,
+                    error: error
+                )
 
-            let requestResult = RoktHTTPRequestResult(
-                httpURLResponse: response as? HTTPURLResponse,
-                responseData: data,
-                responseError: error,
-                jsonSerialisedResponseData: anyJSONSerialisationResult
-            )
+                let requestResult = RoktHTTPRequestResult(
+                    httpURLResponse: response as? HTTPURLResponse,
+                    responseData: data,
+                    responseError: error,
+                    jsonSerialisedResponseData: anyJSONSerialisationResult
+                )
 
-            completionQueue.async { completionHandler?(requestResult) }
+                completionQueue.async { completionHandler?(requestResult) }
+            }.resume()
         }
-
-        task.resume()
 
         return request
     }

--- a/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
@@ -35,6 +35,31 @@ final class RoktHTTPClientTests: XCTestCase {
         XCTAssertEqual(sut.session.configuration.timeoutIntervalForResource, 123, accuracy: 0.1)
     }
 
+    // MARK: - Concurrency: the shared session must not be raced
+
+    func test_concurrentUpdateTimeoutAndRequests_doNotRaceTheSharedSession() {
+        // Regression guard for the shared-session use-after-free: updateTimeout reassigns
+        // `session` while startRequestWith reads it. Interleaving writes and reads across
+        // threads must leave every request completing. ThreadSanitizer is the real detector
+        // of the race; without it this still catches a fix that deadlocks or drops completions.
+        RoktHTTPUrlProtocolStub.stub(data: anyData(), response: anyHTTPURLResponse(), error: nil)
+        let sut = makeSUT()
+
+        let requests = 200
+        let exp = expectation(description: "all requests complete")
+        exp.expectedFulfillmentCount = requests
+
+        // Fixed-size independent iterations — no shared stop flag that would itself race.
+        DispatchQueue.concurrentPerform(iterations: requests) { index in
+            sut.updateTimeout(timeout: Double((index % 30) + 1))
+            sut.startRequestWith(urlAddress: anyURLString(), method: .get) { _ in
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 20.0)
+    }
+
     // MARK: - Downloads are not bound by the API client timeout
 
     func test_updateTimeout_leavesTheDownloadResourceBudgetAlone() {

--- a/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
+++ b/Tests/Rokt_WidgetTests/Shared/Networking/RoktHTTPClientTests.swift
@@ -38,10 +38,6 @@ final class RoktHTTPClientTests: XCTestCase {
     // MARK: - Concurrency: the shared session must not be raced
 
     func test_concurrentUpdateTimeoutAndRequests_doNotRaceTheSharedSession() {
-        // Regression guard for the shared-session use-after-free: updateTimeout reassigns
-        // `session` while startRequestWith reads it. Interleaving writes and reads across
-        // threads must leave every request completing. ThreadSanitizer is the real detector
-        // of the race; without it this still catches a fix that deadlocks or drops completions.
         RoktHTTPUrlProtocolStub.stub(data: anyData(), response: anyHTTPURLResponse(), error: nil)
         let sut = makeSUT()
 


### PR DESCRIPTION
## Problem

`RoktHTTPClient.session` is reassigned by `updateTimeout` while `startRequestWith`
reads it concurrently on the request path. The unsynchronised read/write
over-releases the shared `URLSession` — a use-after-free that faults inside
CFNetwork on the network queue.

## Fix

- Guard `session` with an `NSLock`.
- Add a `withSession` accessor that creates **and** resumes the data task under
  the lock, so a task always binds to a live session and no concurrent swap can
  race the read.
- Timeout behaviour is unchanged; no session invalidation is introduced (that
  would risk a request whose completion never fires).

Single-file change plus one test; `downloadSession` is assigned once and is not
part of the race.

## Verification

- New concurrency regression test interleaves `updateTimeout` with many
  concurrent `startRequestWith` calls and requires every request to complete.
  ThreadSanitizer is the reliable detector of the race itself; without it the
  test still catches a fix that deadlocks or drops completions.
- All existing `RoktHTTPClientTests` pass.

## Follow-ups (separate PRs)

- CI runs no ThreadSanitizer today; a standing TSan job for `Networking/` would
  stop this class of bug regressing silently.
- ThreadSanitizer surfaced other unsynchronised shared state in the same area —
  tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)