### PR TITLE
docs: correct the mParticle note on clearSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Behaviour to be aware of:
 - **Calling it is always safe:** repeated calls are idempotent, and with no active session there is no session state to clear.
 - **Experience caching:** avoid enabling `RoktConfig` experience caching on shared terminals — a cached experience belongs to the customer it was fetched for.
 
-**mParticle integrations** get this automatically: the Rokt kit ends the session when the mParticle user changes — a different user identifying or logging in, or the current user logging out. An anonymous user being identified is treated as the same person and keeps the session. Calling `clearSession()` as well is safe; both paths converge on the same idempotent reset.
+**mParticle integrations** call this the same way, through the kit: `MParticle.sharedInstance().rokt.clearSession()`. The kit forwards it straight to this API. It does not end the session on its own — a login or logout is not treated as a transaction boundary, since an mParticle user can change mid-journey for a single customer — so a shared terminal needs the explicit call here too.
 
 ## Shoppable Ads and payment extensions
 


### PR DESCRIPTION
## Problem

The session-management section added in #299 told mParticle partners the reset happens for them:

> **mParticle integrations** get this automatically: the Rokt kit ends the session when the mParticle user changes…

That automatic path was dropped before shipping. Two reasons:

1. It changed session behaviour for **every** partner on the Rokt kit, not only shared-device ones — a login or logout would have started a new Rokt session for everyone.
2. An mParticle user changing is not reliably a change of person. A single customer can be anonymous on the payment page and known on the confirmation page.

Left as-is, the docs would tell a kiosk partner on mParticle that their transaction boundary is handled when it is not — which is exactly the bug this whole change set exists to fix, except now with the partner believing it is solved.

## Change

One paragraph. The kit forwards the explicit call and nothing more, so a shared terminal on mParticle needs `clearSession()` just as a direct integration does. Names the kit-side entry point so the reader knows what to call.

Everything else in the section already described the explicit API correctly and is unchanged.

## Testing

`trunk check` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)