### PR TITLE
fix: declare dcui-swift-schema dependency explicitly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/ROKT/rokt-ux-helper-ios.git", from: "2.0.0"),
+        .package(url: "https://github.com/ROKT/dcui-swift-schema.git", .upToNextMajor(from: "2.8.1")),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/surpher/PactSwift.git", .upToNextMajor(from: "1.2.0"))
     ],
@@ -30,7 +31,8 @@ let package = Package(
             name: "Rokt_Widget",
             dependencies: [
                 .product(name: "RoktContracts", package: "rokt-contracts-apple"),
-                .product(name: "RoktUXHelper", package: "rokt-ux-helper-ios")
+                .product(name: "RoktUXHelper", package: "rokt-ux-helper-ios"),
+                .product(name: "DcuiSchema", package: "dcui-swift-schema")
             ],
             path: "Sources/Rokt_Widget",
             resources: [


### PR DESCRIPTION
## Background

A partner integrating rokt-sdk-ios 5.3.4 hit a linker failure — `Undefined symbol: DcuiSchema.PaymentProvider.rawValue.getter` — when their workspace builds the SDK as a dynamic SPM framework (PackageFrameworks).

`Rokt_Widget` uses `DcuiSchema.PaymentProvider` symbols (`.rawValue` in `RoktInternalImplementation` and `RoktUxEvent+Extension`), but the type only reached us transitively through RoktUXHelper's public API (`RoktUXEvent.CartItemDevicePay.paymentProvider`), which does not re-export DcuiSchema. That compiles fine — compile-time visibility of transitive types is allowed — but contributes nothing to the link line. Default static linking hides the gap because the whole package graph links into the app; a dynamic framework links only declared dependencies, so the symbol goes undefined.

## What Has Changed

- Declared `dcui-swift-schema` as a top-level package dependency (`.upToNextMajor(from: "2.8.1")`) and added the `DcuiSchema` product to the `Rokt_Widget` target.
- Range chosen over `exact:` to avoid lockstep manifest bumps here whenever ux-helper moves its own `exact` pin; today both resolve to the identical 2.8.1.

## How Has This Been Tested

- `swift package resolve` — graph resolves to a single DcuiSchema 2.8.1.
- `SPM_GENERATE_FRAMEWORK=1 xcodebuild -scheme Rokt-Widget -destination 'generic/platform=iOS Simulator' build` — the dynamic-framework configuration that previously failed — builds successfully.
- `nm` on the built `PackageFrameworks/Rokt-Widget.framework` binary shows the previously failing symbol (`_$s10DcuiSchema15PaymentProviderO8rawValueSSvg`) defined, with zero undefined DcuiSchema symbols remaining.

## Notes

- The failure does not reproduce in an isolated workspace (static linking), which is why CI never caught it.
- `PaymentProvider` is currently the only DcuiSchema type on RoktUXHelper's public surface; wrapping it in an ux-helper-owned type is a possible follow-up in rokt-ux-helper-ios, but this declaration is correct and required regardless.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)