### PR TITLE
docs: session management guidance for self-service terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ Behaviour to be aware of:
 
 - **When to call it:** at the boundary between customers — not between screens within one customer's journey. Two placements shown to the same customer are meant to share a session.
 - **When the new session begins:** on the next `selectPlacements` call. `clearSession()` only ends the current session; the next placement starts the new one.
-- **What it clears:** the stored session, session-scoped events, and cached experiences. The id returned by `getSessionId()` becomes `nil`, so a WebView session hand-off must be re-established afterwards.
-- **Calling it is always safe:** with no active session it is a no-op, and repeated calls are idempotent.
+- **What it clears:** the stored session, the real-time event state tied to it, and cached experiences. The id returned by `getSessionId()` becomes `nil`, so a WebView session hand-off must be re-established afterwards.
+- **Buffered events are not lost:** queued analytics events are flushed _before_ the session is dropped, so they are sent under the departing session and the previous customer's activity stays attributed to them.
+- **Calling it is always safe:** repeated calls are idempotent, and with no active session there is no session state to clear.
 - **Experience caching:** avoid enabling `RoktConfig` experience caching on shared terminals — a cached experience belongs to the customer it was fetched for.
 
 **mParticle integrations** get this automatically: the Rokt kit ends the session when the mParticle user changes — a different user identifying or logging in, or the current user logging out. An anonymous user being identified is treated as the same person and keeps the session. Calling `clearSession()` as well is safe; both paths converge on the same idempotent reset.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ Finally, call this function in **any subsequent view** where the placement needs
 
 To test your integration with embedded placement, [view steps here](https://docs.rokt.com/developers/integration-guides/ios/how-to/adding-a-placement#embedded-placements)
 
+## Session management on self-service terminals
+
+Rokt sessions are managed automatically: placements shown to the same user share one session, and the session survives app restarts. No session code is needed for a normal single-user app.
+
+On a **self-service terminal** — a kiosk, counter tablet, or shared point-of-sale device — a queue of unrelated customers uses one device, and each transaction should be its own session. Call `clearSession()` at the transaction boundary so the next customer starts fresh:
+
+```swift
+// The customer has finished at the terminal; the next person starts fresh.
+Rokt.clearSession()
+```
+
+Behaviour to be aware of:
+
+- **When to call it:** at the boundary between customers — not between screens within one customer's journey. Two placements shown to the same customer are meant to share a session.
+- **When the new session begins:** on the next `selectPlacements` call. `clearSession()` only ends the current session; the next placement starts the new one.
+- **What it clears:** the stored session, session-scoped events, and cached experiences. The id returned by `getSessionId()` becomes `nil`, so a WebView session hand-off must be re-established afterwards.
+- **Calling it is always safe:** with no active session it is a no-op, and repeated calls are idempotent.
+- **Experience caching:** avoid enabling `RoktConfig` experience caching on shared terminals — a cached experience belongs to the customer it was fetched for.
+
+**mParticle integrations** get this automatically: the Rokt kit ends the session when the mParticle user changes — a different user identifying or logging in, or the current user logging out. An anonymous user being identified is treated as the same person and keeps the session. Calling `clearSession()` as well is safe; both paths converge on the same idempotent reset.
+
 ## Shoppable Ads and payment extensions
 
 For Shoppable Ads, implement the payment contract from **RoktContracts** and register it before showing the placement:


### PR DESCRIPTION
## What

README section documenting session management for self-service terminals, covering the `clearSession()` API that shipped in #298:

- when to call it (customer boundary, not between screens of one journey)
- when the new session begins (the next `selectPlacements` — the wipe only ends the old one)
- what it clears, including the `getSessionId()` → `nil` / WebView hand-off caveat
- idempotency and no-op safety
- the recommendation to avoid experience caching on shared terminals
- the automatic behaviour mParticle integrations get from the kit (session ends when a known user is replaced or logs out; an anonymous user being identified keeps the session)

Docs only — no code changes. Android counterpart rides on ROKT/sdk-android-source#1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
