### PR TITLE
ci: enforce declared dependencies at compile time and in CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -299,6 +299,31 @@ jobs:
       - name: Run Periphery Scan
         run: periphery scan --format github-actions
 
+  dependency-declaration-check:
+    name: Dependency Declaration Check
+    runs-on: macos-latest-xlarge
+    needs: trunk-check
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: "26.3"
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      # Catches a module used through a dependency's public API but never declared
+      # in Package.swift. Such a module links in most configurations and only fails
+      # for consumers who build each package product as its own dynamic framework.
+      - name: Check declared dependencies
+        run: ./scripts/check_declared_dependencies.sh "${GITHUB_WORKSPACE}/.derived-data-depcheck"
+
   size-report:
     name: SDK Size Report
     needs: trunk-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ You are a senior iOS SDK engineer specializing in stable, lightweight client lib
   3. Run unit tests: Use the `rokt-Example` scheme → Command + U (or `xcodebuild test ...`).
   4. Run periphery scan: `periphery scan` — ensure no unused code is introduced.
   5. If change affects code, assets, or dependencies: Run size report → `Tests/SizeReport/measure_size.sh` and confirm no unacceptable increase.
+  6. If the change touches imports, dependencies, or `Package.swift`: run `./scripts/check_declared_dependencies.sh` — fails when `Rokt_Widget` uses a module that reaches it only through a dependency's public API and is not declared in `Package.swift`.
   - Only propose / commit changes if all steps pass cleanly (no errors, no warnings from `trunk check`, tests green, size OK).
   - If `trunk check` suggests auto-fixes (e.g. formatting), apply them first and re-validate.
   - Never bypass this — it's required to maintain SDK stability, footprint, and public API quality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ You are a senior iOS SDK engineer specializing in stable, lightweight client lib
 - Explicitly dispatch UI work to main actor (`@MainActor`, `DispatchQueue.main.async`).
 - Prefer async/await for new code; existing networking uses completion handlers.
 - Measure & report size impact before proposing dependency or asset changes.
+- Import every module whose members you use, in the file that uses them. `Rokt_Widget` compiles with `MemberImportVisibility`, so relying on a type that reaches us only through a dependency's public API is a compile error rather than a link failure at a consumer.
 
 ### Never automatically (unless specifically requested)
 

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,11 @@ let package = Package(
             path: "Sources/Rokt_Widget",
             resources: [
                 .process("PrivacyInfo.xcprivacy")
-            ]
+            ],
+            // Using a member of a type whose module is not imported in the same
+            // file becomes an error. A type reaching us implicitly through a
+            // dependency's public API is then impossible to use by accident.
+            swiftSettings: [.enableUpcomingFeature("MemberImportVisibility")]
         ),
         .testTarget(
             name: "Rokt_WidgetTests",

--- a/Sources/Rokt_Widget/Extensions/RoktUxEvent+Extension.swift
+++ b/Sources/Rokt_Widget/Extensions/RoktUxEvent+Extension.swift
@@ -1,4 +1,5 @@
 import Foundation
+internal import DcuiSchema
 internal import RoktUXHelper
 
 internal extension RoktUXEvent {

--- a/Sources/Rokt_Widget/RoktInternalImplementation.swift
+++ b/Sources/Rokt_Widget/RoktInternalImplementation.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import AppTrackingTransparency
 import RoktContracts
+internal import DcuiSchema
 internal import RoktUXHelper
 
 class RoktInternalImplementation {

--- a/Sources/Rokt_Widget/RoktLayout/RoktLayoutViewModel.swift
+++ b/Sources/Rokt_Widget/RoktLayout/RoktLayoutViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 internal import RoktUXHelper
 

--- a/scripts/check_declared_dependencies.sh
+++ b/scripts/check_declared_dependencies.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Fails if Sources/Rokt_Widget references symbols from a Swift module that
+# Package.swift does not declare as a dependency of the Rokt_Widget target.
+#
+# A type can reach this SDK implicitly, through a dependency's public API, without
+# ever being imported here -- RoktUXHelper exposes DcuiSchema.PaymentProvider on
+# RoktUXEvent.CartItemDevicePay, for example. Using such a type compiles, but the
+# manifest never learns about the module, so it contributes nothing to the link
+# line. That stays invisible in most build configurations and only breaks for a
+# consumer who builds every package product as its own dynamic framework, where
+# undeclared modules are simply absent and the symbols come back undefined.
+#
+# Swift mangles the defining module into every symbol name, so the undefined
+# symbols in this target's object files name exactly which modules it links
+# against. Comparing that set against the declared set catches the gap at PR time,
+# independent of how the build happens to be linked.
+#
+# Usage: ./scripts/check_declared_dependencies.sh [derived-data-path]
+
+set -euo pipefail
+
+DERIVED=${1:-.build-depcheck}
+TARGET_MODULE=Rokt_Widget
+
+echo "==> Building ${TARGET_MODULE}"
+xcodebuild -scheme Rokt-Widget \
+	-destination 'generic/platform=iOS Simulator' \
+	-derivedDataPath "${DERIVED}" \
+	-skipPackagePluginValidation \
+	-quiet build >/dev/null
+
+OBJ_DIR=$(find "${DERIVED}" -type d -path "*${TARGET_MODULE}.build/Objects-normal/*" -print | head -1)
+if [[ -z ${OBJ_DIR} ]]; then
+	echo "error: no object directory for ${TARGET_MODULE} under ${DERIVED}" >&2
+	exit 1
+fi
+
+# Modules built from the package graph. Anything referenced but outside this set is
+# the Swift standard library or an Apple SDK module, which needs no manifest entry.
+GRAPH_MODULES=$(find "${DERIVED}/Build/Products" -maxdepth 2 -name '*.swiftmodule' 2>/dev/null |
+	while read -r m; do basename "${m}" .swiftmodule; done | sort -u || true)
+
+if [[ -z ${GRAPH_MODULES} ]]; then
+	echo "error: found no package modules under ${DERIVED}/Build/Products;" >&2
+	echo "the build layout changed and this check would silently pass." >&2
+	exit 1
+fi
+
+# Modules named by the undefined Swift symbols in this target's objects. The
+# demangled form starts with the defining module, e.g.
+#   DcuiSchema.PaymentProvider.rawValue.getter : Swift.String
+REFERENCED=$(find "${OBJ_DIR}" -name '*.o' -print0 |
+	xargs -0 nm -u 2>/dev/null |
+	grep -o '_[$]s[0-9A-Za-z_]*' | sort -u |
+	xcrun swift-demangle --compact 2>/dev/null |
+	sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)\..*/\1/p' | sort -u || true)
+
+if [[ -z ${REFERENCED} ]]; then
+	echo "error: no Swift symbols found in ${OBJ_DIR}; check the nm/demangle parse" >&2
+	exit 1
+fi
+
+# Products declared for the target in Package.swift.
+DECLARED=$(swift package dump-package |
+	TARGET="${TARGET_MODULE}" python3 -c '
+import json, os, sys
+pkg = json.load(sys.stdin)
+for t in pkg["targets"]:
+    if t["name"] == os.environ["TARGET"]:
+        for d in t["dependencies"]:
+            if "product" in d:
+                print(d["product"][0])
+            elif "byName" in d:
+                print(d["byName"][0])
+' | sort -u)
+
+declared_oneline=$(echo "${DECLARED}" | tr '\n' ' ')
+echo "==> declared:   ${declared_oneline}"
+
+violations=""
+for mod in ${REFERENCED}; do
+	# Only modules from the package graph need a manifest entry.
+	echo "${GRAPH_MODULES}" | grep -qx "${mod}" || continue
+	[[ ${mod} == "${TARGET_MODULE}" ]] && continue
+	echo "${DECLARED}" | grep -qx "${mod}" && continue
+	violations="${violations}${mod}
+"
+done
+
+if [[ -n ${violations} ]]; then
+	first=$(printf '%s' "${violations}" | head -1)
+	{
+		echo
+		echo "error: ${TARGET_MODULE} uses these modules without declaring them in Package.swift:"
+		printf '%s' "${violations}" | sed 's/^/  - /'
+		echo
+		echo "Declare each as a target dependency, e.g.:"
+		echo "  .product(name: \"${first}\", package: \"<package>\")"
+		echo
+		echo "They resolve in this build only because the module happens to be reachable."
+		echo "A consumer building each package product as its own dynamic framework gets"
+		echo "undefined symbols instead."
+	} >&2
+	exit 1
+fi
+
+echo "==> OK: every referenced package module is declared"

--- a/scripts/check_declared_dependencies.sh
+++ b/scripts/check_declared_dependencies.sh
@@ -47,14 +47,27 @@ if [[ -z ${GRAPH_MODULES} ]]; then
 	exit 1
 fi
 
-# Modules named by the undefined Swift symbols in this target's objects. The
-# demangled form starts with the defining module, e.g.
+# Modules named by the undefined Swift symbols in this target's objects.
+#
+# A module name can appear anywhere in a demangled symbol, not just at the front:
 #   DcuiSchema.PaymentProvider.rawValue.getter : Swift.String
+#   type metadata for DcuiSchema.PaymentProvider
+#   protocol conformance descriptor for DcuiSchema.PaymentProvider : ...
+#   (extension in Rokt_Widget):RoktContracts.RoktConfig.getUXConfig() -> ...
+# Anchoring on a leading identifier drops roughly 70% of the symbols, including
+# every metadata, conformance-descriptor, thunk and extension form -- which left
+# detection resting on whichever plain-form reference happened to exist. So match
+# the known package module names wherever they occur instead.
+#
+# The boundary class keeps a short module name from matching inside a longer one.
+# BSD grep on the macOS runners does not handle \b reliably, hence [^A-Za-z0-9_].
+module_alternation=$(echo "${GRAPH_MODULES}" | paste -sd'|' -)
 REFERENCED=$(find "${OBJ_DIR}" -name '*.o' -print0 |
 	xargs -0 nm -u 2>/dev/null |
 	grep -o '_[$]s[0-9A-Za-z_]*' | sort -u |
 	xcrun swift-demangle --compact 2>/dev/null |
-	sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)\..*/\1/p' | sort -u || true)
+	grep -oE "(^|[^A-Za-z0-9_])(${module_alternation})([^A-Za-z0-9_]|$)" |
+	sed -E 's/^[^A-Za-z0-9_]+//; s/[^A-Za-z0-9_]+$//' | sort -u || true)
 
 if [[ -z ${REFERENCED} ]]; then
 	echo "error: no Swift symbols found in ${OBJ_DIR}; check the nm/demangle parse" >&2
@@ -62,6 +75,12 @@ if [[ -z ${REFERENCED} ]]; then
 fi
 
 # Products declared for the target in Package.swift.
+#
+# Caveat: these are product names, while REFERENCED holds module names. Every
+# dependency here is 1:1 (product == target == module), so the comparison is
+# sound today. If a future product is renamed away from its module, or vends
+# several modules, this reports a module that IS declared -- a loud false
+# failure rather than a missed violation, so it self-diagnoses.
 DECLARED=$(swift package dump-package |
 	TARGET="${TARGET_MODULE}" python3 -c '
 import json, os, sys


### PR DESCRIPTION
## Background

Follow-up to #300 / #301. CI never caught the undeclared `DcuiSchema` dependency, and this closes that gap with two layers: the compiler rejects the source-level mistake, and a script catches the manifest-level one.

The suggestion to add a `SPM_GENERATE_FRAMEWORK=1` build step does not work — that build passes with *and* without the dependency declaration, so it would be a green check proving nothing. It makes only the top-level product dynamic and links the transitive Swift modules statically into it. Reproducing the real failure needs every product built as its own dynamic framework, which requires patching third-party manifests, so it is not something to pin CI to.

## What Has Changed

**1. `MemberImportVisibility` on the `Rokt_Widget` target** (thomson-t's suggestion). Using a member of a module not imported in that file is now a compile error, so a type reaching us implicitly through a dependency's public API cannot be used by accident. Cost: 3 import lines across 109 files — `import Combine` in `RoktLayoutViewModel.swift` (pre-existing `ObservableObject`/`@Published` with no Combine import) and `internal import DcuiSchema` in the two `PaymentProvider` files, matching the existing `internal import RoktUXHelper` style so DcuiSchema stays out of our public interface.

**2. `scripts/check_declared_dependencies.sh`** — builds the target and fails on any package-graph module referenced by its undefined symbols but not declared for `Rokt_Widget` in `Package.swift`.

**3. `.github/workflows/pull-request.yml`** — `dependency-declaration-check` job, `needs: trunk-check`, same runner/Xcode as the other build jobs (~2m35s).

**4. `AGENTS.md`** — the import rule under "Always Do", and the script as step 6 of local validation.

CI YAML is listed in AGENTS.md as needing an explicit request; this was explicitly requested.

## Why both layers

They close different holes, and I verified the gap between them rather than assuming:

- **MIV does not enforce the manifest declaration.** With the imports in place I removed `dcui-swift-schema` from `Package.swift` and the build still **succeeded**. Under `xcodebuild` every package module's `.swiftmodule` lands in a shared `Build/Products` directory that sits on the import search path, so `import DcuiSchema` resolves whether or not it is declared.
- **The script does not see source intent**, only what actually gets linked.

So MIV catches "used a module you did not import"; the script catches "linked a module you did not declare".

## How Has This Been Tested

**MIV rejects the original bug.** Removing the new import reproduces it as a compile error:
```
Extensions/RoktUxEvent+Extension.swift:56:56: error: property 'rawValue' is not available
  due to missing import of defining module 'DcuiSchema'
```

**MIV needs nothing beyond those 3 imports.** Full build succeeds. The 13-file `RoktContracts` cluster (via `@_exported import` in `Rokt.swift`) and ~14 files using `DispatchQueue` without importing `Dispatch` all pass, since SE-0444 honours re-exports.

**Script red/green.** Green on the correct manifest (exit 0). Red with the declaration removed (exit 1, naming `DcuiSchema`). Note the build itself still *succeeds* in the failing case — which is the point: this catches what no build in CI surfaces.

**Regression test for the parsing fix.** The original `sed` anchored on the leading identifier and dropped 1004 of 1433 symbols, leaving detection resting on a single `.rawValue` call inside a log string. Rebuilt with both `.rawValue` sites removed, so only metadata and conformance symbols remain, and compared parsers on identical object files:
```
DcuiSchema symbols present:
  type metadata for DcuiSchema.PaymentProvider
  protocol conformance descriptor for DcuiSchema.PaymentProvider : Swift.RawRepresentable

OLD parser:  RoktContracts RoktUXHelper             <- false PASS
NEW parser:  DcuiSchema RoktContracts RoktUXHelper  <- exit 1, correct
```

**Also:** `trunk check` clean (shellcheck, shfmt, actionlint, yamllint, markdownlint, swiftformat, swiftlint). Script targets bash 3.2 — macOS runners have no bash 4. Two guards abort with an error rather than passing silently if the build layout changes and either the module set or the symbol set comes back empty; a check that cannot fail is worse than no check.

## Notes

- **Product vs module names:** `dump-package` yields product names, `nm` yields module names. All three dependencies are 1:1 today, and a future divergence surfaces as a loud false failure rather than a missed violation, so it is documented in a comment rather than hardened now.
- **Scope:** the `Rokt_Widget` target. `Packages/rokt-payment-extension-ios` and the 96 test files are untouched — enabling MIV there is a separate, larger job.
- MIV is not enforced on the CocoaPods path (the podspec sets no Swift flags and does not read `Package.swift`); CI builds via SPM, and the sources are identical either way.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)